### PR TITLE
Documente le shortcode bloc complet dans les README

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -33,6 +33,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 
 ### Shortcodes disponibles
 
+- `[jlg_bloc_complet]` / `[bloc_notation_complet]` - Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 - `[bloc_notation_jeu]` - Bloc de notation principal
 - `[jlg_fiche_technique]` - Fiche technique du jeu
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -30,6 +30,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 
 = Shortcodes disponibles =
 
+* `[jlg_bloc_complet]` / `[bloc_notation_complet]` - Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 * `[bloc_notation_jeu]` - Bloc de notation principal
 * `[jlg_fiche_technique]` - Fiche technique du jeu
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue


### PR DESCRIPTION
## Summary
- documenter le shortcode `[jlg_bloc_complet]` et son alias dans la liste des shortcodes disponibles
- préciser les principaux attributs et la substitution des shortcodes individuels dans la documentation Markdown et WordPress

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9dd7774ac832eaa14bc3e11398a15