### PR TITLE
Escape widget latest reviews output

### DIFF
--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -11,11 +11,11 @@ if ($latest_reviews->have_posts()) {
     echo '<ul>';
     while ($latest_reviews->have_posts()) {
         $latest_reviews->the_post();
-        echo '<li><a href="' . get_permalink() . '">' . get_the_title() . '</a></li>';
+        echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></li>';
     }
     echo '</ul>';
 } else {
-    echo '<p>Aucun test trouvé.</p>';
+    echo '<p>' . esc_html__('Aucun test trouvé.', 'plugin-notation-jeux') . '</p>';
 }
 wp_reset_postdata();
 


### PR DESCRIPTION
## Summary
- escape latest reviews widget link URLs and titles
- make the empty state string translatable and properly escaped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c84888f32c832ea25ef2194291dbb8