### PR TITLE
Isoler les interactions de langue par bloc all-in-one

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -692,19 +692,26 @@ class JLG_Shortcode_All_In_One {
         <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Gestion du changement de langue
-            const flags = document.querySelectorAll('.jlg-aio-flag');
-            const taglines = document.querySelectorAll('.jlg-aio-tagline');
-            
-            flags.forEach(flag => {
+            const allFlags = document.querySelectorAll('.jlg-aio-flag');
+
+            allFlags.forEach(flag => {
+                const block = flag.closest('.jlg-all-in-one-block');
+                if (!block) {
+                    return;
+                }
+
+                const blockFlags = block.querySelectorAll('.jlg-aio-flag');
+                const blockTaglines = block.querySelectorAll('.jlg-aio-tagline');
+
                 flag.addEventListener('click', function() {
                     const selectedLang = this.dataset.lang;
-                    
-                    // Mettre à jour les drapeaux actifs
-                    flags.forEach(f => f.classList.remove('active'));
+
+                    // Mettre à jour les drapeaux actifs du bloc courant
+                    blockFlags.forEach(f => f.classList.remove('active'));
                     this.classList.add('active');
-                    
-                    // Afficher la bonne tagline
-                    taglines.forEach(t => {
+
+                    // Afficher la bonne tagline pour le bloc courant
+                    blockTaglines.forEach(t => {
                         if (t.dataset.lang === selectedLang) {
                             t.style.display = 'block';
                         } else {
@@ -727,10 +734,8 @@ class JLG_Shortcode_All_In_One {
                 threshold: 0.2
             });
 
-            const animatedBlock = document.querySelector('.jlg-all-in-one-block.animate-in');
-            if (animatedBlock) {
-                observer.observe(animatedBlock);
-            }
+            const animatedBlocks = document.querySelectorAll('.jlg-all-in-one-block.animate-in');
+            animatedBlocks.forEach(block => observer.observe(block));
             <?php endif; ?>
         });
         </script>


### PR DESCRIPTION
## Summary
- restreint la sélection des drapeaux et taglines au bloc all-in-one concerné afin d'éviter les interférences entre shortcodes
- observe désormais chaque bloc animé individuellement pour l'intersection observer

## Testing
- php -l plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0d6ae148832e9603fd6d582aea6d