### PR TITLE
Hash user IP when determining rating vote

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -19,15 +19,17 @@ class JLG_Shortcode_User_Rating {
 
         $post_id = get_the_ID();
         $ratings = get_post_meta($post_id, '_jlg_user_ratings', true);
-        $has_voted = (is_array($ratings) && isset($ratings[$_SERVER['REMOTE_ADDR']]));
-        
+        $user_ip = isset($_SERVER['REMOTE_ADDR']) ? filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP) : false;
+        $user_ip_hash = $user_ip ? wp_hash($user_ip) : '';
+        $has_voted = (is_array($ratings) && $user_ip_hash && isset($ratings[$user_ip_hash]));
+
         return JLG_Frontend::get_template_html('shortcode-user-rating', [
             'options' => $options,
             'post_id' => $post_id,
             'avg_rating' => get_post_meta($post_id, '_jlg_user_rating_avg', true),
             'count' => get_post_meta($post_id, '_jlg_user_rating_count', true),
             'has_voted' => $has_voted,
-            'user_vote' => $has_voted ? $ratings[$_SERVER['REMOTE_ADDR']] : 0
+            'user_vote' => $has_voted ? $ratings[$user_ip_hash] : 0
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- hash the visitor IP before checking stored user ratings
- read the stored vote using the hashed key to stay consistent with AJAX storage

## Testing
- php -l includes/shortcodes/class-jlg-shortcode-user-rating.php

------
https://chatgpt.com/codex/tasks/task_e_68c878af21ec832ea67d0df3b5d52c18