### PR TITLE
Refactor template variables without extract

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/admin-page.php
+++ b/plugin-notation-jeux_V4/admin/templates/admin-page.php
@@ -1,9 +1,9 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-$page_title = $page_title ?? '';
-$tab_navigation = $tab_navigation ?? '';
-$tab_content = $tab_content ?? '';
+$page_title = $variables['page_title'] ?? '';
+$tab_navigation = $variables['tab_navigation'] ?? '';
+$tab_content = $variables['tab_content'] ?? '';
 ?>
 <div class="wrap">
     <?php if (!empty($page_title)) : ?>

--- a/plugin-notation-jeux_V4/admin/templates/partials/tab-navigation.php
+++ b/plugin-notation-jeux_V4/admin/templates/partials/tab-navigation.php
@@ -1,9 +1,9 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-$tabs = $tabs ?? [];
-$active_tab = $active_tab ?? '';
-$page_slug = $page_slug ?? '';
+$tabs = isset($variables['tabs']) && is_array($variables['tabs']) ? $variables['tabs'] : [];
+$active_tab = $variables['active_tab'] ?? '';
+$page_slug = $variables['page_slug'] ?? '';
 
 if (empty($tabs)) {
     return;

--- a/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
@@ -1,13 +1,13 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-$has_rated_posts = $has_rated_posts ?? false;
-$empty_state = $empty_state ?? [];
-$stats = $stats ?? [];
-$columns = isset($columns) && is_array($columns) ? $columns : [];
-$posts = isset($posts) && is_array($posts) ? $posts : [];
-$pagination = $pagination ?? '';
-$print_button_label = $print_button_label ?? '';
+$has_rated_posts = $variables['has_rated_posts'] ?? false;
+$empty_state = isset($variables['empty_state']) && is_array($variables['empty_state']) ? $variables['empty_state'] : [];
+$stats = isset($variables['stats']) && is_array($variables['stats']) ? $variables['stats'] : [];
+$columns = isset($variables['columns']) && is_array($variables['columns']) ? $variables['columns'] : [];
+$posts = isset($variables['posts']) && is_array($variables['posts']) ? $variables['posts'] : [];
+$pagination = $variables['pagination'] ?? '';
+$print_button_label = $variables['print_button_label'] ?? '';
 $column_count = count($columns) + 2;
 ?>
 <h2>📊 Vos Articles avec Notation</h2>

--- a/plugin-notation-jeux_V4/admin/templates/tabs/settings.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/settings.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-$settings_page = $settings_page ?? '';
+$settings_page = $variables['settings_page'] ?? '';
 ?>
 <h2>🎨 Configuration du Plugin</h2>
 <p>Personnalisez l'apparence et le comportement du système de notation.</p>

--- a/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
@@ -1,8 +1,8 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-$tutorials = isset($tutorials) && is_array($tutorials) ? $tutorials : [];
-$platforms_url = $platforms_url ?? '';
+$tutorials = isset($variables['tutorials']) && is_array($variables['tutorials']) ? $variables['tutorials'] : [];
+$platforms_url = $variables['platforms_url'] ?? '';
 ?>
 <h2>📚 Guide d'Utilisation</h2>
 <p>Tutoriels et guides pour tirer le meilleur parti du plugin.</p>

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -166,7 +166,14 @@ class JLG_Frontend {
             'tagline_bg_color',
             'tagline_text_color',
         ], $palette);
-        extract($palette_colors, EXTR_OVERWRITE);
+        $bg_color = $palette_colors['bg_color'] ?? '';
+        $bg_color_secondary = $palette_colors['bg_color_secondary'] ?? '';
+        $border_color = $palette_colors['border_color'] ?? '';
+        $main_text_color = $palette_colors['main_text_color'] ?? '';
+        $secondary_text_color = $palette_colors['secondary_text_color'] ?? '';
+        $bar_bg_color = $palette_colors['bar_bg_color'] ?? '';
+        $tagline_bg_color = $palette_colors['tagline_bg_color'] ?? '';
+        $tagline_text_color = $palette_colors['tagline_text_color'] ?? '';
 
         $option_colors = $this->sanitize_color_options([
             'score_gradient_1',
@@ -182,7 +189,18 @@ class JLG_Frontend {
             'table_zebra_bg_color' => ['allow_transparent' => true],
             'circle_border_color',
         ], $options);
-        extract($option_colors, EXTR_OVERWRITE);
+        $score_gradient_1 = $option_colors['score_gradient_1'] ?? '';
+        $score_gradient_2 = $option_colors['score_gradient_2'] ?? '';
+        $color_high = $option_colors['color_high'] ?? '';
+        $color_low = $option_colors['color_low'] ?? '';
+        $user_rating_text_color = $option_colors['user_rating_text_color'] ?? '';
+        $user_rating_star_color = $option_colors['user_rating_star_color'] ?? '';
+        $table_header_bg_color = $option_colors['table_header_bg_color'] ?? '';
+        $table_header_text_color = $option_colors['table_header_text_color'] ?? '';
+        $table_row_bg_color = $option_colors['table_row_bg_color'] ?? '';
+        $table_row_text_color = $option_colors['table_row_text_color'] ?? '';
+        $table_zebra_bg_color = $option_colors['table_zebra_bg_color'] ?? '';
+        $circle_border_color = $option_colors['circle_border_color'] ?? '';
 
         $default_settings = JLG_Helpers::get_default_settings();
         $default_colors = $this->sanitize_color_options([
@@ -209,7 +227,28 @@ class JLG_Frontend {
             'default_dark_text_color' => 'dark_text_color',
             'default_dark_text_color_secondary' => 'dark_text_color_secondary',
         ], $default_settings);
-        extract($default_colors, EXTR_OVERWRITE);
+        $default_score_gradient_1 = $default_colors['default_score_gradient_1'] ?? '';
+        $default_score_gradient_2 = $default_colors['default_score_gradient_2'] ?? '';
+        $default_color_high = $default_colors['default_color_high'] ?? '';
+        $default_color_low = $default_colors['default_color_low'] ?? '';
+        $default_user_rating_text_color = $default_colors['default_user_rating_text_color'] ?? '';
+        $default_user_rating_star_color = $default_colors['default_user_rating_star_color'] ?? '';
+        $default_table_header_bg_color = $default_colors['default_table_header_bg_color'] ?? '';
+        $default_table_header_text_color = $default_colors['default_table_header_text_color'] ?? '';
+        $default_table_row_bg_color = $default_colors['default_table_row_bg_color'] ?? '';
+        $default_table_row_text_color = $default_colors['default_table_row_text_color'] ?? '';
+        $default_table_zebra_bg_color = $default_colors['default_table_zebra_bg_color'] ?? '';
+        $default_circle_border_color = $default_colors['default_circle_border_color'] ?? '';
+        $default_light_bg_color = $default_colors['default_light_bg_color'] ?? '';
+        $default_light_bg_color_secondary = $default_colors['default_light_bg_color_secondary'] ?? '';
+        $default_light_border_color = $default_colors['default_light_border_color'] ?? '';
+        $default_light_text_color = $default_colors['default_light_text_color'] ?? '';
+        $default_light_text_color_secondary = $default_colors['default_light_text_color_secondary'] ?? '';
+        $default_dark_bg_color = $default_colors['default_dark_bg_color'] ?? '';
+        $default_dark_bg_color_secondary = $default_colors['default_dark_bg_color_secondary'] ?? '';
+        $default_dark_border_color = $default_colors['default_dark_border_color'] ?? '';
+        $default_dark_text_color = $default_colors['default_dark_text_color'] ?? '';
+        $default_dark_text_color_secondary = $default_colors['default_dark_text_color_secondary'] ?? '';
 
         $default_score_gradient_1 = $default_score_gradient_1 !== '' ? $default_score_gradient_1 : '#000000';
         $default_score_gradient_2 = $default_score_gradient_2 !== '' ? $default_score_gradient_2 : '#000000';

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
@@ -63,12 +63,14 @@ class JLG_Template_Loader {
     }
 
     private static function load_template_file($template_path, $variables) {
-        if (!empty($variables) && is_array($variables)) {
-            extract($variables, EXTR_SKIP);
-        }
+        $variables = is_array($variables) ? $variables : [];
 
         ob_start();
-        include $template_path;
+        (static function ($__template_path, $__variables) {
+            $variables = $__variables;
+            include $__template_path;
+        })($template_path, $variables);
+
         return ob_get_clean();
     }
 


### PR DESCRIPTION
## Summary
- replace extract usage in the frontend asset setup with explicit variable assignments
- load template context arrays without extract and update admin templates to rely on the shared $variables array

## Testing
- php -l includes/class-jlg-frontend.php
- php -l includes/utils/class-jlg-template-loader.php
- php -l admin/templates/admin-page.php
- php -l admin/templates/partials/tab-navigation.php
- php -l admin/templates/tabs/settings.php
- php -l admin/templates/tabs/posts-list.php
- php -l admin/templates/tabs/tutorials.php

------
https://chatgpt.com/codex/tasks/task_e_68c9308d9a64832e8f5bd052403aa3cd