### PR TITLE
Fix review schema worst rating

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -613,7 +613,7 @@ class JLG_Frontend {
                     '@type'       => 'Rating',
                     'ratingValue' => $average_score,
                     'bestRating'  => '10',
-                    'worstRating' => '1',
+                    'worstRating' => '0',
                 ],
                 'author'        => [
                     '@type' => 'Person',


### PR DESCRIPTION
## Summary
- set the review rating worstRating to 0 in the injected JSON-LD to match the 0–10 editorial scale

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cd6b77d02c832ebc96cfe791dd41c5