### PR TITLE
Remove redundant admin platforms bootstrap hook

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -569,8 +569,3 @@ class JLG_Admin_Platforms {
         <?php
     }
 }
-
-// Initialiser la classe en mode singleton et s'assurer que le hook admin_init est bien enregistré
-add_action('plugins_loaded', function() {
-    JLG_Admin_Platforms::get_instance();
-});


### PR DESCRIPTION
## Summary
- remove the plugins_loaded bootstrap that instantiated the admin platforms singleton, relying on the admin core to load it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84890eff4832ea3faebeeb3437389