### PR TITLE
Hash and validate user IP for ratings

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -141,19 +141,25 @@ class JLG_Frontend {
             wp_send_json_error(['message' => 'Données invalides.']); 
         }
         
-        $user_ip = $_SERVER['REMOTE_ADDR'];
+        $user_ip = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP);
+        if (!$user_ip) {
+            wp_send_json_error(['message' => 'IP invalide.']);
+        }
+
+        $user_hash = wp_hash($user_ip);
         $meta_key = '_jlg_user_ratings';
         $ratings = get_post_meta($post_id, $meta_key, true);
-        
-        if (!is_array($ratings)) { 
-            $ratings = []; 
+
+        if (!is_array($ratings)) {
+            $ratings = [];
         }
-        
-        if (isset($ratings[$user_ip])) { 
-            wp_send_json_error(['message' => 'Vous avez déjà voté !']); 
+
+        if (isset($ratings[$user_hash]) || isset($ratings[$user_ip])) {
+            wp_send_json_error(['message' => 'Vous avez déjà voté !']);
         }
-        
-        $ratings[$user_ip] = $rating;
+
+        $ratings[$user_hash] = $rating;
+        unset($ratings[$user_ip]);
         update_post_meta($post_id, $meta_key, $ratings);
         
         $new_average = round(array_sum($ratings) / count($ratings), 2);


### PR DESCRIPTION
## Summary
- validate IP address before recording user rating
- store a hash of the user IP instead of the raw address
- check for existing votes using the hashed IP

## Testing
- `composer test` *(fails: "./composer.json" does not contain valid JSON)*
- `composer cs` *(fails: "./composer.json" does not contain valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c6e48198832eb57451cca0f6b982