### PR TITLE
Use safe plugin option access for debug toggle

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -337,7 +337,8 @@ class JLG_Admin_Platforms {
             
             <!-- ZONE DE DEBUG AMÉLIORÉE -->
             <?php 
-            $show_debug = isset($_GET['debug']) || !empty(get_option('notation_jlg_settings')['debug_mode_enabled']);
+            $plugin_options = JLG_Helpers::get_plugin_options();
+            $show_debug = isset($_GET['debug']) || !empty($plugin_options['debug_mode_enabled']);
             if ($show_debug) :
                 $debug_messages = get_transient('jlg_platforms_debug');
             ?>


### PR DESCRIPTION
## Summary
- use `JLG_Helpers::get_plugin_options()` when reading the debug option on the platforms admin page
- keep the debug flag as a boolean even if the plugin option is missing so the page renders safely

## Testing
- php -l includes/admin/class-jlg-admin-platforms.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d990d70832e94c55617af58bde1