### PR TITLE
Add AJAX sorting and filtering for summary table

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template pour l'affichage du tableau/grille récapitulatif
- * 
+ *
  * Variables disponibles :
  * - $query : WP_Query object
  * - $atts : Attributs du shortcode
@@ -12,92 +12,43 @@
 
 if (!defined('ABSPATH')) exit;
 
-// Parser les colonnes demandées
-$colonnes = array_map('trim', explode(',', $atts['colonnes']));
-
-// Définir les colonnes disponibles
-$colonnes_disponibles = [
-    'titre' => [
-        'label' => __('Titre du jeu', 'notation-jlg'),
-        'sortable' => true,
-        'key' => 'title'
-    ],
-    'date' => [
-        'label' => __('Date', 'notation-jlg'),
-        'sortable' => true,
-        'key' => 'date'
-    ],
-    'note' => [
-        'label' => __('Note', 'notation-jlg'),
-        'sortable' => true,
-        'key' => 'average_score'
-    ],
-    'developpeur' => [
-        'label' => __('Développeur', 'notation-jlg'),
-        'sortable' => false
-    ],
-    'editeur' => [
-        'label' => __('Éditeur', 'notation-jlg'),
-        'sortable' => false
-    ]
-];
-
-// ID unique pour le tableau
-$table_id = esc_attr($atts['id']);
-
-// Fonction helper locale pour créer les en-têtes triables
-if (!function_exists('jlg_print_sortable_header')) {
-    function jlg_print_sortable_header($col, $col_info, $current_orderby, $current_order, $table_id) {
-        if ($col_info['sortable']) {
-            $sort_key = isset($col_info['key']) ? $col_info['key'] : $col;
-            $new_order = ($current_orderby === $sort_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
-            $url = add_query_arg([
-                'orderby' => $sort_key,
-                'order' => $new_order
-            ]);
-
-            if (!empty($table_id)) {
-                $url .= '#' . $table_id;
-            }
-            
-            $indicator = '';
-            if ($current_orderby === $sort_key || $current_orderby === $col) {
-                $indicator = $current_order === 'ASC'
-                    ? esc_html__(' ▲', 'notation-jlg')
-                    : esc_html__(' ▼', 'notation-jlg');
-            }
-            
-            $class = 'sortable';
-            if ($current_orderby === $sort_key || $current_orderby === $col) {
-                $class .= ' sorted ' . strtolower($current_order);
-            }
-            
-            echo '<th class="' . esc_attr($class) . '">';
-            echo '<a href="' . esc_url($url) . '">' . esc_html($col_info['label']) . $indicator . '</a>';
-            echo '</th>';
-        } else {
-            echo '<th>' . esc_html($col_info['label']) . '</th>';
-        }
-    }
-}
+$table_id = isset($atts['id']) ? sanitize_html_class($atts['id']) : 'jlg-table-' . uniqid();
+$layout = isset($atts['layout']) ? $atts['layout'] : 'table';
+$columns = is_array($colonnes) ? $colonnes : [];
+$available_columns = is_array($colonnes_disponibles) ? $colonnes_disponibles : [];
+$current_orderby = !empty($orderby) ? $orderby : 'date';
+$current_order = !empty($order) ? $order : 'DESC';
+$current_cat_filter = isset($cat_filter) ? intval($cat_filter) : 0;
+$columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $columns)) : '';
 ?>
 
-<div id="<?php echo $table_id; ?>" class="jlg-summary-wrapper">
+<div
+    id="<?php echo esc_attr($table_id); ?>"
+    class="jlg-summary-wrapper"
+    data-posts-per-page="<?php echo esc_attr(intval($atts['posts_per_page'])); ?>"
+    data-layout="<?php echo esc_attr($layout); ?>"
+    data-categorie="<?php echo esc_attr($atts['categorie']); ?>"
+    data-colonnes="<?php echo esc_attr($columns_attr); ?>"
+    data-orderby="<?php echo esc_attr($current_orderby); ?>"
+    data-order="<?php echo esc_attr($current_order); ?>"
+    data-paged="<?php echo esc_attr(intval($paged)); ?>"
+    data-cat-filter="<?php echo esc_attr($current_cat_filter); ?>"
+>
     
     <?php if ($atts['layout'] === 'table') : ?>
         <!-- Filtres -->
         <div class="jlg-summary-filters">
             <form method="get" action="">
+                <input type="hidden" name="orderby" value="<?php echo esc_attr($current_orderby); ?>">
+                <input type="hidden" name="order" value="<?php echo esc_attr($current_order); ?>">
                 <?php
-                if (isset($_GET['orderby'])) echo '<input type="hidden" name="orderby" value="' . esc_attr($_GET['orderby']) . '">';
-                if (isset($_GET['order'])) echo '<input type="hidden" name="order" value="' . esc_attr($_GET['order']) . '">';
                 wp_dropdown_categories([
                     'show_option_all' => __('Toutes les catégories', 'notation-jlg'),
                     'orderby' => 'name',
                     'hide_empty' => 1,
                     'name' => 'cat_filter',
                     'id' => 'jlg_cat_filter',
-                    'selected' => isset($_GET['cat_filter']) ? intval($_GET['cat_filter']) : 0,
+                    'selected' => $current_cat_filter,
                     'hierarchical' => true
                 ]);
                 ?>
@@ -106,110 +57,20 @@ if (!function_exists('jlg_print_sortable_header')) {
         </div>
     <?php endif; ?>
 
-    <?php if ($atts['layout'] === 'grid') : ?>
-        <!-- Affichage en grille -->
-        <div class="jlg-summary-grid-wrapper">
-            <?php if ($query->have_posts()) : 
-                while ($query->have_posts()) : $query->the_post(); 
-                    $post_id = get_the_ID();
-                    $score = get_post_meta($post_id, '_jlg_average_score', true);
-                    $cover_url = get_post_meta($post_id, '_jlg_cover_image_url', true);
-                    if (empty($cover_url)) { 
-                        $cover_url = get_the_post_thumbnail_url($post_id, 'medium_large'); 
-                    } 
-            ?>
-                <a href="<?php the_permalink(); ?>" class="jlg-game-card">
-                    <div class="jlg-game-card-score"><?php echo esc_html($score); ?></div>
-                    <?php if ($cover_url) : ?>
-                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php the_title_attribute(); ?>" loading="lazy">
-                    <?php endif; ?>
-                    <div class="jlg-game-card-title">
-                        <span><?php the_title(); ?></span>
-                    </div>
-                </a>
-            <?php endwhile;
-            else : ?>
-                <p><?php esc_html_e('Aucun article trouvé pour cette sélection.', 'notation-jlg'); ?></p>
-            <?php endif; ?>
-        </div>
-    <?php else : ?>
-        <!-- Affichage en tableau -->
-        <div class="jlg-summary-table-wrapper">
-            <table class="jlg-summary-table">
-                <thead>
-                    <tr>
-                        <?php foreach ($colonnes as $col) : 
-                            if (!isset($colonnes_disponibles[$col])) continue;
-                            jlg_print_sortable_header($col, $colonnes_disponibles[$col], $orderby, $order, $table_id);
-                        endforeach; ?>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php if ($query->have_posts()) : 
-                        while ($query->have_posts()) : $query->the_post(); 
-                            $post_id = get_the_ID();
-                    ?>
-                        <tr>
-                            <?php foreach ($colonnes as $col) : 
-                                if (!isset($colonnes_disponibles[$col])) continue;
-                                echo '<td data-label="' . esc_attr($colonnes_disponibles[$col]['label']) . '">';
-                                
-                                switch ($col) {
-                                    case 'titre':
-                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html(get_the_title()) . '</a>';
-                                        break;
-                                    case 'date':
-                                        echo esc_html(get_the_date());
-                                        break;
-                                    case 'note':
-                                        $score = get_post_meta($post_id, '_jlg_average_score', true);
-                                        /* translators: Abbreviation meaning that the average score is not available. */
-                                        $score_display = $score ?: __('N/A', 'notation-jlg');
-                                        echo '<strong>' . esc_html($score_display) . '</strong> ';
-                                        printf(
-                                            /* translators: %s: Maximum possible rating value. */
-                                            esc_html__('/ %s', 'notation-jlg'),
-                                            10
-                                        );
-                                        break;
-                                    case 'developpeur':
-                                        $developer = get_post_meta($post_id, '_jlg_developpeur', true) ?: __('-', 'notation-jlg');
-                                        echo esc_html($developer);
-                                        break;
-                                    case 'editeur':
-                                        $publisher = get_post_meta($post_id, '_jlg_editeur', true) ?: __('-', 'notation-jlg');
-                                        echo esc_html($publisher);
-                                        break;
-                                }
-                                echo '</td>';
-                            endforeach; ?>
-                        </tr>
-                    <?php endwhile;
-                    else : ?>
-                        <tr>
-                            <td colspan="<?php echo count($colonnes); ?>"><?php esc_html_e('Aucun article trouvé pour cette sélection.', 'notation-jlg'); ?></td>
-                        </tr>
-                    <?php endif; ?>
-                </tbody>
-            </table>
-        </div>
-    <?php endif; ?>
-
-    <?php
-    // Pagination
-    $pagination_links = paginate_links([
-        'base' => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))) . '#' . $table_id, 
-        'format' => '?paged=%#%', 
-        'current' => max(1, $paged), 
-        'total' => $query->max_num_pages, 
-        'prev_text' => __('« Précédent', 'notation-jlg'),
-        'next_text' => __('Suivant »', 'notation-jlg')
-    ]);
-    
-    if ($pagination_links) {
-        echo '<nav class="jlg-pagination">' . $pagination_links . '</nav>';
-    }
-    
-    wp_reset_postdata();
-    ?>
+    <div class="jlg-summary-content">
+        <?php
+        echo JLG_Frontend::get_template_html('summary-table-fragment', [
+            'query'                => $query,
+            'atts'                 => $atts,
+            'paged'                => $paged,
+            'orderby'              => $orderby,
+            'order'                => $order,
+            'colonnes'             => $columns,
+            'colonnes_disponibles' => $available_columns,
+            'error_message'        => isset($error_message) ? $error_message : '',
+            'cat_filter'           => $current_cat_filter,
+            'table_id'             => $table_id,
+        ]);
+        ?>
+    </div>
 </div>

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Fragment HTML pour l'affichage du tableau ou de la grille récapitulative.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$columns = is_array($colonnes) ? $colonnes : [];
+$available_columns = is_array($colonnes_disponibles) ? $colonnes_disponibles : [];
+$table_id = !empty($table_id) ? sanitize_html_class($table_id) : '';
+if ($table_id === '' && isset($atts['id'])) {
+    $table_id = sanitize_html_class($atts['id']);
+}
+$layout = isset($atts['layout']) ? $atts['layout'] : 'table';
+$current_orderby = !empty($orderby) ? $orderby : 'date';
+$current_order = !empty($order) ? strtoupper($order) : 'DESC';
+$current_cat_filter = isset($cat_filter) ? intval($cat_filter) : 0;
+$default_empty_message = '<p>' . esc_html__('Aucun article trouvé pour cette sélection.', 'notation-jlg') . '</p>';
+$empty_message = !empty($error_message) ? $error_message : $default_empty_message;
+$columns_count = count($columns);
+
+if ($columns_count === 0) {
+    $columns_count = 1;
+}
+
+if (!function_exists('jlg_print_sortable_header')) {
+    function jlg_print_sortable_header($col, $col_info, $current_orderby, $current_order, $table_id) {
+        if (!isset($col_info['sortable']) || !$col_info['sortable']) {
+            echo '<th>' . esc_html($col_info['label']) . '</th>';
+            return;
+        }
+
+        $sort_key = isset($col_info['key']) ? $col_info['key'] : $col;
+        $new_order = ($current_orderby === $sort_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
+        $url = add_query_arg([
+            'orderby' => $sort_key,
+            'order'   => $new_order,
+        ]);
+
+        if (!empty($table_id)) {
+            $url .= '#' . $table_id;
+        }
+
+        $indicator = '';
+        if ($current_orderby === $sort_key || $current_orderby === $col) {
+            $indicator = $current_order === 'ASC'
+                ? esc_html__(' ▲', 'notation-jlg')
+                : esc_html__(' ▼', 'notation-jlg');
+        }
+
+        $class = 'sortable';
+        if ($current_orderby === $sort_key || $current_orderby === $col) {
+            $class .= ' sorted ' . strtolower($current_order);
+        }
+
+        echo '<th class="' . esc_attr($class) . '">';
+        echo '<a href="' . esc_url($url) . '">' . esc_html($col_info['label']) . $indicator . '</a>';
+        echo '</th>';
+    }
+}
+
+if ($layout === 'grid') :
+    ?>
+    <div class="jlg-summary-grid-wrapper">
+        <?php if ($query instanceof WP_Query && $query->have_posts()) :
+            while ($query->have_posts()) : $query->the_post();
+                $post_id = get_the_ID();
+                $score = get_post_meta($post_id, '_jlg_average_score', true);
+                $cover_url = get_post_meta($post_id, '_jlg_cover_image_url', true);
+                if (empty($cover_url)) {
+                    $cover_url = get_the_post_thumbnail_url($post_id, 'medium_large');
+                }
+                ?>
+                <a href="<?php the_permalink(); ?>" class="jlg-game-card">
+                    <div class="jlg-game-card-score"><?php echo esc_html($score); ?></div>
+                    <?php if ($cover_url) : ?>
+                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php the_title_attribute(); ?>" loading="lazy">
+                    <?php endif; ?>
+                    <div class="jlg-game-card-title">
+                        <span><?php the_title(); ?></span>
+                    </div>
+                </a>
+            <?php endwhile;
+        else :
+            echo wp_kses_post($empty_message);
+        endif; ?>
+    </div>
+<?php
+else :
+    ?>
+    <div class="jlg-summary-table-wrapper">
+        <table class="jlg-summary-table">
+            <thead>
+                <tr>
+                    <?php
+                    foreach ($columns as $col) {
+                        if (!isset($available_columns[$col])) {
+                            continue;
+                        }
+                        jlg_print_sortable_header($col, $available_columns[$col], $current_orderby, $current_order, $table_id);
+                    }
+                    ?>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if ($query instanceof WP_Query && $query->have_posts()) :
+                    while ($query->have_posts()) : $query->the_post();
+                        $post_id = get_the_ID();
+                        ?>
+                        <tr>
+                            <?php
+                            foreach ($columns as $col) {
+                                if (!isset($available_columns[$col])) {
+                                    continue;
+                                }
+                                echo '<td data-label="' . esc_attr($available_columns[$col]['label']) . '">';
+
+                                switch ($col) {
+                                    case 'titre':
+                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html(get_the_title()) . '</a>';
+                                        break;
+                                    case 'date':
+                                        echo esc_html(get_the_date());
+                                        break;
+                                    case 'note':
+                                        $score = get_post_meta($post_id, '_jlg_average_score', true);
+                                        /* translators: Abbreviation meaning that the average score is not available. */
+                                        $score_display = $score ?: __('N/A', 'notation-jlg');
+                                        echo '<strong>' . esc_html($score_display) . '</strong> ';
+                                        printf(
+                                            /* translators: %s: Maximum possible rating value. */
+                                            esc_html__('/ %s', 'notation-jlg'),
+                                            10
+                                        );
+                                        break;
+                                    case 'developpeur':
+                                        $developer = get_post_meta($post_id, '_jlg_developpeur', true) ?: __('-', 'notation-jlg');
+                                        echo esc_html($developer);
+                                        break;
+                                    case 'editeur':
+                                        $publisher = get_post_meta($post_id, '_jlg_editeur', true) ?: __('-', 'notation-jlg');
+                                        echo esc_html($publisher);
+                                        break;
+                                }
+                                echo '</td>';
+                            }
+                            ?>
+                        </tr>
+                    <?php endwhile;
+                else :
+                    ?>
+                    <tr>
+                        <td colspan="<?php echo esc_attr($columns_count); ?>"><?php echo wp_kses_post($empty_message); ?></td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+<?php
+endif;
+
+if ($query instanceof WP_Query) {
+    $total_pages = intval($query->max_num_pages);
+} else {
+    $total_pages = 0;
+}
+
+if ($query instanceof WP_Query) {
+    wp_reset_postdata();
+}
+
+if ($total_pages > 1) {
+    $pagination_args = [
+        'base'      => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
+        'format'    => '?paged=%#%',
+        'current'   => max(1, intval($paged)),
+        'total'     => $total_pages,
+        'prev_text' => __('« Précédent', 'notation-jlg'),
+        'next_text' => __('Suivant »', 'notation-jlg'),
+        'add_args'  => [
+            'orderby' => $current_orderby,
+            'order'   => $current_order,
+        ],
+    ];
+
+    if ($current_cat_filter > 0) {
+        $pagination_args['add_args']['cat_filter'] = $current_cat_filter;
+    }
+
+    $pagination_links = paginate_links($pagination_args);
+
+    if (!empty($pagination_links) && !empty($table_id)) {
+        $pagination_links = preg_replace(
+            '/href="([^"]+)"/i',
+            'href="$1#' . $table_id . '"',
+            $pagination_links
+        );
+    }
+
+    if (!empty($pagination_links)) {
+        echo '<nav class="jlg-pagination">' . $pagination_links . '</nav>';
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the summary shortcode to expose a reusable render context used by both the shortcode output and the new AJAX endpoint
- register an AJAX handler, enqueue the summary script with nonce/localized strings, and update the frontend template to expose state for asynchronous updates while keeping the GET fallback intact
- extract the summary grid/table markup into a dedicated fragment template and overhaul the JavaScript to request, render, and synchronize the table and pagination without a page reload

## Testing
- php -l includes/shortcodes/class-jlg-shortcode-summary-display.php
- php -l includes/class-jlg-frontend.php
- php -l templates/summary-table-fragment.php
- php -l templates/shortcode-summary-display.php
- composer cs *(fails: phpcs missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb07b34f8832e9ae7c43e5dccb038