### PR TITLE
Supprimer l'instanciation directe du shortcode All-In-One

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -746,5 +746,4 @@ class JLG_Shortcode_All_In_One {
     }
 }
 
-// Initialiser le shortcode
-new JLG_Shortcode_All_In_One();
+// L'initialisation est désormais gérée par JLG_Frontend::load_shortcodes()


### PR DESCRIPTION
## Summary
- supprimer l'instanciation directe de `JLG_Shortcode_All_In_One`
- documenter que l'enregistrement du shortcode est réalisé via `JLG_Frontend::load_shortcodes()`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc49439cb0832e8a9995818268607a