### PR TITLE
Handle enable animations checkbox

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
@@ -58,7 +58,12 @@ class JLG_Admin_Settings {
                 $sanitized[$key] = $this->sanitize_option_value($key, $input[$key], $default_value);
             } else {
                 // Pour les checkboxes non cochées
-                if (strpos($key, 'enabled') !== false || strpos($key, 'pulse') !== false || strpos($key, 'striping') !== false) {
+                if (
+                    strpos($key, 'enabled') !== false ||
+                    strpos($key, 'pulse') !== false ||
+                    strpos($key, 'striping') !== false ||
+                    strpos($key, 'enable_') === 0
+                ) {
                     $sanitized[$key] = 0;
                 } else {
                     $sanitized[$key] = $default_value;
@@ -102,7 +107,12 @@ class JLG_Admin_Settings {
         }
         
         // Checkboxes
-        if (strpos($key, 'enabled') !== false || strpos($key, 'pulse') !== false || strpos($key, 'striping') !== false) {
+        if (
+            strpos($key, 'enabled') !== false ||
+            strpos($key, 'pulse') !== false ||
+            strpos($key, 'striping') !== false ||
+            strpos($key, 'enable_') === 0
+        ) {
             return !empty($value) ? 1 : 0;
         }
 


### PR DESCRIPTION
## Summary
- ensure unchecked checkboxes default to zero for enable_ prefixed options such as enable_animations
- treat enable_ prefixed options as boolean when sanitizing values so enable_animations returns 0 or 1

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cb164309c4832eb3df80040f745317