### PR TITLE
Fix sortable header links to preserve hash anchor

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -54,7 +54,11 @@ if (!function_exists('jlg_print_sortable_header')) {
             $url = add_query_arg([
                 'orderby' => $sort_key,
                 'order' => $new_order
-            ], '#' . $table_id);
+            ]);
+
+            if (!empty($table_id)) {
+                $url .= '#' . $table_id;
+            }
             
             $indicator = '';
             if ($current_orderby === $sort_key || $current_orderby === $col) {


### PR DESCRIPTION
## Summary
- ensure sortable header links reuse the current URL and append the table anchor after the query string so orderby/order params remain visible

## Testing
- php -l templates/shortcode-summary-display.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d98ee5c832e912ee5135b6770d4