### PR TITLE
Escape dynamic image URLs in shortcode tagline template

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-tagline.php
@@ -9,8 +9,8 @@ $default_lang = $has_fr ? 'fr' : 'en';
 <div class="jlg-tagline-block">
     <?php if ($has_fr && $has_en): ?>
         <div class="jlg-tagline-flags">
-            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'; ?>" data-lang="fr" class="jlg-lang-flag <?php if($default_lang == 'fr') echo 'active'; ?>" alt="<?php echo esc_attr__('Français', 'notation-jlg'); ?>">
-            <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'; ?>" data-lang="en" class="jlg-lang-flag <?php if($default_lang == 'en') echo 'active'; ?>" alt="<?php echo esc_attr__('English', 'notation-jlg'); ?>">
+            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'); ?>" data-lang="fr" class="jlg-lang-flag <?php if($default_lang == 'fr') echo 'active'; ?>" alt="<?php echo esc_attr__('Français', 'notation-jlg'); ?>">
+            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'); ?>" data-lang="en" class="jlg-lang-flag <?php if($default_lang == 'en') echo 'active'; ?>" alt="<?php echo esc_attr__('English', 'notation-jlg'); ?>">
         </div>
     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- escape dynamically generated flag image URLs in the shortcode tagline template

## Testing
- php -l templates/shortcode-tagline.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b3207430832e9172f4aab730c181