### PR TITLE
Validate release dates and PEGI metadata

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -40,6 +40,12 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - réordonner et supprimer les plateformes existantes selon vos besoins ;
 - réinitialiser la liste pour revenir à la configuration par défaut grâce à l'option **Reset**.
 
+### Validation des métadonnées
+
+- La **date de sortie** est vérifiée avec `DateTime::createFromFormat('Y-m-d')`. Une valeur invalide est rejetée, la méta correspondante est supprimée et une alerte d'administration liste les erreurs détectées.
+- Le champ **PEGI** n'accepte que les mentions officielles `PEGI 3`, `PEGI 7`, `PEGI 12`, `PEGI 16` et `PEGI 18`. Toute autre valeur est ignorée et signalée via la même notice.
+- Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
+
 ### Shortcodes disponibles
 
 - `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -37,6 +37,12 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * Réordonner et supprimer les plateformes existantes selon vos besoins ;
 * Réinitialiser la liste pour revenir à la configuration par défaut grâce à l'option **Reset**.
 
+= Validation des métadonnées =
+
+* La **date de sortie** est vérifiée avec `DateTime::createFromFormat('Y-m-d')`. Une valeur invalide est rejetée, la méta concernée est supprimée et une notice d'administration affiche les erreurs repérées.
+* Le champ **PEGI** n'accepte que les mentions officielles `PEGI 3`, `PEGI 7`, `PEGI 12`, `PEGI 16` et `PEGI 18`. Toute autre valeur est ignorée et signalée via la même notice.
+* Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
+
 = Shortcodes disponibles =
 
 * `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.

--- a/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
@@ -149,6 +149,9 @@ jQuery(document).ready(function($) {
             $('#jlg_editeur').val(gameData.publishers);
             $('#jlg_date_sortie').val(gameData.release_date);
             $('#jlg_cover_image_url').val(gameData.cover_image);
+            if (gameData.pegi) {
+                $('#jlg_pegi').val(gameData.pegi);
+            }
 
             // Gère les cases à cocher des plateformes
             $('input[name="jlg_plateformes[]"]').prop('checked', false);

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -55,12 +55,27 @@ class JLG_Admin_Ajax {
                 'release_date' => '2024-01-15',
                 'developers' => 'Studio Exemple',
                 'publishers' => 'Éditeur Exemple',
-                'platforms' => ['PC', 'PlayStation 5']
+                'platforms' => ['PC', 'PlayStation 5'],
+                'pegi' => 'PEGI 12',
             ]
         ];
 
+        $normalized_games = array_map(function($game) {
+            if (!empty($game['release_date'])) {
+                $sanitized_date = JLG_Validator::sanitize_date($game['release_date']);
+                $game['release_date'] = $sanitized_date !== null ? $sanitized_date : '';
+            }
+
+            if (!empty($game['pegi'])) {
+                $sanitized_pegi = JLG_Validator::sanitize_pegi($game['pegi']);
+                $game['pegi'] = $sanitized_pegi !== null ? $sanitized_pegi : '';
+            }
+
+            return $game;
+        }, $mock_games);
+
         wp_send_json_success([
-            'games' => $mock_games,
+            'games' => $normalized_games,
             'message' => 'Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.'
         ]);
     }


### PR DESCRIPTION
## Summary
- add reusable validators for release dates and PEGI ratings, including helpers to normalize accepted values
- run metabox saves through the new checks, drop invalid metadata, and surface admin notices for rejected values
- normalize RAWG API mock responses, auto-fill PEGI from the picker, and document the enforced metadata rules

## Testing
- php -l plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb0545c80832ea7f8552d7cae8387