### PR TITLE
Refactor admin menu rendering with templates

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/admin-page.php
+++ b/plugin-notation-jeux_V4/admin/templates/admin-page.php
@@ -1,0 +1,17 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$page_title = $page_title ?? '';
+$tab_navigation = $tab_navigation ?? '';
+$tab_content = $tab_content ?? '';
+?>
+<div class="wrap">
+    <?php if (!empty($page_title)) : ?>
+        <h1><?php echo esc_html($page_title); ?></h1>
+    <?php endif; ?>
+    <?php echo $tab_navigation; ?>
+    <div style="background:#fff; padding:20px; margin-top:20px; border-radius:8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+        <?php echo $tab_content; ?>
+    </div>
+</div>
+

--- a/plugin-notation-jeux_V4/admin/templates/partials/tab-navigation.php
+++ b/plugin-notation-jeux_V4/admin/templates/partials/tab-navigation.php
@@ -1,0 +1,25 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$tabs = $tabs ?? [];
+$active_tab = $active_tab ?? '';
+$page_slug = $page_slug ?? '';
+
+if (empty($tabs)) {
+    return;
+}
+?>
+<h2 class="nav-tab-wrapper">
+    <?php foreach ($tabs as $tab_key => $tab_label) :
+        $active_class = ($active_tab === $tab_key) ? 'nav-tab-active' : '';
+        $url = add_query_arg([
+            'page' => $page_slug,
+            'tab' => $tab_key,
+        ], admin_url('admin.php'));
+        ?>
+        <a href="<?php echo esc_url($url); ?>" class="nav-tab <?php echo esc_attr($active_class); ?>">
+            <?php echo esc_html($tab_label); ?>
+        </a>
+    <?php endforeach; ?>
+</h2>
+

--- a/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
@@ -1,0 +1,90 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$has_rated_posts = $has_rated_posts ?? false;
+$empty_state = $empty_state ?? [];
+$stats = $stats ?? [];
+$columns = isset($columns) && is_array($columns) ? $columns : [];
+$posts = isset($posts) && is_array($posts) ? $posts : [];
+$pagination = $pagination ?? '';
+$print_button_label = $print_button_label ?? '';
+$column_count = count($columns) + 2;
+?>
+<h2>📊 Vos Articles avec Notation</h2>
+
+<?php if (!$has_rated_posts) : ?>
+    <div style="text-align:center; padding:40px; background:#f9f9f9; border-radius:8px; margin-top:20px;">
+        <h3>🎮 Aucun test trouvé</h3>
+        <p>Créez votre premier article avec notation !</p>
+        <a href="<?php echo esc_url($empty_state['create_post_url'] ?? admin_url('post-new.php')); ?>" class="button button-primary">✏️ Créer un Test</a>
+    </div>
+<?php else : ?>
+    <?php if (!empty($stats)) : ?>
+        <div style="background:#f0f6fc; padding:15px; border-radius:4px; margin-bottom:20px;">
+            <?php
+            printf(
+                '<strong>%d</strong> articles avec notation trouvés • Page <strong>%d</strong> sur <strong>%d</strong> • Affichage de <strong>%d</strong> articles',
+                intval($stats['total_items'] ?? 0),
+                intval($stats['current_page'] ?? 1),
+                max(1, intval($stats['total_pages'] ?? 1)),
+                intval($stats['display_count'] ?? 0)
+            );
+            ?>
+        </div>
+    <?php endif; ?>
+
+    <table class="wp-list-table widefat striped">
+        <thead>
+            <tr>
+                <?php foreach ($columns as $column) : ?>
+                    <th scope="col" class="<?php echo esc_attr($column['class'] ?? ''); ?>" aria-sort="<?php echo esc_attr($column['aria_sort'] ?? 'none'); ?>">
+                        <a href="<?php echo esc_url($column['url'] ?? '#'); ?>">
+                            <span><?php echo esc_html($column['label'] ?? ''); ?></span>
+                            <span class="sorting-indicator" aria-hidden="true"></span>
+                        </a>
+                    </th>
+                <?php endforeach; ?>
+                <th><?php echo esc_html('Catégories'); ?></th>
+                <th><?php echo esc_html('Actions'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (!empty($posts)) : ?>
+                <?php foreach ($posts as $post) :
+                    $categories = isset($post['categories']) && is_array($post['categories']) ? $post['categories'] : [];
+                    ?>
+                    <tr>
+                        <td><strong><a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>"><?php echo esc_html($post['title'] ?? ''); ?></a></strong></td>
+                        <td><?php echo esc_html($post['date'] ?? ''); ?></td>
+                        <td><strong style="color:<?php echo esc_attr($post['score_color'] ?? '#0073aa'); ?>;"><?php echo esc_html($post['score_display'] ?? ''); ?></strong>/10</td>
+                        <td><?php echo !empty($categories) ? esc_html(implode(', ', $categories)) : '-'; ?></td>
+                        <td>
+                            <a href="<?php echo esc_url($post['view_link'] ?? '#'); ?>" target="_blank" rel="noopener noreferrer">👁 Voir</a>
+                            |
+                            <a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>">✏️ Modifier</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <tr>
+                    <td colspan="<?php echo (int) max(1, $column_count); ?>">Aucun article trouvé pour cette page.</td>
+                </tr>
+            <?php endif; ?>
+        </tbody>
+    </table>
+
+    <?php if (!empty($pagination)) : ?>
+        <div class="tablenav bottom">
+            <div class="tablenav-pages">
+                <?php echo wp_kses_post($pagination); ?>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($print_button_label)) : ?>
+        <div style="margin-top:20px;">
+            <p><a href="#" class="button" onclick="window.print(); return false;"><?php echo esc_html($print_button_label); ?></a></p>
+        </div>
+    <?php endif; ?>
+<?php endif; ?>
+

--- a/plugin-notation-jeux_V4/admin/templates/tabs/settings.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/settings.php
@@ -1,0 +1,15 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$settings_page = $settings_page ?? '';
+?>
+<h2>🎨 Configuration du Plugin</h2>
+<p>Personnalisez l'apparence et le comportement du système de notation.</p>
+<form action="options.php" method="post">
+    <?php if (!empty($settings_page)) : ?>
+        <?php settings_fields($settings_page); ?>
+        <?php do_settings_sections($settings_page); ?>
+    <?php endif; ?>
+    <?php submit_button('💾 Enregistrer les modifications'); ?>
+</form>
+

--- a/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
@@ -1,0 +1,180 @@
+<?php
+if (!defined('ABSPATH')) exit;
+?>
+<h2>📝 Documentation des Shortcodes</h2>
+<p>Référence complète de tous les shortcodes disponibles avec leurs paramètres.</p>
+
+<!-- NOUVEAU : Bloc tout-en-un en premier -->
+<div style="background:#e8f5e9; padding:20px; margin:20px 0; border-left:4px solid #4caf50; border-radius:4px;">
+    <h3 style="color:#2e7d32; margin-top:0;">🆕 NOUVEAU : Bloc Complet Tout-en-Un</h3>
+    <p><strong>Le shortcode le plus complet qui combine notation, points forts/faibles et tagline en un seul bloc élégant !</strong></p>
+</div>
+
+<div style="margin-top:30px;">
+
+    <!-- NOUVEAU SHORTCODE : Bloc Complet -->
+    <div style="background:#f0f8ff; padding:20px; margin-bottom:20px; border-left:4px solid #4caf50; border-radius:4px; border:2px solid #4caf50;">
+        <h3>⭐ 1. Bloc Complet Tout-en-Un (RECOMMANDÉ)</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[jlg_bloc_complet]</code>
+        <span style="margin-left:10px;">ou</span>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[bloc_notation_complet]</code>
+
+        <p style="color:#2e7d32; font-weight:bold;">✨ Combine en un seul bloc : Tagline + Notation complète + Points forts/faibles</p>
+
+        <h4>Paramètres :</h4>
+        <ul>
+            <li><strong>post_id</strong> : ID de l'article (défaut : article actuel)</li>
+            <li><strong>afficher_notation</strong> : "oui" ou "non" (défaut : "oui")</li>
+            <li><strong>afficher_points</strong> : "oui" ou "non" (défaut : "oui")</li>
+            <li><strong>afficher_tagline</strong> : "oui" ou "non" (défaut : "oui")</li>
+            <li><strong>style</strong> : "moderne", "classique" ou "compact" (défaut : "moderne")</li>
+            <li><strong>couleur_accent</strong> : Code couleur hex (ex: "#60a5fa")</li>
+            <li><strong>titre_points_forts</strong> : Titre personnalisé (défaut : "Points Forts")</li>
+            <li><strong>titre_points_faibles</strong> : Titre personnalisé (défaut : "Points Faibles")</li>
+        </ul>
+
+        <h4>Exemples d'utilisation :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
+<span style="color:#666;">// Bloc complet avec tous les éléments (recommandé)</span>
+[jlg_bloc_complet]
+
+<span style="color:#666;">// Sans la tagline du haut</span>
+[jlg_bloc_complet afficher_tagline="non"]
+
+<span style="color:#666;">// Style compact pour économiser l'espace</span>
+[jlg_bloc_complet style="compact"]
+
+<span style="color:#666;">// Avec couleur personnalisée</span>
+[jlg_bloc_complet couleur_accent="#ff6b6b"]
+
+<span style="color:#666;">// Seulement notation et points (sans tagline)</span>
+[jlg_bloc_complet afficher_tagline="non"]
+
+<span style="color:#666;">// Configuration complète personnalisée</span>
+[jlg_bloc_complet style="moderne" couleur_accent="#8b5cf6" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
+
+        <div style="background:#e8f5e9; padding:10px; margin-top:10px; border-radius:4px;">
+            <strong>💡 Conseil :</strong> Ce shortcode est idéal pour remplacer les 3 shortcodes séparés et avoir une présentation unifiée et professionnelle.
+        </div>
+    </div>
+
+    <hr style="margin: 30px 0; border:none; border-top:2px solid #e0e0e0;">
+
+    <h3 style="color:#666; margin-bottom:20px;">Shortcodes individuels (si vous préférez les utiliser séparément)</h3>
+
+    <!-- Bloc de notation principal -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>2. Bloc de Notation Principal (seul)</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[bloc_notation_jeu]</code>
+
+        <h4>Paramètres :</h4>
+        <ul>
+            <li><strong>post_id</strong> (optionnel) : ID d'un article spécifique. Par défaut : article actuel</li>
+        </ul>
+
+        <h4>Exemples :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
+[bloc_notation_jeu]
+[bloc_notation_jeu post_id="123"]</pre>
+    </div>
+
+    <!-- Fiche technique -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>3. Fiche Technique</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_fiche_technique]</code>
+
+        <h4>Paramètres :</h4>
+        <ul>
+            <li><strong>titre</strong> : Titre du bloc (défaut : "Fiche Technique")</li>
+            <li><strong>champs</strong> : Champs à afficher, séparés par des virgules</li>
+        </ul>
+
+        <h4>Champs disponibles :</h4>
+        <ul style="columns:2;">
+            <li>developpeur</li>
+            <li>editeur</li>
+            <li>date_sortie</li>
+            <li>version</li>
+            <li>pegi</li>
+            <li>temps_de_jeu</li>
+            <li>plateformes</li>
+        </ul>
+
+        <h4>Exemples :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
+[jlg_fiche_technique]
+[jlg_fiche_technique titre="Informations"]
+[jlg_fiche_technique champs="developpeur,editeur,date_sortie"]
+[jlg_fiche_technique titre="Info Rapide" champs="plateformes,pegi"]</pre>
+    </div>
+
+    <!-- Tableau récapitulatif -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>4. Tableau Récapitulatif</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_tableau_recap]</code>
+
+        <h4>Paramètres :</h4>
+        <ul>
+            <li><strong>posts_per_page</strong> : Nombre d'articles par page (défaut : 12)</li>
+            <li><strong>layout</strong> : "table" ou "grid" (défaut : "table")</li>
+            <li><strong>categorie</strong> : Slug de catégorie à filtrer</li>
+            <li><strong>colonnes</strong> : Colonnes à afficher (table uniquement)</li>
+        </ul>
+
+        <h4>Colonnes disponibles :</h4>
+        <ul>
+            <li><strong>titre</strong> : Titre du jeu</li>
+            <li><strong>date</strong> : Date de publication</li>
+            <li><strong>note</strong> : Note moyenne</li>
+            <li><strong>developpeur</strong> : Développeur</li>
+            <li><strong>editeur</strong> : Éditeur</li>
+        </ul>
+
+        <h4>Exemples :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
+[jlg_tableau_recap]
+[jlg_tableau_recap layout="grid"]
+[jlg_tableau_recap posts_per_page="20"]
+[jlg_tableau_recap categorie="fps"]
+[jlg_tableau_recap colonnes="titre,note,developpeur"]
+[jlg_tableau_recap layout="grid" posts_per_page="16" categorie="rpg"]
+[jlg_tableau_recap colonnes="titre,date,note,editeur" posts_per_page="30"]</pre>
+    </div>
+
+    <!-- Points forts/faibles -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>5. Points Forts et Faibles (seuls)</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_points_forts_faibles]</code>
+
+        <p>Affiche automatiquement les points forts et faibles définis dans les métadonnées de l'article.</p>
+        <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
+
+        <h4>Exemple :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[jlg_points_forts_faibles]</pre>
+    </div>
+
+    <!-- Tagline -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>6. Tagline Bilingue (seule)</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[tagline_notation_jlg]</code>
+
+        <p>Affiche la phrase d'accroche avec switch de langue FR/EN.</p>
+        <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
+
+        <h4>Exemple :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[tagline_notation_jlg]</pre>
+    </div>
+
+    <!-- Notation utilisateurs -->
+    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
+        <h3>7. Notation Utilisateurs</h3>
+        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[notation_utilisateurs_jlg]</code>
+
+        <p>Permet aux visiteurs de voter (système 5 étoiles).</p>
+        <p><em>Pas de paramètres - utilise l'article actuel.</em></p>
+
+        <h4>Exemple :</h4>
+        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[notation_utilisateurs_jlg]</pre>
+    </div>
+</div>
+

--- a/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
@@ -1,0 +1,130 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$tutorials = isset($tutorials) && is_array($tutorials) ? $tutorials : [];
+$platforms_url = $platforms_url ?? '';
+?>
+<h2>📚 Guide d'Utilisation</h2>
+<p>Tutoriels et guides pour tirer le meilleur parti du plugin.</p>
+
+<div style="background:linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:white; padding:30px; border-radius:12px; margin:30px 0; box-shadow: 0 10px 25px rgba(102,126,234,0.3);">
+    <h2 style="color:white; margin-top:0;">🚀 Nouveauté : Bloc Complet Tout-en-Un</h2>
+    <p style="font-size:18px; margin-bottom:20px;">Simplifiez votre workflow avec le nouveau shortcode <code style="background:rgba(255,255,255,0.2); padding:3px 8px; border-radius:4px;">[jlg_bloc_complet]</code> qui combine automatiquement :</p>
+    <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); gap:15px;">
+        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Tagline bilingue</div>
+        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Notation détaillée</div>
+        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Points forts/faibles</div>
+    </div>
+    <p style="margin-top:20px;"><strong>Un seul shortcode pour tout afficher de manière élégante et cohérente !</strong></p>
+</div>
+
+<div class="jlg-tutorial-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap:20px; margin-top:30px;">
+    <?php foreach ($tutorials as $tutorial) :
+        $steps = isset($tutorial['steps']) && is_array($tutorial['steps']) ? $tutorial['steps'] : [];
+        ?>
+        <div style="background:#f9f9f9; padding:20px; border-radius:8px; border-left:4px solid #0073aa;">
+            <h3><?php echo esc_html($tutorial['title'] ?? ''); ?></h3>
+            <p><?php echo esc_html($tutorial['content'] ?? ''); ?></p>
+            <?php if (!empty($steps)) : ?>
+                <ol style="margin-left:20px;">
+                    <?php foreach ($steps as $step) : ?>
+                        <li><?php echo esc_html($step); ?></li>
+                    <?php endforeach; ?>
+                </ol>
+            <?php endif; ?>
+        </div>
+    <?php endforeach; ?>
+</div>
+
+<div style="background:#e3f2fd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #2196f3;">
+    <h3>📝 Exemples d'utilisation du Bloc Complet</h3>
+    <p>Voici différentes configurations possibles pour le shortcode <code>[jlg_bloc_complet]</code> :</p>
+    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
+        <h4>Configuration minimale (recommandée pour débuter) :</h4>
+        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #4caf50;">[jlg_bloc_complet]</pre>
+    </div>
+    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
+        <h4>Style compact sans tagline :</h4>
+        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #ff9800;">[jlg_bloc_complet style="compact" afficher_tagline="non"]</pre>
+    </div>
+    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
+        <h4>Personnalisation complète :</h4>
+        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #9c27b0;">[jlg_bloc_complet style="moderne" couleur_accent="#e91e63" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
+    </div>
+</div>
+
+<div style="background:#fce4ec; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #e91e63;">
+    <h3>🔄 Migration vers le Bloc Complet</h3>
+    <p><strong>Vous utilisez déjà les shortcodes séparés ?</strong> Voici comment migrer :</p>
+    <table style="width:100%; background:white; border-radius:4px; overflow:hidden; margin-top:15px;">
+        <tr style="background:#f5f5f5;">
+            <th style="padding:10px; text-align:left;">Avant (3 shortcodes)</th>
+            <th style="padding:10px; text-align:left;">Après (1 shortcode)</th>
+        </tr>
+        <tr>
+            <td style="padding:10px; border-top:1px solid #ddd;"><pre>[tagline_notation_jlg]
+[bloc_notation_jeu]
+[jlg_points_forts_faibles]</pre></td>
+            <td style="padding:10px; border-top:1px solid #ddd;"><pre>[jlg_bloc_complet]</pre></td>
+        </tr>
+    </table>
+    <p style="margin-top:15px;"><em>✅ Plus simple, plus cohérent, même résultat en mieux !</em></p>
+</div>
+
+<div style="background:#fff3cd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #ffc107;">
+    <h3>💡 Astuce Pro</h3>
+    <p><strong>Pour une intégration optimale :</strong> Créez un template d'article dédié aux tests dans votre thème avec le shortcode <code>[jlg_bloc_complet]</code> pré-intégré. Ainsi, vous n'aurez plus qu'à remplir les métadonnées !</p>
+    <p style="margin-top:10px;">Exemple de template personnalisé :</p>
+    <pre style="background:#f5f5f5; padding:10px; border-radius:4px;">&lt;?php
+// Dans votre template single-test.php
+if (have_posts()) : while (have_posts()) : the_post(); ?&gt;
+    &lt;article&gt;
+        &lt;h1&gt;&lt;?php the_title(); ?&gt;&lt;/h1&gt;
+
+        &lt;!-- Bloc de notation complet automatique --&gt;
+        &lt;?php echo do_shortcode('[jlg_bloc_complet]'); ?&gt;
+
+        &lt;!-- Contenu de l'article --&gt;
+        &lt;?php the_content(); ?&gt;
+
+        &lt;!-- Notation des utilisateurs --&gt;
+        &lt;?php echo do_shortcode('[notation_utilisateurs_jlg]'); ?&gt;
+    &lt;/article&gt;
+&lt;?php endwhile; endif; ?&gt;</pre>
+</div>
+
+<div style="background:#f3e5f5; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #9c27b0;">
+    <h3>❓ Questions Fréquentes sur le Bloc Complet</h3>
+    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
+        <summary style="cursor:pointer; font-weight:bold;">Puis-je utiliser le bloc complet ET les shortcodes séparés ?</summary>
+        <p style="margin-top:10px;">Oui, mais évitez la duplication. Utilisez soit le bloc complet, soit les shortcodes individuels, pas les deux ensemble.</p>
+    </details>
+    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
+        <summary style="cursor:pointer; font-weight:bold;">Comment changer l'ordre des sections ?</summary>
+        <p style="margin-top:10px;">L'ordre est fixe (Tagline → Notation → Points), mais vous pouvez masquer des sections avec les paramètres afficher_*="non".</p>
+    </details>
+    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
+        <summary style="cursor:pointer; font-weight:bold;">Le bloc complet est-il plus lourd en performance ?</summary>
+        <p style="margin-top:10px;">Non, au contraire ! Un seul shortcode est plus performant que trois shortcodes séparés.</p>
+    </details>
+    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
+        <summary style="cursor:pointer; font-weight:bold;">Puis-je avoir plusieurs blocs complets sur la même page ?</summary>
+        <p style="margin-top:10px;">Oui, en utilisant le paramètre post_id pour cibler différents articles : [jlg_bloc_complet post_id="123"]</p>
+    </details>
+</div>
+
+<div style="background:#e8f5e9; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #4caf50;">
+    <h3>🎮 Gestion des Plateformes</h3>
+    <p><strong>Nouveau système de plateformes dynamiques !</strong></p>
+    <ul style="margin-left:20px;">
+        <li>Ajoutez vos propres plateformes depuis l'onglet "Plateformes"</li>
+        <li>Réorganisez l'ordre d'affichage par glisser-déposer</li>
+        <li>Les plateformes personnalisées apparaissent automatiquement dans les metaboxes</li>
+        <li>Supprimez les plateformes obsolètes en un clic</li>
+        <li>Compatibilité totale avec le shortcode [jlg_fiche_technique]</li>
+    </ul>
+    <p style="margin-top:15px;">
+        <a href="<?php echo esc_url($platforms_url); ?>" class="button button-primary">Gérer les plateformes →</a>
+    </p>
+</div>
+

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Gestion du menu admin et des pages
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
@@ -26,7 +26,230 @@ class JLG_Admin_Menu {
             30
         );
     }
-    
+
+    public function render_admin_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die('Accès refusé.');
+        }
+
+        $tabs = $this->get_tabs();
+        $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'reglages';
+        if (!array_key_exists($active_tab, $tabs)) {
+            $active_tab = 'reglages';
+        }
+
+        $tab_navigation = $this->get_tab_navigation_html($tabs, $active_tab);
+        $tab_content = $this->get_tab_content($active_tab);
+
+        JLG_Template_Loader::display_admin_template('admin-page', [
+            'page_title' => '⭐ Notation JLG v5.0',
+            'tab_navigation' => $tab_navigation,
+            'tab_content' => $tab_content,
+        ]);
+    }
+
+    private function get_tabs() {
+        return [
+            'reglages' => '⚙️ Réglages',
+            'articles_notes' => '📊 Articles Notés',
+            'plateformes' => '🎮 Plateformes',
+            'shortcodes' => '📝 Shortcodes',
+            'tutoriels' => '📚 Tutoriels',
+        ];
+    }
+
+    private function get_tab_navigation_html(array $tabs, $active_tab) {
+        return JLG_Template_Loader::get_admin_template('partials/tab-navigation', [
+            'tabs' => $tabs,
+            'active_tab' => $active_tab,
+            'page_slug' => $this->page_slug,
+        ]);
+    }
+
+    private function get_tab_content($active_tab) {
+        switch ($active_tab) {
+            case 'articles_notes':
+                return $this->get_posts_list_tab_content();
+            case 'plateformes':
+                return $this->get_platforms_tab_content();
+            case 'shortcodes':
+                return $this->get_shortcodes_tab_content();
+            case 'tutoriels':
+                return $this->get_tutorials_tab_content();
+            case 'reglages':
+            default:
+                return $this->get_settings_tab_content();
+        }
+    }
+
+    private function get_settings_tab_content() {
+        return JLG_Template_Loader::get_admin_template('tabs/settings', [
+            'settings_page' => 'notation_jlg_page',
+        ]);
+    }
+
+    private function get_posts_list_tab_content() {
+        $rated_posts = JLG_Helpers::get_rated_post_ids();
+        $empty_state = [
+            'create_post_url' => admin_url('post-new.php'),
+        ];
+
+        if (empty($rated_posts)) {
+            return JLG_Template_Loader::get_admin_template('tabs/posts-list', [
+                'has_rated_posts' => false,
+                'empty_state' => $empty_state,
+            ]);
+        }
+
+        $per_page = 30;
+        $current_page = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
+        $orderby = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'date';
+        $order = isset($_GET['order']) && in_array(strtoupper($_GET['order']), ['ASC', 'DESC'], true) ? strtoupper($_GET['order']) : 'DESC';
+
+        $args = [
+            'post_type' => 'post',
+            'post__in' => $rated_posts,
+            'posts_per_page' => $per_page,
+            'paged' => $current_page,
+            'orderby' => $orderby === 'score' ? 'meta_value_num' : $orderby,
+            'order' => $order,
+        ];
+
+        if ($orderby === 'score') {
+            $args['meta_key'] = '_jlg_average_score';
+        }
+
+        $query = new WP_Query($args);
+
+        $posts = [];
+        if ($query->have_posts()) {
+            while ($query->have_posts()) {
+                $query->the_post();
+                $post_id = get_the_ID();
+                $score = get_post_meta($post_id, '_jlg_average_score', true);
+
+                $score_color = '#0073aa';
+                if ($score !== '' && is_numeric($score)) {
+                    $score_value = (float) $score;
+                    if ($score_value >= 8) {
+                        $score_color = '#22c55e';
+                    } elseif ($score_value >= 5) {
+                        $score_color = '#f97316';
+                    } else {
+                        $score_color = '#ef4444';
+                    }
+                }
+
+                $categories = get_the_category($post_id);
+                $cat_names = array_map(function ($cat) {
+                    return $cat->name;
+                }, $categories);
+
+                $posts[] = [
+                    'title' => get_the_title(),
+                    'edit_link' => get_edit_post_link($post_id),
+                    'view_link' => get_permalink($post_id),
+                    'date' => get_the_date('d/m/Y', $post_id),
+                    'score_display' => ($score !== '' && $score !== null) ? $score : 'N/A',
+                    'score_color' => $score_color,
+                    'categories' => $cat_names,
+                ];
+            }
+        }
+
+        wp_reset_postdata();
+
+        $total_items = count($rated_posts);
+        $total_pages = (int) ceil($total_items / $per_page);
+        $pagination = '';
+
+        if ($total_pages > 1) {
+            $pagination_args = [
+                'base' => add_query_arg('paged', '%#%'),
+                'format' => '',
+                'prev_text' => '&laquo;',
+                'next_text' => '&raquo;',
+                'total' => $total_pages,
+                'current' => $current_page,
+                'show_all' => false,
+                'end_size' => 1,
+                'mid_size' => 2,
+                'type' => 'plain',
+                'before_page_number' => '<span class="screen-reader-text">Page </span>',
+            ];
+
+            if (isset($_GET['orderby'])) {
+                $pagination_args['add_args'] = [
+                    'orderby' => $orderby,
+                    'order' => $order,
+                ];
+            }
+
+            $pagination = paginate_links($pagination_args);
+        }
+
+        return JLG_Template_Loader::get_admin_template('tabs/posts-list', [
+            'has_rated_posts' => true,
+            'empty_state' => $empty_state,
+            'stats' => [
+                'total_items' => $total_items,
+                'current_page' => $current_page,
+                'total_pages' => $total_pages,
+                'display_count' => count($posts),
+            ],
+            'columns' => $this->get_sortable_columns($orderby, $order),
+            'posts' => $posts,
+            'pagination' => $pagination,
+            'print_button_label' => '🖨️ Imprimer cette liste',
+        ]);
+    }
+
+    private function get_sortable_columns($current_orderby, $current_order) {
+        $columns = [
+            ['label' => 'Titre', 'key' => 'title'],
+            ['label' => 'Date', 'key' => 'date'],
+            ['label' => 'Note', 'key' => 'score'],
+        ];
+
+        $results = [];
+        foreach ($columns as $column) {
+            $column_key = $column['key'];
+            $new_order = ($current_orderby === $column_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
+
+            $class = 'manage-column column-' . $column_key;
+            $aria_sort = 'none';
+            if ($current_orderby === $column_key) {
+                $class .= ' sorted ' . strtolower($current_order);
+                $aria_sort = ($current_order === 'ASC') ? 'ascending' : 'descending';
+            } else {
+                $class .= ' sortable desc';
+            }
+
+            $url = add_query_arg([
+                'page' => $this->page_slug,
+                'tab' => 'articles_notes',
+                'orderby' => $column_key,
+                'order' => $new_order,
+                'paged' => 1,
+            ], admin_url('admin.php'));
+
+            $results[] = [
+                'label' => $column['label'],
+                'class' => $class,
+                'url' => $url,
+                'aria_sort' => $aria_sort,
+            ];
+        }
+
+        return $results;
+    }
+
+    private function get_platforms_tab_content() {
+        ob_start();
+        $this->render_platforms_tab();
+        return ob_get_clean();
+    }
+
     private function render_platforms_tab() {
         // Utiliser l'instance singleton de la classe Platforms
         if (class_exists('JLG_Admin_Platforms')) {
@@ -49,450 +272,11 @@ class JLG_Admin_Menu {
         }
     }
 
-    public function render_admin_page() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Accès refusé.');
-        }
-
-        $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'reglages';
-        
-        echo '<div class="wrap">';
-        echo '<h1>⭐ Notation JLG v5.0</h1>';
-        
-        // Navigation
-        $this->render_tab_navigation($active_tab);
-        
-        // Contenu
-        echo '<div style="background:#fff; padding:20px; margin-top:20px; border-radius:8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">';
-        switch ($active_tab) {
-            case 'reglages':
-                $this->render_settings_tab();
-                break;
-            case 'articles_notes':
-                $this->render_posts_list_tab();
-                break;
-            case 'plateformes':
-                $this->render_platforms_tab();
-                break;
-            case 'shortcodes':
-                $this->render_shortcodes_tab();
-                break;
-            case 'tutoriels':
-                $this->render_tutorials_tab();
-                break;
-            default:
-                $this->render_settings_tab();
-        }
-        echo '</div>';
-        
-        echo '</div>';
+    private function get_shortcodes_tab_content() {
+        return JLG_Template_Loader::get_admin_template('tabs/shortcodes');
     }
 
-    private function render_tab_navigation($active_tab) {
-        $tabs = [
-            'reglages' => '⚙️ Réglages',
-            'articles_notes' => '📊 Articles Notés',
-            'plateformes' => '🎮 Plateformes',
-            'shortcodes' => '📝 Shortcodes',
-            'tutoriels' => '📚 Tutoriels'
-        ];
-
-        echo '<h2 class="nav-tab-wrapper">';
-        foreach ($tabs as $tab_key => $tab_label) {
-            $active_class = ($active_tab === $tab_key) ? 'nav-tab-active' : '';
-            $url = add_query_arg(['page' => $this->page_slug, 'tab' => $tab_key], admin_url('admin.php'));
-            
-            printf(
-                '<a href="%s" class="nav-tab %s">%s</a>',
-                esc_url($url),
-                esc_attr($active_class),
-                esc_html($tab_label)
-            );
-        }
-        echo '</h2>';
-    }
-
-    private function render_settings_tab() {
-        echo '<h2>🎨 Configuration du Plugin</h2>';
-        echo '<p>Personnalisez l\'apparence et le comportement du système de notation.</p>';
-        echo '<form action="options.php" method="post">';
-        settings_fields('notation_jlg_page');
-        do_settings_sections('notation_jlg_page');
-        submit_button('💾 Enregistrer les modifications');
-        echo '</form>';
-    }
-
-    private function render_posts_list_tab() {
-        $rated_posts = JLG_Helpers::get_rated_post_ids();
-        
-        echo '<h2>📊 Vos Articles avec Notation</h2>';
-        
-        if (empty($rated_posts)) {
-            echo '<div style="text-align:center; padding:40px; background:#f9f9f9; border-radius:8px; margin-top:20px;">';
-            echo '<h3>🎮 Aucun test trouvé</h3>';
-            echo '<p>Créez votre premier article avec notation !</p>';
-            echo '<a href="' . admin_url('post-new.php') . '" class="button button-primary">✏️ Créer un Test</a>';
-            echo '</div>';
-            return;
-        }
-
-        // Configuration de la pagination
-        $per_page = 30;
-        $current_page = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
-        $total_items = count($rated_posts);
-        $total_pages = ceil($total_items / $per_page);
-        $offset = ($current_page - 1) * $per_page;
-        
-        // Tri des articles
-        $orderby = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'date';
-        $order = isset($_GET['order']) && in_array(strtoupper($_GET['order']), ['ASC', 'DESC']) ? strtoupper($_GET['order']) : 'DESC';
-        
-        // Récupération des posts pour cette page avec tri
-        $args = [
-            'post_type' => 'post',
-            'post__in' => $rated_posts,
-            'posts_per_page' => $per_page,
-            'paged' => $current_page,
-            'orderby' => $orderby === 'score' ? 'meta_value_num' : $orderby,
-            'order' => $order
-        ];
-        
-        if ($orderby === 'score') {
-            $args['meta_key'] = '_jlg_average_score';
-        }
-        
-        $query = new WP_Query($args);
-        
-        // Affichage des statistiques
-        echo '<div style="background:#f0f6fc; padding:15px; border-radius:4px; margin-bottom:20px;">';
-        printf(
-            '<strong>%d</strong> articles avec notation trouvés • Page <strong>%d</strong> sur <strong>%d</strong> • Affichage de <strong>%d</strong> articles',
-            $total_items, 
-            $current_page, 
-            $total_pages,
-            min($per_page, $total_items - $offset)
-        );
-        echo '</div>';
-        
-        // Tableau des articles
-        echo '<table class="wp-list-table widefat striped">';
-        echo '<thead><tr>';
-        
-        // En-têtes avec tri
-        $this->render_sortable_column('Titre', 'title', $orderby, $order);
-        $this->render_sortable_column('Date', 'date', $orderby, $order);
-        $this->render_sortable_column('Note', 'score', $orderby, $order);
-        echo '<th>Catégories</th>';
-        echo '<th>Actions</th>';
-        
-        echo '</tr></thead><tbody>';
-        
-        if ($query->have_posts()) {
-            while ($query->have_posts()) {
-                $query->the_post();
-                $post_id = get_the_ID();
-                $score = get_post_meta($post_id, '_jlg_average_score', true);
-                
-                // Récupération des catégories
-                $categories = get_the_category($post_id);
-                $cat_names = array_map(function($cat) { return $cat->name; }, $categories);
-                
-                echo '<tr>';
-                printf('<td><strong><a href="%s">%s</a></strong></td>', 
-                    get_edit_post_link($post_id), 
-                    esc_html(get_the_title())
-                );
-                printf('<td>%s</td>', get_the_date('d/m/Y', $post_id));
-                
-                // Note avec couleur selon valeur
-                $score_color = '#0073aa';
-                if ($score !== '' && is_numeric($score)) {
-                    if ($score >= 8) $score_color = '#22c55e';
-                    elseif ($score >= 5) $score_color = '#f97316';
-                    else $score_color = '#ef4444';
-                }
-                printf('<td><strong style="color:%s;">%s</strong>/10</td>', 
-                    $score_color,
-                    esc_html($score ?: 'N/A')
-                );
-                
-                printf('<td>%s</td>', implode(', ', $cat_names) ?: '-');
-                printf(
-                    '<td><a href="%s" target="_blank">👁 Voir</a> | <a href="%s">✏️ Modifier</a></td>', 
-                    get_permalink($post_id), 
-                    get_edit_post_link($post_id)
-                );
-                echo '</tr>';
-            }
-        }
-        
-        echo '</tbody></table>';
-        
-        wp_reset_postdata();
-        
-        // Pagination
-        if ($total_pages > 1) {
-            echo '<div class="tablenav bottom">';
-            echo '<div class="tablenav-pages">';
-            
-            $pagination_args = [
-                'base' => add_query_arg('paged', '%#%'),
-                'format' => '',
-                'prev_text' => '&laquo;',
-                'next_text' => '&raquo;',
-                'total' => $total_pages,
-                'current' => $current_page,
-                'show_all' => false,
-                'end_size' => 1,
-                'mid_size' => 2,
-                'type' => 'plain',
-                'before_page_number' => '<span class="screen-reader-text">Page </span>'
-            ];
-            
-            // Conserver les paramètres de tri dans la pagination
-            if (isset($_GET['orderby'])) {
-                $pagination_args['add_args'] = ['orderby' => $orderby, 'order' => $order];
-            }
-            
-            echo paginate_links($pagination_args);
-            echo '</div>';
-            echo '</div>';
-        }
-        
-        // Bouton d'export (optionnel)
-        echo '<div style="margin-top:20px;">';
-        echo '<p><a href="#" class="button" onclick="window.print(); return false;">🖨️ Imprimer cette liste</a></p>';
-        echo '</div>';
-    }
-
-    /**
-     * Helper pour créer une colonne triable
-     */
-    private function render_sortable_column($label, $column, $current_orderby, $current_order) {
-        $new_order = ($current_orderby === $column && $current_order === 'ASC') ? 'DESC' : 'ASC';
-        $class = 'manage-column column-' . $column;
-        
-        if ($current_orderby === $column) {
-            $class .= ' sorted ' . strtolower($current_order);
-        } else {
-            $class .= ' sortable desc';
-        }
-        
-        $url = add_query_arg([
-            'page' => $this->page_slug,
-            'tab' => 'articles_notes',
-            'orderby' => $column,
-            'order' => $new_order,
-            'paged' => 1 // Retour à la première page lors du tri
-        ], admin_url('admin.php'));
-        
-        printf(
-            '<th scope="col" class="%s"><a href="%s"><span>%s</span><span class="sorting-indicator" aria-hidden="true"></span></a></th>',
-            esc_attr($class),
-            esc_url($url),
-            esc_html($label)
-        );
-    }
-
-    private function render_shortcodes_tab() {
-        ?>
-        <h2>📝 Documentation des Shortcodes</h2>
-        <p>Référence complète de tous les shortcodes disponibles avec leurs paramètres.</p>
-        
-        <!-- NOUVEAU : Bloc tout-en-un en premier -->
-        <div style="background:#e8f5e9; padding:20px; margin:20px 0; border-left:4px solid #4caf50; border-radius:4px;">
-            <h3 style="color:#2e7d32; margin-top:0;">🆕 NOUVEAU : Bloc Complet Tout-en-Un</h3>
-            <p><strong>Le shortcode le plus complet qui combine notation, points forts/faibles et tagline en un seul bloc élégant !</strong></p>
-        </div>
-        
-        <div style="margin-top:30px;">
-            
-            <!-- NOUVEAU SHORTCODE : Bloc Complet -->
-            <div style="background:#f0f8ff; padding:20px; margin-bottom:20px; border-left:4px solid #4caf50; border-radius:4px; border:2px solid #4caf50;">
-                <h3>⭐ 1. Bloc Complet Tout-en-Un (RECOMMANDÉ)</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[jlg_bloc_complet]</code>
-                <span style="margin-left:10px;">ou</span>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[bloc_notation_complet]</code>
-                
-                <p style="color:#2e7d32; font-weight:bold;">✨ Combine en un seul bloc : Tagline + Notation complète + Points forts/faibles</p>
-                
-                <h4>Paramètres :</h4>
-                <ul>
-                    <li><strong>post_id</strong> : ID de l'article (défaut : article actuel)</li>
-                    <li><strong>afficher_notation</strong> : "oui" ou "non" (défaut : "oui")</li>
-                    <li><strong>afficher_points</strong> : "oui" ou "non" (défaut : "oui")</li>
-                    <li><strong>afficher_tagline</strong> : "oui" ou "non" (défaut : "oui")</li>
-                    <li><strong>style</strong> : "moderne", "classique" ou "compact" (défaut : "moderne")</li>
-                    <li><strong>couleur_accent</strong> : Code couleur hex (ex: "#60a5fa")</li>
-                    <li><strong>titre_points_forts</strong> : Titre personnalisé (défaut : "Points Forts")</li>
-                    <li><strong>titre_points_faibles</strong> : Titre personnalisé (défaut : "Points Faibles")</li>
-                </ul>
-                
-                <h4>Exemples d'utilisation :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-<span style="color:#666;">// Bloc complet avec tous les éléments (recommandé)</span>
-[jlg_bloc_complet]
-
-<span style="color:#666;">// Sans la tagline du haut</span>
-[jlg_bloc_complet afficher_tagline="non"]
-
-<span style="color:#666;">// Style compact pour économiser l'espace</span>
-[jlg_bloc_complet style="compact"]
-
-<span style="color:#666;">// Avec couleur personnalisée</span>
-[jlg_bloc_complet couleur_accent="#ff6b6b"]
-
-<span style="color:#666;">// Seulement notation et points (sans tagline)</span>
-[jlg_bloc_complet afficher_tagline="non"]
-
-<span style="color:#666;">// Configuration complète personnalisée</span>
-[jlg_bloc_complet style="moderne" couleur_accent="#8b5cf6" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
-                
-                <div style="background:#e8f5e9; padding:10px; margin-top:10px; border-radius:4px;">
-                    <strong>💡 Conseil :</strong> Ce shortcode est idéal pour remplacer les 3 shortcodes séparés et avoir une présentation unifiée et professionnelle.
-                </div>
-            </div>
-
-            <hr style="margin: 30px 0; border:none; border-top:2px solid #e0e0e0;">
-            
-            <h3 style="color:#666; margin-bottom:20px;">Shortcodes individuels (si vous préférez les utiliser séparément)</h3>
-
-            <!-- Bloc de notation principal -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>2. Bloc de Notation Principal (seul)</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[bloc_notation_jeu]</code>
-                
-                <h4>Paramètres :</h4>
-                <ul>
-                    <li><strong>post_id</strong> (optionnel) : ID d'un article spécifique. Par défaut : article actuel</li>
-                </ul>
-                
-                <h4>Exemples :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[bloc_notation_jeu]
-[bloc_notation_jeu post_id="123"]</pre>
-            </div>
-
-            <!-- Fiche technique -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>3. Fiche Technique</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_fiche_technique]</code>
-                
-                <h4>Paramètres :</h4>
-                <ul>
-                    <li><strong>titre</strong> : Titre du bloc (défaut : "Fiche Technique")</li>
-                    <li><strong>champs</strong> : Champs à afficher, séparés par des virgules</li>
-                </ul>
-                
-                <h4>Champs disponibles :</h4>
-                <ul style="columns:2;">
-                    <li>developpeur</li>
-                    <li>editeur</li>
-                    <li>date_sortie</li>
-                    <li>version</li>
-                    <li>pegi</li>
-                    <li>temps_de_jeu</li>
-                    <li>plateformes</li>
-                </ul>
-                
-                <h4>Exemples :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[jlg_fiche_technique]
-[jlg_fiche_technique titre="Informations"]
-[jlg_fiche_technique champs="developpeur,editeur,date_sortie"]
-[jlg_fiche_technique titre="Info Rapide" champs="plateformes,pegi"]</pre>
-            </div>
-
-            <!-- Tableau récapitulatif -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>4. Tableau Récapitulatif</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_tableau_recap]</code>
-                
-                <h4>Paramètres :</h4>
-                <ul>
-                    <li><strong>posts_per_page</strong> : Nombre d'articles par page (défaut : 12)</li>
-                    <li><strong>layout</strong> : "table" ou "grid" (défaut : "table")</li>
-                    <li><strong>categorie</strong> : Slug de catégorie à filtrer</li>
-                    <li><strong>colonnes</strong> : Colonnes à afficher (table uniquement)</li>
-                </ul>
-                
-                <h4>Colonnes disponibles :</h4>
-                <ul>
-                    <li><strong>titre</strong> : Titre du jeu</li>
-                    <li><strong>date</strong> : Date de publication</li>
-                    <li><strong>note</strong> : Note moyenne</li>
-                    <li><strong>developpeur</strong> : Développeur</li>
-                    <li><strong>editeur</strong> : Éditeur</li>
-                </ul>
-                
-                <h4>Exemples :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[jlg_tableau_recap]
-[jlg_tableau_recap layout="grid"]
-[jlg_tableau_recap posts_per_page="20"]
-[jlg_tableau_recap categorie="fps"]
-[jlg_tableau_recap colonnes="titre,note,developpeur"]
-[jlg_tableau_recap layout="grid" posts_per_page="16" categorie="rpg"]
-[jlg_tableau_recap colonnes="titre,date,note,editeur" posts_per_page="30"]</pre>
-            </div>
-
-            <!-- Points forts/faibles -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>5. Points Forts et Faibles (seuls)</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_points_forts_faibles]</code>
-                
-                <p>Affiche automatiquement les points forts et faibles définis dans les métadonnées de l'article.</p>
-                <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
-                
-                <h4>Exemple :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[jlg_points_forts_faibles]</pre>
-            </div>
-
-            <!-- Tagline -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>6. Tagline Bilingue (seule)</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[tagline_notation_jlg]</code>
-                
-                <p>Affiche la phrase d'accroche avec switch de langue FR/EN.</p>
-                <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
-                
-                <h4>Exemple :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[tagline_notation_jlg]</pre>
-            </div>
-
-            <!-- Notation utilisateurs -->
-            <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-                <h3>7. Notation Utilisateurs</h3>
-                <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[notation_utilisateurs_jlg]</code>
-                
-                <p>Permet aux visiteurs de voter (système 5 étoiles).</p>
-                <p><em>Pas de paramètres - utilise l'article actuel.</em></p>
-                
-                <h4>Exemple :</h4>
-                <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[notation_utilisateurs_jlg]</pre>
-            </div>
-        </div>
-        <?php
-    }
-
-    private function render_tutorials_tab() {
-        echo '<h2>📚 Guide d\'Utilisation</h2>';
-        echo '<p>Tutoriels et guides pour tirer le meilleur parti du plugin.</p>';
-        
-        // Nouveau bloc en vedette pour le shortcode tout-en-un
-        echo '<div style="background:linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:white; padding:30px; border-radius:12px; margin:30px 0; box-shadow: 0 10px 25px rgba(102,126,234,0.3);">';
-        echo '<h2 style="color:white; margin-top:0;">🚀 Nouveauté : Bloc Complet Tout-en-Un</h2>';
-        echo '<p style="font-size:18px; margin-bottom:20px;">Simplifiez votre workflow avec le nouveau shortcode <code style="background:rgba(255,255,255,0.2); padding:3px 8px; border-radius:4px;">[jlg_bloc_complet]</code> qui combine automatiquement :</p>';
-        echo '<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); gap:15px;">';
-        echo '<div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Tagline bilingue</div>';
-        echo '<div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Notation détaillée</div>';
-        echo '<div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Points forts/faibles</div>';
-        echo '</div>';
-        echo '<p style="margin-top:20px;"><strong>Un seul shortcode pour tout afficher de manière élégante et cohérente !</strong></p>';
-        echo '</div>';
-        
-        echo '<div class="jlg-tutorial-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap:20px; margin-top:30px;">';
-        
+    private function get_tutorials_tab_content() {
         $tutorials = [
             [
                 'title' => '⚡ Démarrage rapide avec le Bloc Complet',
@@ -502,30 +286,30 @@ class JLG_Admin_Menu {
                     'Remplir les notes dans la metabox (colonne droite)',
                     'Ajouter tagline et points forts/faibles',
                     'Insérer [jlg_bloc_complet] dans le contenu',
-                    'C\'est tout ! Publiez votre test'
-                ]
+                    'C\'est tout ! Publiez votre test',
+                ],
             ],
             [
                 'title' => '🎮 Créer un test détaillé (méthode classique)',
                 'content' => 'Guide pas-à-pas pour un contrôle total.',
                 'steps' => [
                     'Créer un nouvel article',
-                    'Remplir la metabox "Notation" (colonne droite)', 
+                    'Remplir la metabox "Notation" (colonne droite)',
                     'Ajouter les détails du jeu (metabox principale)',
                     'Intégrer les shortcodes séparés si besoin',
-                    'Publier et vérifier l\'affichage'
-                ]
+                    'Publier et vérifier l\'affichage',
+                ],
             ],
             [
                 'title' => '🎨 Personnalisation du Bloc Complet',
-                'content' => 'Adapter le nouveau bloc à vos besoins.',
+                'content' => 'Créez un rendu unique.',
                 'steps' => [
                     'Choisir le style (moderne/classique/compact)',
                     'Définir une couleur d\'accent personnalisée',
                     'Activer/désactiver les sections',
                     'Personnaliser les titres des sections',
-                    'Combiner avec d\'autres shortcodes si besoin'
-                ]
+                    'Combiner avec d\'autres shortcodes si besoin',
+                ],
             ],
             [
                 'title' => '🎨 Personnalisation visuelle globale',
@@ -535,8 +319,8 @@ class JLG_Admin_Menu {
                     'Activer les effets Neon/Glow',
                     'Configurer la pulsation',
                     'Personnaliser les couleurs',
-                    'Ajouter du CSS personnalisé'
-                ]
+                    'Ajouter du CSS personnalisé',
+                ],
             ],
             [
                 'title' => '📊 Tableau récapitulatif avancé',
@@ -546,8 +330,8 @@ class JLG_Admin_Menu {
                     'Sélectionner les colonnes à afficher',
                     'Filtrer par catégorie',
                     'Ajuster la pagination',
-                    'Personnaliser les couleurs dans Réglages'
-                ]
+                    'Personnaliser les couleurs dans Réglages',
+                ],
             ],
             [
                 'title' => '⚡ Optimisations',
@@ -557,8 +341,8 @@ class JLG_Admin_Menu {
                     'Activer un plugin de cache',
                     'Optimiser les images de couverture',
                     'Limiter le nombre d\'articles affichés',
-                    'Désactiver les animations si non nécessaires'
-                ]
+                    'Désactiver les animations si non nécessaires',
+                ],
             ],
             [
                 'title' => '🔧 Intégration dans le thème',
@@ -568,8 +352,8 @@ class JLG_Admin_Menu {
                     'Utiliser jlg_get_post_rating() pour récupérer la note',
                     'Personnaliser les templates dans /templates/',
                     'Créer des hooks personnalisés',
-                    'Surcharger les styles CSS du plugin'
-                ]
+                    'Surcharger les styles CSS du plugin',
+                ],
             ],
             [
                 'title' => '❓ Dépannage',
@@ -579,119 +363,15 @@ class JLG_Admin_Menu {
                     'Vider le cache navigateur et site',
                     'Vérifier les permissions utilisateur',
                     'Consulter les logs d\'erreur',
-                    'Réinitialiser les réglages si nécessaire'
-                ]
-            ]
+                    'Réinitialiser les réglages si nécessaire',
+                ],
+            ],
         ];
 
-        foreach ($tutorials as $tutorial) {
-            echo '<div style="background:#f9f9f9; padding:20px; border-radius:8px; border-left:4px solid #0073aa;">';
-            echo '<h3>' . esc_html($tutorial['title']) . '</h3>';
-            echo '<p>' . esc_html($tutorial['content']) . '</p>';
-            echo '<ol style="margin-left:20px;">';
-            foreach ($tutorial['steps'] as $step) {
-                echo '<li>' . esc_html($step) . '</li>';
-            }
-            echo '</ol>';
-            echo '</div>';
-        }
-
-        echo '</div>';
-        
-        // Section exemples d'utilisation
-        echo '<div style="background:#e3f2fd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #2196f3;">';
-        echo '<h3>📝 Exemples d\'utilisation du Bloc Complet</h3>';
-        echo '<p>Voici différentes configurations possibles pour le shortcode <code>[jlg_bloc_complet]</code> :</p>';
-        echo '<div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">';
-        echo '<h4>Configuration minimale (recommandée pour débuter) :</h4>';
-        echo '<pre style="background:#f5f5f5; padding:10px; border-left:3px solid #4caf50;">[jlg_bloc_complet]</pre>';
-        echo '</div>';
-        echo '<div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">';
-        echo '<h4>Style compact sans tagline :</h4>';
-        echo '<pre style="background:#f5f5f5; padding:10px; border-left:3px solid #ff9800;">[jlg_bloc_complet style="compact" afficher_tagline="non"]</pre>';
-        echo '</div>';
-        echo '<div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">';
-        echo '<h4>Personnalisation complète :</h4>';
-        echo '<pre style="background:#f5f5f5; padding:10px; border-left:3px solid #9c27b0;">[jlg_bloc_complet style="moderne" couleur_accent="#e91e63" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>';
-        echo '</div>';
-        echo '</div>';
-        
-        // Section migration
-        echo '<div style="background:#fce4ec; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #e91e63;">';
-        echo '<h3>🔄 Migration vers le Bloc Complet</h3>';
-        echo '<p><strong>Vous utilisez déjà les shortcodes séparés ?</strong> Voici comment migrer :</p>';
-        echo '<table style="width:100%; background:white; border-radius:4px; overflow:hidden; margin-top:15px;">';
-        echo '<tr style="background:#f5f5f5;">';
-        echo '<th style="padding:10px; text-align:left;">Avant (3 shortcodes)</th>';
-        echo '<th style="padding:10px; text-align:left;">Après (1 shortcode)</th>';
-        echo '</tr>';
-        echo '<tr>';
-        echo '<td style="padding:10px; border-top:1px solid #ddd;"><pre>[tagline_notation_jlg]
-[bloc_notation_jeu]
-[jlg_points_forts_faibles]</pre></td>';
-        echo '<td style="padding:10px; border-top:1px solid #ddd;"><pre>[jlg_bloc_complet]</pre></td>';
-        echo '</tr>';
-        echo '</table>';
-        echo '<p style="margin-top:15px;"><em>✅ Plus simple, plus cohérent, même résultat en mieux !</em></p>';
-        echo '</div>';
-        
-        echo '<div style="background:#fff3cd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #ffc107;">';
-        echo '<h3>💡 Astuce Pro</h3>';
-        echo '<p><strong>Pour une intégration optimale :</strong> Créez un template d\'article dédié aux tests dans votre thème avec le shortcode <code>[jlg_bloc_complet]</code> pré-intégré. Ainsi, vous n\'aurez plus qu\'à remplir les métadonnées !</p>';
-        echo '<p style="margin-top:10px;">Exemple de template personnalisé :</p>';
-        echo '<pre style="background:#f5f5f5; padding:10px; border-radius:4px;">&lt;?php
-// Dans votre template single-test.php
-if (have_posts()) : while (have_posts()) : the_post(); ?&gt;
-    &lt;article&gt;
-        &lt;h1&gt;&lt;?php the_title(); ?&gt;&lt;/h1&gt;
-        
-        &lt;!-- Bloc de notation complet automatique --&gt;
-        &lt;?php echo do_shortcode(\'[jlg_bloc_complet]\'); ?&gt;
-        
-        &lt;!-- Contenu de l\'article --&gt;
-        &lt;?php the_content(); ?&gt;
-        
-        &lt;!-- Notation des utilisateurs --&gt;
-        &lt;?php echo do_shortcode(\'[notation_utilisateurs_jlg]\'); ?&gt;
-    &lt;/article&gt;
-&lt;?php endwhile; endif; ?&gt;</pre>';
-        echo '</div>';
-        
-        // Section FAQ
-        echo '<div style="background:#f3e5f5; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #9c27b0;">';
-        echo '<h3>❓ Questions Fréquentes sur le Bloc Complet</h3>';
-        echo '<details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">';
-        echo '<summary style="cursor:pointer; font-weight:bold;">Puis-je utiliser le bloc complet ET les shortcodes séparés ?</summary>';
-        echo '<p style="margin-top:10px;">Oui, mais évitez la duplication. Utilisez soit le bloc complet, soit les shortcodes individuels, pas les deux ensemble.</p>';
-        echo '</details>';
-        echo '<details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">';
-        echo '<summary style="cursor:pointer; font-weight:bold;">Comment changer l\'ordre des sections ?</summary>';
-        echo '<p style="margin-top:10px;">L\'ordre est fixe (Tagline → Notation → Points), mais vous pouvez masquer des sections avec les paramètres afficher_*="non".</p>';
-        echo '</details>';
-        echo '<details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">';
-        echo '<summary style="cursor:pointer; font-weight:bold;">Le bloc complet est-il plus lourd en performance ?</summary>';
-        echo '<p style="margin-top:10px;">Non, au contraire ! Un seul shortcode est plus performant que trois shortcodes séparés.</p>';
-        echo '</details>';
-        echo '<details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">';
-        echo '<summary style="cursor:pointer; font-weight:bold;">Puis-je avoir plusieurs blocs complets sur la même page ?</summary>';
-        echo '<p style="margin-top:10px;">Oui, en utilisant le paramètre post_id pour cibler différents articles : [jlg_bloc_complet post_id="123"]</p>';
-        echo '</details>';
-        echo '</div>';
-        
-        // Section Gestion des Plateformes
-        echo '<div style="background:#e8f5e9; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #4caf50;">';
-        echo '<h3>🎮 Gestion des Plateformes</h3>';
-        echo '<p><strong>Nouveau système de plateformes dynamiques !</strong></p>';
-        echo '<ul style="margin-left:20px;">';
-        echo '<li>Ajoutez vos propres plateformes depuis l\'onglet "Plateformes"</li>';
-        echo '<li>Réorganisez l\'ordre d\'affichage par glisser-déposer</li>';
-        echo '<li>Les plateformes personnalisées apparaissent automatiquement dans les metaboxes</li>';
-        echo '<li>Supprimez les plateformes obsolètes en un clic</li>';
-        echo '<li>Compatibilité totale avec le shortcode [jlg_fiche_technique]</li>';
-        echo '</ul>';
-        echo '<p style="margin-top:15px;">';
-        echo '<a href="' . admin_url('admin.php?page=' . $this->page_slug . '&tab=plateformes') . '" class="button button-primary">Gérer les plateformes →</a>';
-        echo '</p>';
-        echo '</div>';
+        return JLG_Template_Loader::get_admin_template('tabs/tutorials', [
+            'tutorials' => $tutorials,
+            'platforms_url' => admin_url('admin.php?page=' . $this->page_slug . '&tab=plateformes'),
+        ]);
     }
 }
+

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
@@ -14,21 +14,52 @@ class JLG_Template_Loader {
             self::init();
         }
 
-        $template_path = self::get_template_path($template_name);
-        
+        return self::load_template_from_directory(self::$templates_dir, $template_name, $variables);
+    }
+
+    public static function get_admin_template($template_name, $variables = []) {
+        $directory = JLG_NOTATION_PLUGIN_DIR . 'admin/templates/';
+        return self::load_template_from_directory($directory, $template_name, $variables);
+    }
+
+    public static function get_template_from_directory($directory, $template_name, $variables = []) {
+        return self::load_template_from_directory($directory, $template_name, $variables);
+    }
+
+    private static function load_template_from_directory($directory, $template_name, $variables) {
+        $template_path = self::build_template_path($directory, $template_name);
+
         if (!file_exists($template_path)) {
-            return self::handle_missing_template($template_name);
+            $relative_name = self::get_relative_template_name($directory, $template_name);
+            return self::handle_missing_template($relative_name);
         }
 
         return self::load_template_file($template_path, $variables);
     }
 
-    private static function get_template_path($template_name) {
+    private static function build_template_path($directory, $template_name) {
+        $directory = rtrim($directory, '/\\') . '/';
         $template_name = ltrim($template_name, '/');
+
         if (!str_ends_with($template_name, '.php')) {
             $template_name .= '.php';
         }
-        return self::$templates_dir . $template_name;
+
+        return $directory . $template_name;
+    }
+
+    private static function get_relative_template_name($directory, $template_name) {
+        $directory = rtrim($directory, '/\\') . '/';
+        $relative_base = str_replace(JLG_NOTATION_PLUGIN_DIR, '', $directory);
+        $relative_base = trim($relative_base, '/');
+
+        $template_name = ltrim($template_name, '/');
+
+        if (!empty($relative_base)) {
+            return $relative_base . '/' . $template_name;
+        }
+
+        return $template_name;
     }
 
     private static function load_template_file($template_path, $variables) {
@@ -53,5 +84,13 @@ class JLG_Template_Loader {
 
     public static function display_template($template_name, $variables = []) {
         echo self::get_template($template_name, $variables);
+    }
+
+    public static function display_admin_template($template_name, $variables = []) {
+        echo self::get_admin_template($template_name, $variables);
+    }
+
+    public static function display_template_from_directory($directory, $template_name, $variables = []) {
+        echo self::get_template_from_directory($directory, $template_name, $variables);
     }
 }


### PR DESCRIPTION
## Summary
- split the admin menu page rendering into tab-specific helpers that pass data to templates
- load the admin navigation and tab content from new files in `admin/templates` via the shared template loader
- extend `JLG_Template_Loader` so it can locate admin templates alongside the existing front-end views

## Testing
- `php -l includes/admin/class-jlg-admin-menu.php`
- `php -l includes/utils/class-jlg-template-loader.php`
- `php -l admin/templates/admin-page.php`
- `php -l admin/templates/partials/tab-navigation.php`
- `php -l admin/templates/tabs/settings.php`
- `php -l admin/templates/tabs/posts-list.php`
- `php -l admin/templates/tabs/shortcodes.php`
- `php -l admin/templates/tabs/tutorials.php`


------
https://chatgpt.com/codex/tasks/task_e_68c8488e135c832ebae116123e355d98