### PR TITLE
Delete platforms list option on uninstall

### DIFF
--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -21,6 +21,7 @@ if ($delete_data) {
     delete_option('notation_jlg_settings');
     delete_option('jlg_notation_version');
     delete_option('jlg_migration_v5_completed');
+    delete_option('jlg_platforms_list');
     delete_option('jlg_notation_delete_data_on_uninstall');
     
     // Supprimer toutes les métadonnées des posts


### PR DESCRIPTION
## Summary
- ensure the uninstall routine deletes the `jlg_platforms_list` option so the option table is cleaned

## Testing
- php -l uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68c878bb3840832e8dbae92f203b2047