### PR TITLE
Secure user rating nonce with per-visitor token

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/user-rating.js
+++ b/plugin-notation-jeux_V4/assets/js/user-rating.js
@@ -37,7 +37,8 @@ jQuery(document).ready(function($) {
                 action: 'jlg_rate_post',
                 post_id: postId,
                 rating: rating,
-                nonce: jlg_rating_ajax.nonce
+                nonce: jlg_rating_ajax.nonce,
+                token: jlg_rating_ajax.token
             },
             success: function(response) {
                 ratingBlock.removeClass('is-loading');


### PR DESCRIPTION
## Summary
- generate and persist a per-visitor rating token via cookie and localize it with a matching nonce for the user rating script
- validate the token in the AJAX handler before checking the nonce and return explicit security errors when validation fails
- send the visitor token with the AJAX request so the server can enforce the token-specific nonce

## Testing
- php -l includes/class-jlg-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d6952680832ea27e7915bcce7add