### PR TITLE
Use dynamic platform list for metabox sanitization

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -264,7 +264,7 @@ class JLG_Admin_Metaboxes {
             if (isset($_POST['jlg_plateformes']) && is_array($_POST['jlg_plateformes'])) {
                 $raw_platforms = wp_unslash($_POST['jlg_plateformes']);
                 $raw_platforms = is_array($raw_platforms) ? $raw_platforms : [];
-                $platforms = array_map('sanitize_text_field', $raw_platforms);
+                $platforms = JLG_Validator::sanitize_platforms($raw_platforms);
                 update_post_meta($post_id, '_jlg_plateformes', $platforms);
             } else {
                 delete_post_meta($post_id, '_jlg_plateformes');

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
@@ -55,13 +55,27 @@ class JLG_Validator {
         if (!is_array($platforms)) {
             return [];
         }
-        
-        $allowed_platforms = [
-            'PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch 2', 
-            'Nintendo Switch', 'PlayStation 4', 'Xbox One'
-        ];
-        
+
+        $allowed_platforms = [];
+
+        if (class_exists('JLG_Admin_Platforms')) {
+            $platform_manager = JLG_Admin_Platforms::get_instance();
+            if ($platform_manager && method_exists($platform_manager, 'get_platform_names')) {
+                $platform_names = $platform_manager->get_platform_names();
+                if (is_array($platform_names)) {
+                    $allowed_platforms = array_map('sanitize_text_field', array_values($platform_names));
+                }
+            }
+        }
+
+        if (empty($allowed_platforms)) {
+            $allowed_platforms = [
+                'PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch 2',
+                'Nintendo Switch', 'PlayStation 4', 'Xbox One'
+            ];
+        }
+
         $sanitized = array_map('sanitize_text_field', $platforms);
-        return array_intersect($sanitized, $allowed_platforms);
+        return array_values(array_intersect($sanitized, $allowed_platforms));
     }
 }


### PR DESCRIPTION
## Summary
- build the list of allowed platforms in `JLG_Validator::sanitize_platforms()` using the registered platform manager when available
- reuse the validator when saving metabox data so only approved platforms are persisted

## Testing
- php -l plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb21ce0d0832e84978d26b9016d2a