### PR TITLE
Enable drag and drop ordering for platforms

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
@@ -1,0 +1,54 @@
+(function ($) {
+    'use strict';
+
+    function getSettings() {
+        if (window.jlgPlatformsOrder && typeof window.jlgPlatformsOrder === 'object') {
+            return window.jlgPlatformsOrder;
+        }
+
+        return {
+            listSelector: '#platforms-list',
+            positionSelector: '.jlg-platform-position',
+            handleSelector: '.jlg-sort-handle'
+        };
+    }
+
+    function refreshPositions($list, selector) {
+        $list.find('tr').each(function (index) {
+            $(this).find(selector).text(index + 1);
+        });
+    }
+
+    $(function () {
+        var settings = getSettings();
+        var $list = $(settings.listSelector);
+
+        if (!$list.length || typeof $list.sortable !== 'function') {
+            return;
+        }
+
+        var positionSelector = settings.positionSelector || '.jlg-platform-position';
+        var handleSelector = settings.handleSelector || undefined;
+
+        $list.sortable({
+            axis: 'y',
+            handle: handleSelector,
+            placeholder: 'jlg-sortable-placeholder',
+            helper: function (event, ui) {
+                ui.children().each(function () {
+                    $(this).width($(this).width());
+                });
+                return ui;
+            },
+            update: function () {
+                refreshPositions($list, positionSelector);
+            }
+        });
+
+        if (typeof $list.disableSelection === 'function') {
+            $list.disableSelection();
+        }
+
+        refreshPositions($list, positionSelector);
+    });
+})(jQuery);

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -1,0 +1,46 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class JLG_Assets {
+    private static $instance = null;
+
+    public static function get_instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
+    }
+
+    public function enqueue_admin_assets($hook_suffix) {
+        if ($hook_suffix !== 'toplevel_page_notation_jlg_settings') {
+            return;
+        }
+
+        $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'reglages';
+        if ($active_tab !== 'plateformes') {
+            return;
+        }
+
+        wp_enqueue_script('jquery-ui-sortable');
+
+        $handle = 'jlg-platforms-order';
+        $src = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-platforms-order.js';
+        $deps = ['jquery', 'jquery-ui-sortable'];
+        $version = defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : false;
+
+        wp_register_script($handle, $src, $deps, $version, true);
+
+        wp_localize_script($handle, 'jlgPlatformsOrder', [
+            'listSelector' => '#platforms-list',
+            'positionSelector' => '.jlg-platform-position',
+            'handleSelector' => '.jlg-sort-handle',
+        ]);
+
+        wp_enqueue_script($handle);
+    }
+}

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -42,6 +42,7 @@ if (version_compare(get_bloginfo('version'), '5.0', '<')) {
 final class JLG_Plugin_De_Notation_Main {
     private static $instance = null;
     private $admin = null;
+    private $assets = null;
     private $frontend = null;
 
     public static function get_instance() {
@@ -60,6 +61,7 @@ final class JLG_Plugin_De_Notation_Main {
     private function load_dependencies() {
         // Helpers (requis par tous)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-helpers.php';
+        require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-assets.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'functions.php';
 
         // Frontend (toujours)
@@ -94,6 +96,11 @@ final class JLG_Plugin_De_Notation_Main {
     }
 
     private function init_components() {
+        // Assets communs
+        if (class_exists('JLG_Assets')) {
+            $this->assets = JLG_Assets::get_instance();
+        }
+
         // Frontend
         if (class_exists('JLG_Frontend')) {
             $this->frontend = new JLG_Frontend();


### PR DESCRIPTION
## Summary
- introduce a reusable JLG_Assets singleton to load admin scripts and enqueue jquery-ui-sortable on the platforms tab
- add drag handles and hidden order inputs to the platforms table so rows can be reordered visually
- persist the submitted indexed order server-side and refresh position labels automatically through a lightweight script

## Testing
- php -l plugin-notation-jeux.php
- php -l includes/class-jlg-assets.php
- php -l includes/admin/class-jlg-admin-platforms.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb0757078832e8d947d9e098793e9