### PR TITLE
Document [jlg_bloc_complet] shortcode alias details

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -42,7 +42,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 ### Shortcodes disponibles
 
-- `[jlg_bloc_complet]` / `[bloc_notation_complet]` - Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+- `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 - `[bloc_notation_jeu]` - Bloc de notation principal
 - `[jlg_fiche_technique]` - Fiche technique du jeu
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -39,7 +39,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 = Shortcodes disponibles =
 
-* `[jlg_bloc_complet]` / `[bloc_notation_complet]` - Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+* `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 * `[bloc_notation_jeu]` - Bloc de notation principal
 * `[jlg_fiche_technique]` - Fiche technique du jeu
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue


### PR DESCRIPTION
## Summary
- clarify the documentation of the `[jlg_bloc_complet]` shortcode and its `[bloc_notation_complet]` alias in both README formats, noting available attributes and its all-in-one role

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac4b5df14832e8fd0cb9218cfea7b