### PR TITLE
Fix metabox registration callback signature

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -4,31 +4,30 @@ if (!defined('ABSPATH')) exit;
 class JLG_Admin_Metaboxes {
 
     public function __construct() {
-        add_action('add_meta_boxes', [$this, 'register_metaboxes']);
+        add_action('add_meta_boxes', [$this, 'register_metaboxes'], 10, 2);
         add_action('save_post', [$this, 'save_meta_data']);
     }
 
-    public function register_metaboxes() {
+    public function register_metaboxes($post_type, $post = null) {
         // Vérifier qu'on est bien sur un post
-        global $post;
-        if (!$post || $post->post_type !== 'post') {
+        if ($post_type !== 'post') {
             return;
         }
-        
+
         add_meta_box(
             'notation_jlg_metabox',
             '⭐ Notation du Jeu Vidéo',
             [$this, 'render_notation_metabox'],
-            'post',
+            $post_type,
             'side',
             'high'
         );
-        
+
         add_meta_box(
             'jlg_details_metabox',
             '🎮 Détails du Test',
             [$this, 'render_details_metabox'],
-            'post',
+            $post_type,
             'normal',
             'high'
         );


### PR DESCRIPTION
## Summary
- register the metabox callback with the expected argument count
- update the metabox registration method to rely on the passed post type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6333843c832ea67f019c7461f69a