### PR TITLE
Use helper options access for frontend features

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -590,7 +590,7 @@ class JLG_Frontend {
      * Injecte le schema de notation pour le SEO
      */
     public function inject_review_schema() {
-        $options = get_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
+        $options = JLG_Helpers::get_plugin_options();
         
         if (empty($options['seo_schema_enabled']) || !is_singular('post')) { 
             return; 
@@ -637,7 +637,11 @@ class JLG_Frontend {
         
         $user_rating_count = get_post_meta($post_id, '_jlg_user_rating_count', true);
         
-        if (!empty($options['user_rating_enabled']) && $user_rating_count > 0) {
+        $user_rating_enabled = isset($options['user_rating_enabled'])
+            ? $options['user_rating_enabled']
+            : (JLG_Helpers::get_default_settings()['user_rating_enabled'] ?? 0);
+
+        if (!empty($user_rating_enabled) && $user_rating_count > 0) {
             $schema['aggregateRating'] = [
                 '@type'       => 'AggregateRating',
                 'ratingValue' => get_post_meta($post_id, '_jlg_user_rating_avg', true),

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
@@ -12,7 +12,7 @@ class JLG_Shortcode_Tagline {
             return '';
         }
 
-        $options = get_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
+        $options = JLG_Helpers::get_plugin_options();
         if (empty($options['tagline_enabled'])) {
             return '';
         }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -12,7 +12,7 @@ class JLG_Shortcode_User_Rating {
             return '';
         }
 
-        $options = get_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
+        $options = JLG_Helpers::get_plugin_options();
         if (empty($options['user_rating_enabled'])) {
             return '';
         }


### PR DESCRIPTION
## Summary
- use `JLG_Helpers::get_plugin_options()` when loading shortcode settings for the tagline and user rating features
- rely on the helper to populate review schema options and preserve the fallback for the user rating aggregate block

## Testing
- php -l includes/shortcodes/class-jlg-shortcode-tagline.php
- php -l includes/shortcodes/class-jlg-shortcode-user-rating.php
- php -l includes/class-jlg-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cda8ccf7ec832e836b0e47e3c84328