### PR TITLE
Enable drag-and-drop ordering for platforms

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
@@ -9,13 +9,67 @@
         return {
             listSelector: '#platforms-list',
             positionSelector: '.jlg-platform-position',
-            handleSelector: '.jlg-sort-handle'
+            handleSelector: '.jlg-sort-handle',
+            rowSelector: 'tr[data-key]',
+            inputSelector: 'input[name="platform_order[]"]',
+            placeholderClass: 'jlg-sortable-placeholder'
         };
     }
 
-    function refreshPositions($list, selector) {
-        $list.find('tr').each(function (index) {
-            $(this).find(selector).text(index + 1);
+    function ensurePlaceholderStyle(className) {
+        if (!className) {
+            return;
+        }
+
+        var styleId = 'jlg-platforms-sortable-style';
+
+        if (document.getElementById(styleId)) {
+            return;
+        }
+
+        var style = document.createElement('style');
+        style.id = styleId;
+        style.type = 'text/css';
+        style.appendChild(document.createTextNode(
+            '.' + className + ' td {\n' +
+            '    border: 2px dashed #2271b1;\n' +
+            '    background: #f0f6fc;\n' +
+            '}\n' +
+            '.jlg-sorting {\n' +
+            '    opacity: 0.8;\n' +
+            '}\n'
+        ));
+
+        document.head.appendChild(style);
+    }
+
+    function syncOrder($list, settings) {
+        var rowSelector = settings.rowSelector || 'tr';
+        var positionSelector = settings.positionSelector || '.jlg-platform-position';
+        var inputSelector = settings.inputSelector || 'input[name="platform_order[]"]';
+
+        $list.find(rowSelector).each(function (index) {
+            var $row = $(this);
+            var key = $row.data('key') || '';
+
+            if (positionSelector) {
+                $row.find(positionSelector).text(index + 1);
+            }
+
+            if (!key) {
+                return;
+            }
+
+            var $input = $row.find(inputSelector);
+
+            if (!$input.length) {
+                $input = $('<input>', {
+                    type: 'hidden',
+                    name: 'platform_order[]'
+                }).appendTo($row);
+            }
+
+            $input.val(key);
         });
     }
 
@@ -27,21 +81,38 @@
             return;
         }
 
-        var positionSelector = settings.positionSelector || '.jlg-platform-position';
-        var handleSelector = settings.handleSelector || undefined;
+        ensurePlaceholderStyle(settings.placeholderClass);
+
+        var handleSelector = settings.handleSelector || false;
+        var rowSelector = settings.rowSelector || '> tr';
+        var placeholderClass = settings.placeholderClass || 'jlg-sortable-placeholder';
 
         $list.sortable({
             axis: 'y',
             handle: handleSelector,
-            placeholder: 'jlg-sortable-placeholder',
+            items: rowSelector,
+            placeholder: placeholderClass,
+            tolerance: 'pointer',
             helper: function (event, ui) {
                 ui.children().each(function () {
-                    $(this).width($(this).width());
+                    var $cell = $(this);
+                    $cell.width($cell.width());
                 });
                 return ui;
             },
+            start: function (event, ui) {
+                ui.placeholder.height(ui.item.outerHeight());
+                ui.item.addClass('jlg-sorting');
+            },
+            sort: function () {
+                syncOrder($list, settings);
+            },
             update: function () {
-                refreshPositions($list, positionSelector);
+                syncOrder($list, settings);
+            },
+            stop: function (event, ui) {
+                ui.item.removeClass('jlg-sorting');
+                syncOrder($list, settings);
             }
         });
 
@@ -49,6 +120,6 @@
             $list.disableSelection();
         }
 
-        refreshPositions($list, positionSelector);
+        syncOrder($list, settings);
     });
 })(jQuery);

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -39,6 +39,9 @@ class JLG_Assets {
             'listSelector' => '#platforms-list',
             'positionSelector' => '.jlg-platform-position',
             'handleSelector' => '.jlg-sort-handle',
+            'rowSelector' => 'tr[data-key]',
+            'inputSelector' => 'input[name="platform_order[]"]',
+            'placeholderClass' => 'jlg-sortable-placeholder',
         ]);
 
         wp_enqueue_script($handle);


### PR DESCRIPTION
## Summary
- enqueue the sortable dependency and pass configuration for the platforms ordering script from `JLG_Assets`
- refresh the admin platforms table markup with drag handles and helper text
- extend the drag and drop script to synchronise positions and hidden inputs during sorting
- persist the submitted indexed order in `update_platform_order()` without relying on numeric inputs

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
- php -l plugin-notation-jeux_V4/includes/class-jlg-assets.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb946c3ec832ea625714532313718