### PR TITLE
Ensure template suffix detection is PHP 7.4 compatible

### DIFF
--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
@@ -41,7 +41,7 @@ class JLG_Template_Loader {
         $directory = rtrim($directory, '/\\') . '/';
         $template_name = ltrim($template_name, '/');
 
-        if (substr($template_name, -4) !== '.php') {
+        if (substr_compare($template_name, '.php', -4) !== 0) {
             $template_name .= '.php';
         }
 


### PR DESCRIPTION
## Summary
- update the template loader to detect the ".php" suffix with `substr_compare`, avoiding PHP 8-only helpers

## Testing
- php -l plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php

------
https://chatgpt.com/codex/tasks/task_e_68cac46118e8832eadc9e68af61d7966