### PR TITLE
Centralize asset management

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -2,8 +2,16 @@
 if (!defined('ABSPATH')) exit;
 
 class JLG_Admin_Ajax {
-    
-    public function __construct() {
+
+    /**
+     * Gestionnaire centralisé des assets.
+     *
+     * @var JLG_Assets
+     */
+    private $assets;
+
+    public function __construct(JLG_Assets $assets) {
+        $this->assets = $assets;
         add_action('wp_ajax_jlg_search_rawg_games', [$this, 'handle_rawg_search']);
         add_action('wp_ajax_nopriv_jlg_search_rawg_games', [$this, 'handle_rawg_search']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_ajax_assets']);
@@ -20,18 +28,10 @@ class JLG_Admin_Ajax {
             return;
         }
 
-        $script_handle = 'jlg-admin-api';
-        $script_url = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js';
-        $version = defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : false;
-
-        wp_register_script($script_handle, $script_url, ['jquery'], $version, true);
-
-        wp_localize_script($script_handle, 'jlg_admin_ajax', [
+        $this->assets->enqueue_admin_ajax([
             'nonce' => wp_create_nonce('jlg_admin_ajax_nonce'),
             'ajax_url' => admin_url('admin-ajax.php'),
         ]);
-
-        wp_enqueue_script($script_handle);
     }
 
     public function handle_rawg_search() {

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
@@ -7,15 +7,21 @@ class JLG_Admin_Core {
     private $metaboxes;
     private $settings;
     private $platforms;
+    private $assets;
 
-    public static function get_instance() {
+    public static function get_instance($assets = null) {
         if (self::$instance === null) {
-            self::$instance = new self();
+            self::$instance = new self($assets);
+        } elseif ($assets instanceof JLG_Assets) {
+            self::$instance->assets = $assets;
         }
         return self::$instance;
     }
 
-    private function __construct() {
+    private function __construct($assets = null) {
+        if ($assets instanceof JLG_Assets) {
+            $this->assets = $assets;
+        }
         $this->load_admin_dependencies();
         $this->init_admin_components();
     }
@@ -50,8 +56,8 @@ class JLG_Admin_Core {
             $this->settings = new JLG_Admin_Settings();
         }
 
-        if (class_exists('JLG_Admin_Ajax')) {
-            new JLG_Admin_Ajax();
+        if (class_exists('JLG_Admin_Ajax') && $this->assets instanceof JLG_Assets) {
+            new JLG_Admin_Ajax($this->assets);
         }
         
         // Initialiser la classe Platforms en mode singleton

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -1,0 +1,164 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class JLG_Assets {
+    /**
+     * Plugin version used for asset versioning.
+     *
+     * @var string|bool
+     */
+    private $version;
+
+    public function __construct($version = null) {
+        if ($version !== null) {
+            $this->version = $version;
+        } elseif (defined('JLG_NOTATION_VERSION')) {
+            $this->version = JLG_NOTATION_VERSION;
+        } else {
+            $this->version = false;
+        }
+    }
+
+    /**
+     * Enregistre les assets front-end du plugin.
+     */
+    public function enqueue_frontend() {
+        $this->register_frontend_assets();
+    }
+
+    /**
+     * Enregistre les assets admin du plugin.
+     */
+    public function enqueue_admin() {
+        $this->register_admin_assets();
+    }
+
+    /**
+     * S'assure que la feuille de style principale est en file.
+     */
+    public function enqueue_frontend_style() {
+        if (!wp_style_is('jlg-frontend', 'registered')) {
+            $this->register_frontend_assets();
+        }
+
+        wp_enqueue_style('jlg-frontend');
+    }
+
+    /**
+     * Ajoute le script de notation utilisateur et le localise.
+     *
+     * @param array $localized_data
+     */
+    public function enqueue_user_rating(array $localized_data = []) {
+        if (!wp_script_is('jlg-user-rating', 'registered')) {
+            $this->register_frontend_assets();
+        }
+
+        wp_enqueue_script('jlg-user-rating');
+
+        if (!empty($localized_data)) {
+            wp_localize_script('jlg-user-rating', 'jlg_rating_ajax', $localized_data);
+        }
+    }
+
+    /**
+     * Ajoute le script de changement de langue des taglines.
+     */
+    public function enqueue_tagline_switcher() {
+        if (!wp_script_is('jlg-tagline-switcher', 'registered')) {
+            $this->register_frontend_assets();
+        }
+
+        wp_enqueue_script('jlg-tagline-switcher');
+    }
+
+    /**
+     * Ajoute le script des animations front-end.
+     */
+    public function enqueue_animations() {
+        if (!wp_script_is('jlg-animations', 'registered')) {
+            $this->register_frontend_assets();
+        }
+
+        wp_enqueue_script('jlg-animations');
+    }
+
+    /**
+     * Ajoute le script AJAX côté admin et le localise.
+     *
+     * @param array $localized_data
+     */
+    public function enqueue_admin_ajax(array $localized_data = []) {
+        if (!wp_script_is('jlg-admin-api', 'registered')) {
+            $this->register_admin_assets();
+        }
+
+        wp_enqueue_script('jlg-admin-api');
+
+        if (!empty($localized_data)) {
+            wp_localize_script('jlg-admin-api', 'jlg_admin_ajax', $localized_data);
+        }
+    }
+
+    /**
+     * Enregistre les assets front-end.
+     */
+    private function register_frontend_assets() {
+        $version = $this->get_version();
+
+        wp_register_style(
+            'jlg-frontend',
+            JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-frontend.css',
+            [],
+            $version
+        );
+
+        wp_register_script(
+            'jlg-user-rating',
+            JLG_NOTATION_PLUGIN_URL . 'assets/js/user-rating.js',
+            ['jquery'],
+            $version,
+            true
+        );
+
+        wp_register_script(
+            'jlg-tagline-switcher',
+            JLG_NOTATION_PLUGIN_URL . 'assets/js/tagline-switcher.js',
+            ['jquery'],
+            $version,
+            true
+        );
+
+        wp_register_script(
+            'jlg-animations',
+            JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-animations.js',
+            [],
+            $version,
+            true
+        );
+    }
+
+    /**
+     * Enregistre les assets admin.
+     */
+    private function register_admin_assets() {
+        $version = $this->get_version();
+
+        wp_register_script(
+            'jlg-admin-api',
+            JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js',
+            ['jquery'],
+            $version,
+            true
+        );
+    }
+
+    /**
+     * Retourne la version utilisée pour les assets.
+     *
+     * @return string|bool
+     */
+    private function get_version() {
+        return $this->version;
+    }
+}

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -8,11 +8,13 @@ class JLG_Frontend {
      * @var array
      */
     private static $shortcode_errors = [];
+    private $assets;
 
-    public function __construct() {
+    public function __construct(JLG_Assets $assets) {
+        $this->assets = $assets;
         // On charge les shortcodes via le hook 'init' pour s'assurer que WordPress est prêt
         add_action('init', [$this, 'initialize_shortcodes']);
-        
+
         add_action('wp_enqueue_scripts', [$this, 'enqueue_jlg_scripts']);
         add_action('wp_ajax_jlg_rate_post', [$this, 'handle_user_rating']);
         add_action('wp_ajax_nopriv_jlg_rate_post', [$this, 'handle_user_rating']);
@@ -197,12 +199,7 @@ class JLG_Frontend {
         $average_score = JLG_Helpers::get_average_score_for_post($post_id);
 
         // Feuille de styles principale
-        wp_enqueue_style(
-            'jlg-frontend',
-            JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-frontend.css',
-            [],
-            JLG_NOTATION_VERSION
-        );
+        $this->assets->enqueue_frontend_style();
 
         $palette_colors = $this->sanitize_color_options([
             'bg_color',
@@ -448,13 +445,6 @@ class JLG_Frontend {
 
         // Script pour la notation utilisateur
         if (!empty($options['user_rating_enabled'])) {
-            wp_enqueue_script(
-                'jlg-user-rating',
-                JLG_NOTATION_PLUGIN_URL . 'assets/js/user-rating.js',
-                ['jquery'],
-                JLG_NOTATION_VERSION,
-                true
-            );
             $cookie_name = 'jlg_user_rating_token';
             $token = '';
 
@@ -492,7 +482,7 @@ class JLG_Frontend {
 
             $nonce = wp_create_nonce('jlg_user_rating_nonce_' . $token);
 
-            wp_localize_script('jlg-user-rating', 'jlg_rating_ajax', [
+            $this->assets->enqueue_user_rating([
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce'    => $nonce,
                 'token'    => $token,
@@ -501,24 +491,12 @@ class JLG_Frontend {
 
         // Script pour le changement de langue des taglines
         if (!empty($options['tagline_enabled'])) {
-            wp_enqueue_script(
-                'jlg-tagline-switcher', 
-                JLG_NOTATION_PLUGIN_URL . 'assets/js/tagline-switcher.js', 
-                ['jquery'], 
-                JLG_NOTATION_VERSION, 
-                true
-            );
+            $this->assets->enqueue_tagline_switcher();
         }
 
         // Script pour les animations
         if (!empty($options['enable_animations'])) {
-            wp_enqueue_script(
-                'jlg-animations', 
-                JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-animations.js', 
-                [], 
-                JLG_NOTATION_VERSION, 
-                true
-            );
+            $this->assets->enqueue_animations();
         }
     }
 

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -43,6 +43,7 @@ final class JLG_Plugin_De_Notation_Main {
     private static $instance = null;
     private $admin = null;
     private $frontend = null;
+    private $assets = null;
 
     public static function get_instance() {
         if (self::$instance === null) {
@@ -61,6 +62,9 @@ final class JLG_Plugin_De_Notation_Main {
         // Helpers (requis par tous)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-helpers.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'functions.php';
+
+        // Gestion centralisée des assets
+        require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-assets.php';
 
         // Frontend (toujours)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-frontend.php';
@@ -94,9 +98,16 @@ final class JLG_Plugin_De_Notation_Main {
     }
 
     private function init_components() {
+        // Assets
+        if (class_exists('JLG_Assets')) {
+            $this->assets = new JLG_Assets(JLG_NOTATION_VERSION);
+            add_action('wp_enqueue_scripts', [$this->assets, 'enqueue_frontend'], 5);
+            add_action('admin_enqueue_scripts', [$this->assets, 'enqueue_admin'], 5);
+        }
+
         // Frontend
         if (class_exists('JLG_Frontend')) {
-            $this->frontend = new JLG_Frontend();
+            $this->frontend = new JLG_Frontend($this->assets);
         }
 
         // Widget
@@ -108,7 +119,7 @@ final class JLG_Plugin_De_Notation_Main {
 
         // Admin
         if (is_admin() && class_exists('JLG_Admin_Core')) {
-            $this->admin = JLG_Admin_Core::get_instance();
+            $this->admin = JLG_Admin_Core::get_instance($this->assets);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a JLG_Assets class to centralize registration and localization of front-end and admin assets
- inject the asset manager into JLG_Frontend and JLG_Admin_Ajax so script/style enqueues go through dedicated helpers
- bootstrap the asset manager in the main plugin class and pass it down through the admin core

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-assets.php
- php -l plugin-notation-jeux_V4/includes/class-jlg-frontend.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
- php -l plugin-notation-jeux_V4/plugin-notation-jeux.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb22297c4832e8303f5dce8324259