### PR TITLE
Validate and hash user IPs for ratings

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -141,19 +141,25 @@ class JLG_Frontend {
             wp_send_json_error(['message' => 'Données invalides.']); 
         }
         
-        $user_ip = $_SERVER['REMOTE_ADDR'];
+        $user_ip = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP);
+        if (!$user_ip) {
+            wp_send_json_error(['message' => 'Adresse IP invalide.']);
+        }
+
+        $user_ip_hash = wp_hash($user_ip);
+
         $meta_key = '_jlg_user_ratings';
         $ratings = get_post_meta($post_id, $meta_key, true);
-        
-        if (!is_array($ratings)) { 
-            $ratings = []; 
+
+        if (!is_array($ratings)) {
+            $ratings = [];
         }
-        
-        if (isset($ratings[$user_ip])) { 
-            wp_send_json_error(['message' => 'Vous avez déjà voté !']); 
+
+        if (isset($ratings[$user_ip_hash])) {
+            wp_send_json_error(['message' => 'Vous avez déjà voté !']);
         }
-        
-        $ratings[$user_ip] = $rating;
+
+        $ratings[$user_ip_hash] = $rating;
         update_post_meta($post_id, $meta_key, $ratings);
         
         $new_average = round(array_sum($ratings) / count($ratings), 2);


### PR DESCRIPTION
## Summary
- Validate incoming IP addresses for user ratings
- Store hashed user IPs and verify votes using these hashes

## Testing
- `php -l includes/class-jlg-frontend.php`
- `composer install` *(fails: `composer.json` does not contain valid JSON)*
- `phpunit --version` *(fails: command not found)*
- `phpcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c5ee82d0832ea5648e04fc12780c