### PR TITLE
Internationalize template strings and regenerate POT

### DIFF
--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -1,0 +1,138 @@
+# Translation template for the Notation JLG plugin.
+# Copyright (C) YEAR Notation JLG
+# This file is distributed under the same license as the Notation JLG package.
+# Translators: Please update the header information with your details.
+msgid ""
+msgstr ""
+"Project-Id-Version: Notation - JLG (Version 5.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-15 21:53+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: xgettext\n"
+
+#. translators: Section title for the list of advantages in the pros and cons block.
+#: templates/shortcode-pros-cons.php:10
+msgid "Points Forts"
+msgstr ""
+
+#. translators: Section title for the list of drawbacks in the pros and cons block.
+#: templates/shortcode-pros-cons.php:19
+msgid "Points Faibles"
+msgstr ""
+
+#. translators: %s: Maximum rating value displayed with the thumbnail score.
+#: templates/widget-thumbnail-score.php:35
+#, php-format
+msgid "/%s"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:21
+msgid "Titre du jeu"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:26
+msgid "Date"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:31
+msgid "Note"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:36
+msgid "Développeur"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:40
+msgid "Éditeur"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:62
+msgid " ▲"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:63
+msgid " ▼"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:91
+msgid "Toutes les catégories"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:100
+msgid "Filtrer"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:128
+#: templates/shortcode-summary-display.php:186
+msgid "Aucun article trouvé pour cette sélection."
+msgstr ""
+
+#. translators: Abbreviation meaning that the average score is not available.
+#. translators: Abbreviation meaning that the user rating is not available.
+#: templates/shortcode-summary-display.php:163
+#: templates/shortcode-user-rating.php:15
+msgid "N/A"
+msgstr ""
+
+#. translators: %s: Maximum possible rating value.
+#: templates/shortcode-summary-display.php:167
+#, php-format
+msgid "/ %s"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:172
+#: templates/shortcode-summary-display.php:176
+msgid "-"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:201
+msgid "« Précédent"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:202
+msgid "Suivant »"
+msgstr ""
+
+#: templates/shortcode-tagline.php:12
+msgid "Français"
+msgstr ""
+
+#: templates/shortcode-tagline.php:13
+msgid "English"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:6
+msgid "Votre avis nous intéresse !"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:19
+#, php-format
+msgid ""
+"Note moyenne : <strong class=\"jlg-user-rating-avg-value\">%1$s</strong> sur "
+"%2$s (<span class=\"jlg-user-rating-count-value\">%3$s</span> votes)"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:37
+msgid "Merci pour votre vote !"
+msgstr ""
+
+#: templates/widget-latest-reviews.php:18
+msgid "Aucun test trouvé."
+msgstr ""
+
+#: templates/shortcode-rating-block.php:22
+#: templates/shortcode-rating-block.php:27
+msgid "Note Globale"
+msgstr ""
+
+#. translators: 1: Rating value for a specific category. 2: Maximum possible rating.
+#: templates/shortcode-rating-block.php:46
+#, php-format
+msgid "%1$s / %2$s"
+msgstr ""

--- a/plugin-notation-jeux_V4/templates/shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-pros-cons.php
@@ -5,13 +5,19 @@ if (!defined('ABSPATH')) exit;
 <div class="jlg-pros-cons-wrapper">
     <?php if (!empty($pros_list)): ?>
     <div class="jlg-pros-cons-col">
-        <h3><span class="icon icon-pros">+</span> Points Forts</h3>
+        <h3><span class="icon icon-pros">+</span> <?php
+            /* translators: Section title for the list of advantages in the pros and cons block. */
+            esc_html_e('Points Forts', 'notation-jlg');
+        ?></h3>
         <ul><?php foreach ($pros_list as $pro) echo '<li>' . esc_html(trim($pro)) . '</li>'; ?></ul>
     </div>
     <?php endif; ?>
     <?php if (!empty($cons_list)): ?>
     <div class="jlg-pros-cons-col">
-        <h3><span class="icon icon-cons">-</span> Points Faibles</h3>
+        <h3><span class="icon icon-cons">-</span> <?php
+            /* translators: Section title for the list of drawbacks in the pros and cons block. */
+            esc_html_e('Points Faibles', 'notation-jlg');
+        ?></h3>
         <ul><?php foreach ($cons_list as $con) echo '<li>' . esc_html(trim($con)) . '</li>'; ?></ul>
     </div>
     <?php endif; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -19,12 +19,12 @@ $options = JLG_Helpers::get_plugin_options();
         <?php if($options['score_layout'] === 'circle'): ?>
             <div class="score-circle">
                 <div class="score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
-                <div class="score-label">Note Globale</div>
+                <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
             </div>
         <?php else: ?>
             <div class="global-score-text">
                 <div class="score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
-                <div class="score-label">Note Globale</div>
+                <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
             </div>
         <?php endif; ?>
     </div>
@@ -38,7 +38,17 @@ $options = JLG_Helpers::get_plugin_options();
             <div class="rating-item">
                 <div class="rating-label">
                     <span><?php echo esc_html($categories[$key]); ?></span>
-                    <span><?php echo esc_html(number_format($score_value, 1, ',', ' ')); ?> / 10</span>
+                    <span>
+                        <?php
+                        $formatted_score_value = esc_html(number_format($score_value, 1, ',', ' '));
+                        printf(
+                            /* translators: 1: Rating value for a specific category. 2: Maximum possible rating. */
+                            esc_html__('%1$s / %2$s', 'notation-jlg'),
+                            $formatted_score_value,
+                            10
+                        );
+                        ?>
+                    </span>
                 </div>
                 <div class="rating-bar-container">
                     <div class="rating-bar" style="--rating-percent:<?php echo esc_attr($score_value * 10); ?>%; --bar-color: <?php echo esc_attr($bar_color); ?>;"></div>

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -17,11 +17,29 @@ $colonnes = array_map('trim', explode(',', $atts['colonnes']));
 
 // Définir les colonnes disponibles
 $colonnes_disponibles = [
-    'titre' => ['label' => 'Titre du jeu', 'sortable' => true, 'key' => 'title'],
-    'date' => ['label' => 'Date', 'sortable' => true, 'key' => 'date'],
-    'note' => ['label' => 'Note', 'sortable' => true, 'key' => 'average_score'],
-    'developpeur' => ['label' => 'Développeur', 'sortable' => false],
-    'editeur' => ['label' => 'Éditeur', 'sortable' => false]
+    'titre' => [
+        'label' => __('Titre du jeu', 'notation-jlg'),
+        'sortable' => true,
+        'key' => 'title'
+    ],
+    'date' => [
+        'label' => __('Date', 'notation-jlg'),
+        'sortable' => true,
+        'key' => 'date'
+    ],
+    'note' => [
+        'label' => __('Note', 'notation-jlg'),
+        'sortable' => true,
+        'key' => 'average_score'
+    ],
+    'developpeur' => [
+        'label' => __('Développeur', 'notation-jlg'),
+        'sortable' => false
+    ],
+    'editeur' => [
+        'label' => __('Éditeur', 'notation-jlg'),
+        'sortable' => false
+    ]
 ];
 
 // ID unique pour le tableau
@@ -40,7 +58,9 @@ if (!function_exists('jlg_print_sortable_header')) {
             
             $indicator = '';
             if ($current_orderby === $sort_key || $current_orderby === $col) {
-                $indicator = $current_order === 'ASC' ? ' ▲' : ' ▼';
+                $indicator = $current_order === 'ASC'
+                    ? esc_html__(' ▲', 'notation-jlg')
+                    : esc_html__(' ▼', 'notation-jlg');
             }
             
             $class = 'sortable';
@@ -68,16 +88,16 @@ if (!function_exists('jlg_print_sortable_header')) {
                 if (isset($_GET['orderby'])) echo '<input type="hidden" name="orderby" value="' . esc_attr($_GET['orderby']) . '">';
                 if (isset($_GET['order'])) echo '<input type="hidden" name="order" value="' . esc_attr($_GET['order']) . '">';
                 wp_dropdown_categories([
-                    'show_option_all' => 'Toutes les catégories', 
-                    'orderby' => 'name', 
-                    'hide_empty' => 1, 
-                    'name' => 'cat_filter', 
-                    'id' => 'jlg_cat_filter', 
-                    'selected' => isset($_GET['cat_filter']) ? intval($_GET['cat_filter']) : 0, 
+                    'show_option_all' => __('Toutes les catégories', 'notation-jlg'),
+                    'orderby' => 'name',
+                    'hide_empty' => 1,
+                    'name' => 'cat_filter',
+                    'id' => 'jlg_cat_filter',
+                    'selected' => isset($_GET['cat_filter']) ? intval($_GET['cat_filter']) : 0,
                     'hierarchical' => true
                 ]);
                 ?>
-                <input type="submit" value="Filtrer">
+                <input type="submit" value="<?php echo esc_attr__('Filtrer', 'notation-jlg'); ?>">
             </form>
         </div>
     <?php endif; ?>
@@ -103,9 +123,9 @@ if (!function_exists('jlg_print_sortable_header')) {
                         <span><?php the_title(); ?></span>
                     </div>
                 </a>
-            <?php endwhile; 
+            <?php endwhile;
             else : ?>
-                <p>Aucun article trouvé pour cette sélection.</p>
+                <p><?php esc_html_e('Aucun article trouvé pour cette sélection.', 'notation-jlg'); ?></p>
             <?php endif; ?>
         </div>
     <?php else : ?>
@@ -139,22 +159,31 @@ if (!function_exists('jlg_print_sortable_header')) {
                                         break;
                                     case 'note':
                                         $score = get_post_meta($post_id, '_jlg_average_score', true);
-                                        echo '<strong>' . esc_html($score ?: 'N/A') . '</strong> / 10';
+                                        /* translators: Abbreviation meaning that the average score is not available. */
+                                        $score_display = $score ?: __('N/A', 'notation-jlg');
+                                        echo '<strong>' . esc_html($score_display) . '</strong> ';
+                                        printf(
+                                            /* translators: %s: Maximum possible rating value. */
+                                            esc_html__('/ %s', 'notation-jlg'),
+                                            10
+                                        );
                                         break;
                                     case 'developpeur':
-                                        echo esc_html(get_post_meta($post_id, '_jlg_developpeur', true) ?: '-');
+                                        $developer = get_post_meta($post_id, '_jlg_developpeur', true) ?: __('-', 'notation-jlg');
+                                        echo esc_html($developer);
                                         break;
                                     case 'editeur':
-                                        echo esc_html(get_post_meta($post_id, '_jlg_editeur', true) ?: '-');
+                                        $publisher = get_post_meta($post_id, '_jlg_editeur', true) ?: __('-', 'notation-jlg');
+                                        echo esc_html($publisher);
                                         break;
                                 }
                                 echo '</td>';
                             endforeach; ?>
                         </tr>
-                    <?php endwhile; 
+                    <?php endwhile;
                     else : ?>
                         <tr>
-                            <td colspan="<?php echo count($colonnes); ?>">Aucun article trouvé pour cette sélection.</td>
+                            <td colspan="<?php echo count($colonnes); ?>"><?php esc_html_e('Aucun article trouvé pour cette sélection.', 'notation-jlg'); ?></td>
                         </tr>
                     <?php endif; ?>
                 </tbody>
@@ -169,8 +198,8 @@ if (!function_exists('jlg_print_sortable_header')) {
         'format' => '?paged=%#%', 
         'current' => max(1, $paged), 
         'total' => $query->max_num_pages, 
-        'prev_text' => '« Précédent', 
-        'next_text' => 'Suivant »'
+        'prev_text' => __('« Précédent', 'notation-jlg'),
+        'next_text' => __('Suivant »', 'notation-jlg')
     ]);
     
     if ($pagination_links) {

--- a/plugin-notation-jeux_V4/templates/shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-tagline.php
@@ -9,8 +9,8 @@ $default_lang = $has_fr ? 'fr' : 'en';
 <div class="jlg-tagline-block">
     <?php if ($has_fr && $has_en): ?>
         <div class="jlg-tagline-flags">
-            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'; ?>" data-lang="fr" class="jlg-lang-flag <?php if($default_lang == 'fr') echo 'active'; ?>" alt="Français">
-            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'; ?>" data-lang="en" class="jlg-lang-flag <?php if($default_lang == 'en') echo 'active'; ?>" alt="English">
+            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'; ?>" data-lang="fr" class="jlg-lang-flag <?php if($default_lang == 'fr') echo 'active'; ?>" alt="<?php echo esc_attr__('Français', 'notation-jlg'); ?>">
+            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'; ?>" data-lang="en" class="jlg-lang-flag <?php if($default_lang == 'en') echo 'active'; ?>" alt="<?php echo esc_attr__('English', 'notation-jlg'); ?>">
         </div>
     <?php endif; ?>
 

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -3,15 +3,36 @@ if (!defined('ABSPATH')) exit;
 ?>
 
 <div class="jlg-user-rating-block <?php if ($has_voted) echo 'has-voted'; ?>">
-    <div class="jlg-user-rating-title">Votre avis nous intéresse !</div>
+    <div class="jlg-user-rating-title"><?php esc_html_e('Votre avis nous intéresse !', 'notation-jlg'); ?></div>
     <div class="jlg-user-rating-stars" data-post-id="<?php echo esc_attr($post_id); ?>">
         <?php for ($i = 1; $i <= 5; $i++): ?>
             <span class="jlg-user-star <?php if($has_voted && $i <= $user_vote) echo 'selected'; ?>" data-value="<?php echo $i; ?>">★</span>
         <?php endfor; ?>
     </div>
     <div class="jlg-user-rating-summary">
-        Note moyenne : <strong class="jlg-user-rating-avg-value"><?php echo !empty($avg_rating) ? number_format(floatval($avg_rating), 2) : 'N/A'; ?></strong> 
-        sur 5 (<span class="jlg-user-rating-count-value"><?php echo !empty($count) ? intval($count) : 0; ?></span> votes)
+        <?php
+        /* translators: Abbreviation meaning that the user rating is not available. */
+        $average_display = !empty($avg_rating) ? number_format(floatval($avg_rating), 2) : __('N/A', 'notation-jlg');
+        $votes_display = !empty($count) ? intval($count) : 0;
+        /* translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes. */
+        $summary_template = __(
+            'Note moyenne : <strong class="jlg-user-rating-avg-value">%1$s</strong> sur %2$s (<span class="jlg-user-rating-count-value">%3$s</span> votes)',
+            'notation-jlg'
+        );
+
+        echo wp_kses(
+            sprintf(
+                $summary_template,
+                esc_html($average_display),
+                esc_html(number_format_i18n(5)),
+                esc_html(number_format_i18n($votes_display))
+            ),
+            [
+                'strong' => ['class' => []],
+                'span' => ['class' => []],
+            ]
+        );
+        ?>
     </div>
-    <div class="jlg-rating-message"><?php if($has_voted) echo 'Merci pour votre vote !'; ?></div>
+    <div class="jlg-rating-message"><?php if($has_voted) esc_html_e('Merci pour votre vote !', 'notation-jlg'); ?></div>
 </div>

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -15,7 +15,7 @@ if ($latest_reviews->have_posts()) {
     }
     echo '</ul>';
 } else {
-    echo '<p>' . esc_html__('Aucun test trouvé.', 'plugin-notation-jeux') . '</p>';
+    echo '<p>' . esc_html__('Aucun test trouvé.', 'notation-jlg') . '</p>';
 }
 wp_reset_postdata();
 

--- a/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
+++ b/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
@@ -28,5 +28,13 @@ $score_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
     z-index: 10;
 ">
     <?php echo esc_html(number_format($average_score, 1)); ?>
-    <span style="font-size: 0.8em; opacity: 0.9;">/10</span>
+    <span style="font-size: 0.8em; opacity: 0.9;">
+        <?php
+        printf(
+            /* translators: %s: Maximum rating value displayed with the thumbnail score. */
+            esc_html__('/%s', 'notation-jlg'),
+            10
+        );
+        ?>
+    </span>
 </div>


### PR DESCRIPTION
## Summary
- wrap user-facing template strings in translation helpers tied to the `notation-jlg` text domain and add context where needed
- localize rating displays and fallback labels across pros/cons, summary tables, user ratings, taglines, and widgets
- generate a fresh `languages/notation-jlg.pot` file capturing the updated strings

## Testing
- find templates -name '*.php' -exec php -l {}


------
https://chatgpt.com/codex/tasks/task_e_68c888e53688832ebc0b7f6af02140d9