### PR TITLE
Sanitize shortcode error output

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -74,7 +74,7 @@ class JLG_Frontend {
         if (!empty(self::$shortcode_errors) && current_user_can('manage_options')) {
             echo '<div class="notice notice-error"><p><strong>Plugin Notation - JLG : Erreur de chargement des shortcodes !</strong></p><ul>';
             foreach (self::$shortcode_errors as $error) {
-                echo '<li>' . $error . '</li>';
+                printf('<li>%s</li>', esc_html($error));
             }
             echo '</ul></div>';
         }


### PR DESCRIPTION
## Summary
- escape shortcode error messages in the admin notice list items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c945e5cadc832eaac7535566e6fb99