### PR TITLE
Fix JSON-LD worstRating for review schema

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -603,6 +603,18 @@ class JLG_Frontend {
             return; 
         }
         
+        $review_rating_bounds = apply_filters(
+            'jlg_review_rating_bounds',
+            [
+                'min' => 0,
+                'max' => 10,
+            ],
+            $post_id
+        );
+
+        $review_best_rating  = isset($review_rating_bounds['max']) ? floatval($review_rating_bounds['max']) : 10;
+        $review_worst_rating = isset($review_rating_bounds['min']) ? floatval($review_rating_bounds['min']) : 0;
+
         $schema = [
             '@context'      => 'https://schema.org',
             '@type'         => 'Game',
@@ -612,8 +624,8 @@ class JLG_Frontend {
                 'reviewRating'  => [
                     '@type'       => 'Rating',
                     'ratingValue' => $average_score,
-                    'bestRating'  => '10',
-                    'worstRating' => '0',
+                    'bestRating'  => $review_best_rating,
+                    'worstRating' => $review_worst_rating,
                 ],
                 'author'        => [
                     '@type' => 'Person',


### PR DESCRIPTION
## Summary
- allow filtering of the review rating scale used in the JSON-LD schema
- ensure the review rating advertises a worstRating of 0 to match editor constraints

## Testing
- php -l includes/class-jlg-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7599b78c832e8ea39b4c0c5d4971