### PR TITLE
Align admin RAWG search parsing

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
@@ -25,7 +25,19 @@ jQuery(document).ready(function($) {
                 $('#jlg-api-search-button').text('Rechercher').prop('disabled', false);
 
                 if (response.success) {
-                    var games = response.data;
+                    var games = [];
+
+                    if (Array.isArray(response.data)) {
+                        games = response.data;
+                    } else if (response.data && Array.isArray(response.data.games)) {
+                        games = response.data.games;
+                    }
+
+                    if (!games.length && response.data && response.data.message) {
+                        resultsDiv.html('<p>' + response.data.message + '</p>');
+                        resultsDiv.data('games', []);
+                        return;
+                    }
                     var html = '<ul style="list-style: disc; padding-left: 20px;">';
                     games.forEach(function(game, index) {
                         var year = game.release_date ? new Date(game.release_date).getFullYear() : 'N/A';

--- a/plugin-notation-jeux_V4/includes/assets/js/jlg-admin-api.js
+++ b/plugin-notation-jeux_V4/includes/assets/js/jlg-admin-api.js
@@ -25,7 +25,19 @@ jQuery(document).ready(function($) {
                 $('#jlg-api-search-button').text('Rechercher').prop('disabled', false);
 
                 if (response.success) {
-                    var games = response.data;
+                    var games = [];
+
+                    if (Array.isArray(response.data)) {
+                        games = response.data;
+                    } else if (response.data && Array.isArray(response.data.games)) {
+                        games = response.data.games;
+                    }
+
+                    if (!games.length && response.data && response.data.message) {
+                        resultsDiv.html('<p>' + response.data.message + '</p>');
+                        resultsDiv.data('games', []);
+                        return;
+                    }
                     var html = '<ul style="list-style: disc; padding-left: 20px;">';
                     games.forEach(function(game, index) {
                         var year = game.release_date ? new Date(game.release_date).getFullYear() : 'N/A';


### PR DESCRIPTION
## Summary
- align the admin RAWG search handler with the PHP response format by reading the `games` collection from the payload
- harden the JavaScript to gracefully handle unexpected payloads and surface informational messages when no results are returned

## Testing
- not run (WordPress admin search requires a full WordPress environment)


------
https://chatgpt.com/codex/tasks/task_e_68c85d1b0cd4832eb2a00dd8f175f90f