### PR TITLE
Sanitize shortcode attributes

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -28,7 +28,17 @@ class JLG_Shortcode_All_In_One {
             'style' => 'moderne', // moderne, classique, compact
             'couleur_accent' => '', // Permet de surcharger la couleur d'accent
         ], $atts, 'jlg_bloc_complet');
-        
+
+        // Sanitize attributes
+        $atts = array_map('sanitize_text_field', $atts);
+        $atts['couleur_accent'] = sanitize_hex_color($atts['couleur_accent']);
+
+        // Validate style
+        $allowed_styles = ['moderne', 'classique', 'compact'];
+        if (!in_array($atts['style'], $allowed_styles, true)) {
+            $atts['style'] = 'moderne';
+        }
+
         $post_id = intval($atts['post_id']);
 
         // Sécurité : ne s'exécute que sur les articles ('post')


### PR DESCRIPTION
## Summary
- sanitize and validate shortcode attributes
- ensure only allowed styles are used
- fall back to default accent color when provided color is invalid

## Testing
- `php -l includes/shortcodes/class-jlg-shortcode-all-in-one.php`
- `composer test` (fails: `"./composer.json" does not contain valid JSON`)
- `composer cs` (fails: `"./composer.json" does not contain valid JSON`)


------
https://chatgpt.com/codex/tasks/task_e_68c7c6ee9d84832ebf509a6c33e35c56