### PR TITLE
Replace str_ends_with usage for PHP 7.4 compatibility

### DIFF
--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
@@ -41,7 +41,7 @@ class JLG_Template_Loader {
         $directory = rtrim($directory, '/\\') . '/';
         $template_name = ltrim($template_name, '/');
 
-        if (!str_ends_with($template_name, '.php')) {
+        if (substr($template_name, -4) !== '.php') {
             $template_name .= '.php';
         }
 


### PR DESCRIPTION
## Summary
- replace usage of str_ends_with when building template paths
- use substr comparison to keep compatibility with PHP 7.4

## Testing
- php -l includes/utils/class-jlg-template-loader.php

------
https://chatgpt.com/codex/tasks/task_e_68cac02810d4832eb296b0fdbdb7075d