### PR TITLE
Escape dynamic values in shortcode summary template

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -152,10 +152,10 @@ if (!function_exists('jlg_print_sortable_header')) {
                                 
                                 switch ($col) {
                                     case 'titre':
-                                        echo '<a href="' . get_permalink() . '">' . get_the_title() . '</a>';
+                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html(get_the_title()) . '</a>';
                                         break;
                                     case 'date':
-                                        echo get_the_date();
+                                        echo esc_html(get_the_date());
                                         break;
                                     case 'note':
                                         $score = get_post_meta($post_id, '_jlg_average_score', true);


### PR DESCRIPTION
## Summary
- escape the summary table link URL and label when rendering titles
- ensure rendered dates are HTML-escaped in the table
- review the template to confirm other dynamic outputs are already escaped or safely generated

## Testing
- php -l templates/shortcode-summary-display.php


------
https://chatgpt.com/codex/tasks/task_e_68c9b31ec7f4832e9bfb7beadbbf8826