### PR TITLE
Load public functions helper for notation plugin

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -60,7 +60,8 @@ final class JLG_Plugin_De_Notation_Main {
     private function load_dependencies() {
         // Helpers (requis par tous)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-helpers.php';
-        
+        require_once JLG_NOTATION_PLUGIN_DIR . 'functions.php';
+
         // Frontend (toujours)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-frontend.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-widget.php';


### PR DESCRIPTION
## Summary
- load the public functions helper file during dependency bootstrap so templates can call helper functions

## Testing
- php test_jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8c540d74832e8d209b77a6ffb92e