### PR TITLE
Allow transparent table row colors

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
@@ -72,7 +72,22 @@ class JLG_Admin_Settings {
     private function sanitize_option_value($key, $value) {
         // Couleurs
         if (strpos($key, 'color') !== false && strpos($key, 'color_mode') === false) {
-            return sanitize_hex_color($value) ?: '#000000';
+            $allow_transparent_fields = [
+                'table_row_bg_color',
+                'table_zebra_bg_color',
+            ];
+
+            if (is_string($value) && in_array($key, $allow_transparent_fields, true)) {
+                $trimmed_value = strtolower(trim($value));
+
+                if ($trimmed_value === 'transparent') {
+                    return 'transparent';
+                }
+            }
+
+            $sanitized_color = sanitize_hex_color($value);
+
+            return !empty($sanitized_color) ? $sanitized_color : '#000000';
         }
         
         // Nombres

--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -99,7 +99,7 @@ class JLG_Helpers {
             'table_border_width'   => 1,
             'table_header_bg_color'   => '#3f3f46',
             'table_header_text_color' => '#ffffff',
-            'table_row_bg_color'      => 'transparent',
+            'table_row_bg_color'      => 'transparent', // Must remain literal "transparent" so CSS vars keep default transparency
             'table_row_text_color'    => '#a1a1aa',
             'table_zebra_bg_color'    => '#27272a',
             'thumb_text_color'      => '#ffffff',


### PR DESCRIPTION
## Summary
- preserve "transparent" for table row and zebra color fields during option sanitization
- document that the default table row background is intentionally stored as the literal "transparent"

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
- php -l plugin-notation-jeux_V4/includes/class-jlg-helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfa74cac832e89cef0f5f83cf731