### PR TITLE
Refactor all-in-one shortcode styling and template

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -1,0 +1,392 @@
+.jlg-all-in-one-block {
+    --jlg-aio-bg-color: #18181b;
+    --jlg-aio-bg-color-secondary: #27272a;
+    --jlg-aio-bg-gradient-start: var(--jlg-aio-bg-color);
+    --jlg-aio-bg-gradient-end: var(--jlg-aio-bg-color-secondary);
+    --jlg-aio-header-gradient-start: rgba(59, 130, 246, 0.1);
+    --jlg-aio-header-gradient-end: rgba(37, 99, 235, 0.06);
+    --jlg-aio-tagline-font-size: 16px;
+    --jlg-aio-text-color: #fafafa;
+    --jlg-aio-text-color-secondary: #a1a1aa;
+    --jlg-aio-accent-color: #3b82f6;
+    --jlg-aio-score-gradient-2: #2563eb;
+    --jlg-aio-rating-bg-color: #18181b;
+    --jlg-aio-score-label-color: #fafafa;
+    --jlg-aio-score-number-color: #a1a1aa;
+    --jlg-aio-score-bar-bg-color: #27272a;
+    --jlg-aio-points-border-color: #3f3f46;
+    --jlg-aio-points-bg-color: #18181b;
+    --jlg-aio-points-title-color: #fafafa;
+    --jlg-aio-points-text-color: #a1a1aa;
+    --jlg-aio-color-high: #22c55e;
+    --jlg-aio-color-high-soft: rgba(34, 197, 94, 0.12);
+    --jlg-aio-color-low: #ef4444;
+    --jlg-aio-color-low-soft: rgba(239, 68, 68, 0.12);
+    --jlg-aio-points-bullet-pros: var(--jlg-aio-color-high);
+    --jlg-aio-points-bullet-cons: var(--jlg-aio-color-low);
+    --jlg-aio-circle-shadow-color: rgba(59, 130, 246, 0.25);
+    --jlg-aio-circle-base-shadow: 0 10px 25px -5px var(--jlg-aio-circle-shadow-color);
+    --jlg-aio-circle-background: linear-gradient(135deg, var(--jlg-aio-accent-color), var(--jlg-aio-score-gradient-2));
+    --jlg-aio-circle-border: none;
+    --jlg-aio-text-glow: none;
+    --jlg-aio-text-glow-start: none;
+    --jlg-aio-text-glow-mid: none;
+    --jlg-aio-text-glow-animation: none;
+    --jlg-aio-circle-glow: 0 0 0 0 rgba(0, 0, 0, 0);
+    --jlg-aio-circle-glow-start: 0 0 0 0 rgba(0, 0, 0, 0);
+    --jlg-aio-circle-glow-mid: 0 0 0 0 rgba(0, 0, 0, 0);
+    --jlg-aio-circle-glow-animation: none;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--jlg-aio-bg-color);
+    border: 1px solid var(--jlg-aio-points-border-color);
+    border-radius: 16px;
+    overflow: hidden;
+    margin: 40px auto;
+    max-width: 750px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    color: var(--jlg-aio-text-color);
+}
+
+.jlg-all-in-one-block.style-moderne {
+    background: linear-gradient(135deg, var(--jlg-aio-bg-gradient-start), var(--jlg-aio-bg-gradient-end));
+}
+
+.jlg-aio-header {
+    position: relative;
+    padding: 25px 30px;
+    background: linear-gradient(135deg, var(--jlg-aio-header-gradient-start), var(--jlg-aio-header-gradient-end));
+    border-bottom: 1px solid var(--jlg-aio-points-border-color);
+}
+
+.jlg-aio-tagline {
+    font-size: var(--jlg-aio-tagline-font-size);
+    font-style: italic;
+    color: var(--jlg-aio-text-color);
+    text-align: center;
+    position: relative;
+    padding: 0 50px;
+}
+
+.jlg-aio-flags {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    display: flex;
+    gap: 8px;
+    z-index: 10;
+}
+
+.jlg-aio-flag {
+    width: 24px;
+    height: auto;
+    cursor: pointer;
+    opacity: 0.4;
+    transition: all 0.2s ease;
+    filter: grayscale(50%);
+    display: block;
+    min-height: 18px;
+}
+
+.jlg-aio-flag.active {
+    opacity: 1;
+    filter: grayscale(0%);
+    transform: scale(1.1);
+}
+
+.jlg-aio-flag:hover {
+    opacity: 0.8;
+    filter: grayscale(0%);
+}
+
+.jlg-aio-rating {
+    padding: 30px;
+    background: var(--jlg-aio-rating-bg-color);
+}
+
+.jlg-aio-main-score {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.jlg-aio-score-value {
+    font-size: 4rem;
+    font-weight: 800;
+    background: linear-gradient(135deg, var(--jlg-aio-accent-color), var(--jlg-aio-score-gradient-2));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    line-height: 1;
+    margin-bottom: 8px;
+    text-shadow: var(--jlg-aio-text-glow);
+    animation: var(--jlg-aio-text-glow-animation, none);
+}
+
+.jlg-aio-score-label {
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--jlg-aio-text-color-secondary);
+    font-weight: 600;
+}
+
+.jlg-aio-score-circle {
+    width: 140px;
+    height: 140px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background: var(--jlg-aio-circle-background);
+    box-shadow: var(--jlg-aio-circle-base-shadow), var(--jlg-aio-circle-glow);
+    border: var(--jlg-aio-circle-border);
+    animation: var(--jlg-aio-circle-glow-animation, none);
+}
+
+.jlg-aio-score-circle .jlg-aio-score-value {
+    font-size: 3rem;
+    color: #ffffff;
+    background: none;
+    -webkit-text-fill-color: #ffffff;
+    text-shadow: none;
+}
+
+.jlg-aio-scores-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 25px;
+}
+
+.jlg-aio-score-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.jlg-aio-score-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+}
+
+.jlg-aio-score-header .jlg-aio-score-label {
+    font-weight: 600;
+    color: var(--jlg-aio-score-label-color);
+}
+
+.jlg-aio-score-number {
+    color: var(--jlg-aio-score-number-color);
+    font-weight: 500;
+}
+
+.jlg-aio-score-bar-bg {
+    height: 8px;
+    background: var(--jlg-aio-score-bar-bg-color);
+    border-radius: 999px;
+    overflow: hidden;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.jlg-aio-score-bar {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.8s cubic-bezier(0.25, 1, 0.5, 1);
+    background: var(--bar-color);
+}
+
+.jlg-aio-points {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+    background: var(--jlg-aio-points-border-color);
+    border-top: 2px solid var(--jlg-aio-points-border-color);
+}
+
+.jlg-aio-points-col {
+    background: var(--jlg-aio-points-bg-color);
+    padding: 25px;
+}
+
+.jlg-aio-points-col.pros {
+    border-right: 1px solid var(--jlg-aio-points-border-color);
+}
+
+.jlg-aio-points-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 15px;
+    color: var(--jlg-aio-points-title-color);
+}
+
+.jlg-aio-points-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    font-weight: bold;
+}
+
+.jlg-aio-points-icon.pros {
+    background: var(--jlg-aio-color-high-soft);
+    color: var(--jlg-aio-color-high);
+}
+
+.jlg-aio-points-icon.cons {
+    background: var(--jlg-aio-color-low-soft);
+    color: var(--jlg-aio-color-low);
+}
+
+.jlg-aio-points-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.jlg-aio-points-list li {
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 12px;
+    color: var(--jlg-aio-points-text-color);
+    line-height: 1.5;
+}
+
+.jlg-aio-points-list li::before {
+    content: '▸';
+    position: absolute;
+    left: 0;
+    font-weight: bold;
+}
+
+.jlg-aio-points-col.pros .jlg-aio-points-list li::before {
+    color: var(--jlg-aio-points-bullet-pros);
+}
+
+.jlg-aio-points-col.cons .jlg-aio-points-list li::before {
+    color: var(--jlg-aio-points-bullet-cons);
+}
+
+@media (max-width: 640px) {
+    .jlg-aio-points {
+        grid-template-columns: 1fr;
+    }
+
+    .jlg-aio-points-col.pros {
+        border-right: none;
+        border-bottom: 1px solid var(--jlg-aio-points-border-color);
+    }
+
+    .jlg-aio-tagline {
+        padding: 0 40px;
+    }
+
+    .jlg-aio-score-value {
+        font-size: 3rem;
+    }
+}
+
+.jlg-all-in-one-block.animate-in .jlg-aio-score-bar {
+    width: 0 !important;
+}
+
+.jlg-all-in-one-block.animate-in.is-visible .jlg-aio-score-bar {
+    width: var(--bar-width) !important;
+}
+
+.jlg-all-in-one-block.animate-in .jlg-aio-score-value {
+    opacity: 0;
+    transform: scale(0.8);
+    transition: all 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.jlg-all-in-one-block.animate-in.is-visible .jlg-aio-score-value {
+    opacity: 1;
+    transform: scale(1);
+}
+
+@keyframes slideInLeft {
+    from {
+        opacity: 0;
+        transform: translateX(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes slideInRight {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+.jlg-all-in-one-block.animate-in.is-visible .jlg-aio-points-col.pros {
+    animation: slideInLeft 0.6s ease-out;
+}
+
+.jlg-all-in-one-block.animate-in.is-visible .jlg-aio-points-col.cons {
+    animation: slideInRight 0.6s ease-out;
+}
+
+.jlg-all-in-one-block.style-compact {
+    border-radius: 12px;
+}
+
+.jlg-all-in-one-block.style-compact .jlg-aio-header {
+    padding: 20px;
+}
+
+.jlg-all-in-one-block.style-compact .jlg-aio-rating {
+    padding: 20px;
+}
+
+.jlg-all-in-one-block.style-compact .jlg-aio-points-col {
+    padding: 20px;
+}
+
+.jlg-all-in-one-block.style-compact .jlg-aio-score-value {
+    font-size: 3rem;
+}
+
+.jlg-all-in-one-block.style-classique {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+}
+
+.jlg-all-in-one-block.style-classique .jlg-aio-header {
+    background: var(--jlg-aio-bg-color-secondary);
+}
+
+@keyframes jlg-aio-text-glow-pulse {
+    0%,
+    100% {
+        text-shadow: var(--jlg-aio-text-glow-start);
+    }
+    50% {
+        text-shadow: var(--jlg-aio-text-glow-mid);
+    }
+}
+
+@keyframes jlg-aio-circle-glow-pulse {
+    0%,
+    100% {
+        box-shadow: var(--jlg-aio-circle-base-shadow), var(--jlg-aio-circle-glow-start);
+    }
+    50% {
+        box-shadow: var(--jlg-aio-circle-base-shadow), var(--jlg-aio-circle-glow-mid);
+    }
+}

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -798,6 +798,9 @@ class JLG_Frontend {
                 'count'              => 0,
                 'has_voted'          => false,
                 'user_vote'          => 0,
+                'block_id'           => '',
+                'css_variables'      => [],
+                'has_multiple_taglines' => false,
             ];
 
             // Fusionner les arguments fournis avec les valeurs par défaut.

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -2,7 +2,7 @@
 /**
  * Shortcode All-in-One : Bloc complet de notation
  * Combine : Notation + Points forts/faibles + Tagline
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
@@ -10,14 +10,13 @@
 if (!defined('ABSPATH')) exit;
 
 class JLG_Shortcode_All_In_One {
-    
+
     public function __construct() {
         add_shortcode('jlg_bloc_complet', [$this, 'render']);
         add_shortcode('bloc_notation_complet', [$this, 'render']); // Alias
     }
 
     public function render($atts) {
-        // Attributs du shortcode
         $atts = shortcode_atts([
             'post_id' => get_the_ID(),
             'afficher_notation' => 'oui',
@@ -25,8 +24,8 @@ class JLG_Shortcode_All_In_One {
             'afficher_tagline' => 'oui',
             'titre_points_forts' => 'Points Forts',
             'titre_points_faibles' => 'Points Faibles',
-            'style' => 'moderne', // moderne, classique, compact
-            'couleur_accent' => '', // Permet de surcharger la couleur d'accent
+            'style' => 'moderne',
+            'couleur_accent' => '',
         ], $atts, 'jlg_bloc_complet');
 
         $post_id = intval($atts['post_id']);
@@ -43,32 +42,26 @@ class JLG_Shortcode_All_In_One {
             $atts['style'] = 'moderne';
         }
 
-        // Sécurité : ne s'exécute que sur les articles ('post')
         if (!$post_id || 'post' !== get_post_type($post_id)) {
             return '';
         }
 
-        // Vérifier qu'il y a des données à afficher
         $average_score = JLG_Helpers::get_average_score_for_post($post_id);
         $tagline_fr = get_post_meta($post_id, '_jlg_tagline_fr', true);
         $tagline_en = get_post_meta($post_id, '_jlg_tagline_en', true);
         $pros = get_post_meta($post_id, '_jlg_points_forts', true);
         $cons = get_post_meta($post_id, '_jlg_points_faibles', true);
 
-        // Si aucune donnée, ne rien afficher
         if ($average_score === null && empty($tagline_fr) && empty($tagline_en) && empty($pros) && empty($cons)) {
             return '';
         }
 
-        // Récupération des options et configuration
         $options = JLG_Helpers::get_plugin_options();
         $palette = JLG_Helpers::get_color_palette();
         $categories = JLG_Helpers::get_rating_categories();
-        
-        // Couleur d'accent (utilise la couleur définie ou celle des options)
-        $accent_color = $atts['couleur_accent'] ?: $options['score_gradient_1'];
-        
-        // Récupérer les scores détaillés
+
+        $accent_color = $atts['couleur_accent'] ?: ($options['score_gradient_1'] ?? '');
+
         $scores = [];
         if ($average_score !== null) {
             foreach (array_keys($categories) as $key) {
@@ -79,670 +72,245 @@ class JLG_Shortcode_All_In_One {
             }
         }
 
-        // Préparer les listes de points
         $pros_list = !empty($pros) ? array_filter(explode("\n", $pros)) : [];
         $cons_list = !empty($cons) ? array_filter(explode("\n", $cons)) : [];
 
-        // Construction du HTML
-        ob_start();
-        ?>
-        <style>
-            /* Conteneur principal du bloc complet */
-            .jlg-all-in-one-block {
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-                background: <?php echo esc_attr($palette['bg_color']); ?>;
-                border: 1px solid <?php echo esc_attr($palette['border_color']); ?>;
-                border-radius: 16px;
-                overflow: hidden;
-                margin: 40px auto;
-                max-width: 750px;
-                box-shadow: 0 20px 25px -5px rgba(0,0,0,.1), 0 10px 10px -5px rgba(0,0,0,.04);
+        $style_handle = 'jlg-shortcode-all-in-one';
+        if (!wp_style_is($style_handle, 'registered')) {
+            wp_register_style(
+                $style_handle,
+                JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-shortcode-all-in-one.css',
+                ['jlg-frontend'],
+                JLG_NOTATION_VERSION
+            );
+        }
+
+        wp_enqueue_style($style_handle);
+
+        $score_gradient_1 = $this->sanitize_color_value($options['score_gradient_1'] ?? '', '#3b82f6');
+        $accent_color = $this->sanitize_color_value($accent_color, $score_gradient_1);
+
+        $css_variables = $this->build_css_variables($palette, $options, $accent_color, $average_score);
+
+        $block_id = 'jlg-aio-' . uniqid('', false);
+        $has_multiple_taglines = (!empty($tagline_fr) && !empty($tagline_en));
+
+        return JLG_Frontend::get_template_html('shortcode-all-in-one', [
+            'atts'                  => $atts,
+            'options'               => $options,
+            'average_score'         => $average_score,
+            'scores'                => $scores,
+            'categories'            => $categories,
+            'pros_list'             => $pros_list,
+            'cons_list'             => $cons_list,
+            'tagline_fr'            => $tagline_fr,
+            'tagline_en'            => $tagline_en,
+            'block_id'              => $block_id,
+            'css_variables'         => $css_variables,
+            'has_multiple_taglines' => $has_multiple_taglines,
+        ]);
+    }
+
+    private function sanitize_color_value($value, $fallback = '', $allow_transparent = false) {
+        $sanitized = sanitize_hex_color($value);
+
+        if (!empty($sanitized)) {
+            return $sanitized;
+        }
+
+        if ($allow_transparent && is_string($value) && strtolower(trim($value)) === 'transparent') {
+            return 'transparent';
+        }
+
+        $fallback_sanitized = sanitize_hex_color($fallback);
+        if (!empty($fallback_sanitized)) {
+            return $fallback_sanitized;
+        }
+
+        if ($allow_transparent && is_string($fallback) && strtolower(trim($fallback)) === 'transparent') {
+            return 'transparent';
+        }
+
+        return '';
+    }
+
+    private function append_alpha_channel($color, $alpha_hex, $fallback = '') {
+        $base = $this->sanitize_color_value($color, $fallback);
+        if ($base === '') {
+            return '';
+        }
+
+        $hex = ltrim($base, '#');
+        if (strlen($hex) === 3) {
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+        }
+
+        return '#' . $hex . $alpha_hex;
+    }
+
+    private function format_float($value, $precision = 2) {
+        $formatted = number_format((float) $value, $precision, '.', '');
+        return rtrim(rtrim($formatted, '0'), '.');
+    }
+
+    private function build_css_variables(array $palette, array $options, $accent_color, $average_score) {
+        $bg_color = $this->sanitize_color_value($palette['bg_color'] ?? '', '#18181b');
+        $bg_color_secondary = $this->sanitize_color_value($palette['bg_color_secondary'] ?? '', '#27272a');
+        $border_color = $this->sanitize_color_value($palette['border_color'] ?? '', '#3f3f46');
+        $text_color = $this->sanitize_color_value($palette['text_color'] ?? '', '#fafafa');
+        $text_color_secondary = $this->sanitize_color_value($palette['text_color_secondary'] ?? '', '#a1a1aa');
+        $score_gradient_2 = $this->sanitize_color_value($options['score_gradient_2'] ?? '', '#2563eb');
+        $color_high = $this->sanitize_color_value($options['color_high'] ?? '', '#22c55e');
+        $color_low = $this->sanitize_color_value($options['color_low'] ?? '', '#ef4444');
+
+        $css_vars = [
+            '--jlg-aio-bg-color'               => $bg_color,
+            '--jlg-aio-bg-color-secondary'     => $bg_color_secondary,
+            '--jlg-aio-bg-gradient-start'      => $bg_color,
+            '--jlg-aio-bg-gradient-end'        => $bg_color_secondary,
+            '--jlg-aio-header-gradient-start'  => $this->append_alpha_channel($accent_color, '15', $accent_color ?: '#3b82f6'),
+            '--jlg-aio-header-gradient-end'    => $this->append_alpha_channel($score_gradient_2, '10', $score_gradient_2 ?: $accent_color),
+            '--jlg-aio-tagline-font-size'      => intval($options['tagline_font_size'] ?? 16) . 'px',
+            '--jlg-aio-text-color'             => $text_color,
+            '--jlg-aio-text-color-secondary'   => $text_color_secondary,
+            '--jlg-aio-accent-color'           => $accent_color,
+            '--jlg-aio-score-gradient-2'       => $score_gradient_2,
+            '--jlg-aio-rating-bg-color'        => $bg_color,
+            '--jlg-aio-score-label-color'      => $text_color,
+            '--jlg-aio-score-number-color'     => $text_color_secondary,
+            '--jlg-aio-score-bar-bg-color'     => $bg_color_secondary,
+            '--jlg-aio-points-border-color'    => $border_color,
+            '--jlg-aio-points-bg-color'        => $bg_color,
+            '--jlg-aio-points-title-color'     => $text_color,
+            '--jlg-aio-points-text-color'      => $text_color_secondary,
+            '--jlg-aio-color-high'             => $color_high,
+            '--jlg-aio-color-high-soft'        => $this->append_alpha_channel($color_high, '20', $color_high),
+            '--jlg-aio-color-low'              => $color_low,
+            '--jlg-aio-color-low-soft'         => $this->append_alpha_channel($color_low, '20', $color_low),
+            '--jlg-aio-points-bullet-pros'     => $color_high,
+            '--jlg-aio-points-bullet-cons'     => $color_low,
+            '--jlg-aio-circle-shadow-color'    => $this->append_alpha_channel($accent_color, '40', $accent_color ?: '#3b82f6'),
+            '--jlg-aio-circle-border'          => 'none',
+            '--jlg-aio-circle-glow'            => '0 0 0 0 rgba(0,0,0,0)',
+            '--jlg-aio-circle-glow-start'      => '0 0 0 0 rgba(0,0,0,0)',
+            '--jlg-aio-circle-glow-mid'        => '0 0 0 0 rgba(0,0,0,0)',
+            '--jlg-aio-circle-glow-animation'  => 'none',
+            '--jlg-aio-text-glow'              => 'none',
+            '--jlg-aio-text-glow-start'        => 'none',
+            '--jlg-aio-text-glow-mid'          => 'none',
+            '--jlg-aio-text-glow-animation'    => 'none',
+        ];
+
+        $circle_start = $accent_color;
+        $circle_end = $score_gradient_2 !== '' ? $score_gradient_2 : $accent_color;
+
+        if (($options['score_layout'] ?? 'text') === 'circle') {
+            if (!empty($options['circle_dynamic_bg_enabled'])) {
+                $dynamic_color = $this->sanitize_color_value(JLG_Helpers::calculate_color_from_note($average_score, $options), $accent_color);
+                $darker_color = $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($dynamic_color, -30), $circle_end);
+                $circle_start = $dynamic_color ?: $accent_color;
+                $circle_end = $darker_color ?: $circle_end;
             }
 
-            /* Style moderne avec effet gradient */
-            .jlg-all-in-one-block.style-moderne {
-                background: linear-gradient(135deg, 
-                    <?php echo esc_attr($palette['bg_color']); ?> 0%, 
-                    <?php echo esc_attr($palette['bg_color_secondary']); ?> 100%);
-            }
-
-            /* Header avec tagline */
-            .jlg-aio-header {
-                position: relative;
-                padding: 25px 30px;
-                background: linear-gradient(135deg, 
-                    <?php echo esc_attr($accent_color); ?>15 0%, 
-                    <?php echo esc_attr($options['score_gradient_2']); ?>10 100%);
-                border-bottom: 1px solid <?php echo esc_attr($palette['border_color']); ?>;
-            }
-
-            .jlg-aio-tagline {
-                font-size: <?php echo intval($options['tagline_font_size'] ?? 16); ?>px;
-                font-style: italic;
-                color: <?php echo esc_attr($palette['text_color']); ?>;
-                text-align: center;
-                position: relative;
-                padding: 0 50px;
-            }
-
-            /* Drapeaux de langue */
-            .jlg-aio-flags {
-                position: absolute;
-                top: 15px;
-                right: 15px;
-                display: flex;
-                gap: 8px;
-                z-index: 10; /* Assure que les drapeaux sont au-dessus */
-            }
-
-            .jlg-aio-flag {
-                width: 24px;
-                height: auto;
-                cursor: pointer;
-                opacity: 0.4;
-                transition: all 0.2s ease;
-                filter: grayscale(50%);
-                display: block; /* Force le display block pour une meilleure hitbox */
-                min-height: 18px; /* Hauteur minimum pour la hitbox */
-            }
-
-            .jlg-aio-flag.active {
-                opacity: 1;
-                filter: grayscale(0%);
-                transform: scale(1.1);
-            }
-
-            .jlg-aio-flag:hover {
-                opacity: 0.8;
-                filter: grayscale(0%);
-            }
-
-            /* Section notation */
-            .jlg-aio-rating {
-                padding: 30px;
-                background: <?php echo esc_attr($palette['bg_color']); ?>;
-            }
-
-            /* Score global */
-            .jlg-aio-main-score {
-                text-align: center;
-                margin-bottom: 30px;
-            }
-
-            .jlg-aio-score-value {
-                font-size: 4rem;
-                font-weight: 800;
-                background: linear-gradient(135deg, <?php echo esc_attr($accent_color); ?>, <?php echo esc_attr($options['score_gradient_2']); ?>);
-                -webkit-background-clip: text;
-                -webkit-text-fill-color: transparent;
-                background-clip: text;
-                line-height: 1;
-                margin-bottom: 8px;
-            }
-
-            /* Mode cercle optionnel */
-            <?php if ($options['score_layout'] === 'circle'): ?>
-            .jlg-aio-score-circle {
-                width: 140px;
-                height: 140px;
-                margin: 0 auto 20px;
-                border-radius: 50%;
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
-                <?php 
-                // Fond dynamique ou gradient standard
-                if (!empty($options['circle_dynamic_bg_enabled'])) {
-                    $dynamic_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
-                    $darker_color = JLG_Helpers::adjust_hex_brightness($dynamic_color, -30);
-                    echo "background: linear-gradient(135deg, " . esc_attr($dynamic_color) . ", " . esc_attr($darker_color) . ");";
-                } else {
-                    echo "background: linear-gradient(135deg, " . esc_attr($accent_color) . ", " . esc_attr($options['score_gradient_2']) . ");";
-                }
-                ?>
-                box-shadow: 0 10px 25px -5px <?php echo esc_attr($accent_color); ?>40;
-                <?php
-                // Bordure du cercle si activée
-                if (!empty($options['circle_border_enabled'])) {
-                    echo "border: " . intval($options['circle_border_width']) . "px solid " . esc_attr($options['circle_border_color']) . ";";
-                }
-                ?>
-            }
-
-            .jlg-aio-score-circle .jlg-aio-score-value {
-                font-size: 3rem;
-                color: white;
-                background: none;
-                -webkit-text-fill-color: white;
-            }
-            <?php endif; ?>
-            
-            /* Effet Glow/Neon */
-            <?php 
-            if ($options['score_layout'] !== 'circle') {
-                // Mode texte - Glow sur le score
-                if (!empty($options['text_glow_enabled'])) {
-                    // Déterminer la couleur du glow
-                    $glow_mode = isset($options['text_glow_color_mode']) ? $options['text_glow_color_mode'] : 'dynamic';
-                    
-                    // Calculer la couleur selon le mode
-                    if ($glow_mode === 'dynamic') {
-                        // Mode dynamique : couleur selon la note
-                        $glow_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
-                    } else {
-                        // Mode custom : utiliser la couleur personnalisée
-                        $glow_color = isset($options['text_glow_custom_color']) && !empty($options['text_glow_custom_color']) 
-                            ? $options['text_glow_custom_color'] 
-                            : '#60a5fa'; // Fallback to a default color
-                    }
-                    
-                    // S'assurer que la couleur est valide
-                    if (!preg_match('/^#[0-9A-Fa-f]{6}$/', $glow_color)) {
-                        $glow_color = '#60a5fa'; // Couleur par défaut si invalide
-                    }
-                    
-                    $intensity = isset($options['text_glow_intensity']) ? intval($options['text_glow_intensity']) : 15;
-                    $has_pulse = !empty($options['text_glow_pulse']);
-                    $speed = isset($options['text_glow_speed']) ? floatval($options['text_glow_speed']) : 2.5;
-                    
-                    $s1 = round($intensity * 0.5);
-                    $s2 = $intensity;
-                    $s3 = round($intensity * 1.5);
-                    
-                    // Utiliser une classe spécifique pour éviter les conflits
-                    echo ".jlg-all-in-one-block .jlg-aio-score-value { ";
-                    echo "text-shadow: ";
-                    echo "0 0 {$s1}px {$glow_color}, ";
-                    echo "0 0 {$s2}px {$glow_color}, ";
-                    echo "0 0 {$s3}px {$glow_color} !important; ";
-                    echo "} ";
-                    
-                    if ($has_pulse) {
-                        $ps1 = round($intensity * 0.7);
-                        $ps2 = round($intensity * 1.5);
-                        $ps3 = round($intensity * 2.5);
-                        
-                        echo "@keyframes jlg-aio-text-glow-pulse { ";
-                        echo "0%, 100% { ";
-                        echo "text-shadow: 0 0 {$s1}px {$glow_color}, 0 0 {$s2}px {$glow_color}, 0 0 {$s3}px {$glow_color}; ";
-                        echo "} ";
-                        echo "50% { ";
-                        echo "text-shadow: 0 0 {$ps1}px {$glow_color}, 0 0 {$ps2}px {$glow_color}, 0 0 {$ps3}px {$glow_color}; ";
-                        echo "} ";
-                        echo "} ";
-                        echo ".jlg-all-in-one-block .jlg-aio-score-value { ";
-                        echo "animation: jlg-aio-text-glow-pulse {$speed}s infinite ease-in-out !important; ";
-                        echo "} ";
-                    }
-                    
-                    // Debug
-                    echo "/* AIO Text Glow: Mode={$glow_mode}, Color={$glow_color}, Score={$average_score} */ ";
-                }
-            } else {
-                // Mode cercle - Glow sur le cercle
-                if (!empty($options['circle_glow_enabled'])) {
-                    // Déterminer la couleur du glow
-                    $glow_mode = isset($options['circle_glow_color_mode']) ? $options['circle_glow_color_mode'] : 'dynamic';
-                    
-                    // Calculer la couleur selon le mode
-                    if ($glow_mode === 'dynamic') {
-                        // Mode dynamique : couleur selon la note
-                        $glow_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
-                    } else {
-                        // Mode custom : utiliser la couleur personnalisée
-                        $glow_color = isset($options['circle_glow_custom_color']) && !empty($options['circle_glow_custom_color']) 
-                            ? $options['circle_glow_custom_color'] 
-                            : '#60a5fa'; // Fallback to a default color
-                    }
-                    
-                    // S'assurer que la couleur est valide
-                    if (!preg_match('/^#[0-9A-Fa-f]{6}$/', $glow_color)) {
-                        $glow_color = '#60a5fa'; // Couleur par défaut si invalide
-                    }
-                    
-                    $intensity = isset($options['circle_glow_intensity']) ? intval($options['circle_glow_intensity']) : 15;
-                    $has_pulse = !empty($options['circle_glow_pulse']);
-                    $speed = isset($options['circle_glow_speed']) ? floatval($options['circle_glow_speed']) : 2.5;
-                    
-                    $s1 = round($intensity * 0.5);
-                    $s2 = $intensity;
-                    $s3 = round($intensity * 1.5);
-                    
-                    // Utiliser une classe spécifique pour éviter les conflits
-                    echo ".jlg-all-in-one-block .jlg-aio-score-circle { ";
-                    echo "box-shadow: ";
-                    echo "0 0 {$s1}px {$glow_color}, ";
-                    echo "0 0 {$s2}px {$glow_color}, ";
-                    echo "0 0 {$s3}px {$glow_color}, ";
-                    echo "inset 0 0 {$s1}px rgba(255,255,255,0.1) !important; ";
-                    echo "} ";
-                    
-                    if ($has_pulse) {
-                        $ps1 = round($intensity * 0.7);
-                        $ps2 = round($intensity * 1.5);
-                        $ps3 = round($intensity * 2.5);
-                        
-                        echo "@keyframes jlg-aio-circle-glow-pulse { ";
-                        echo "0%, 100% { ";
-                        echo "box-shadow: ";
-                        echo "0 0 {$s1}px {$glow_color}, ";
-                        echo "0 0 {$s2}px {$glow_color}, ";
-                        echo "0 0 {$s3}px {$glow_color}, ";
-                        echo "inset 0 0 {$s1}px rgba(255,255,255,0.1); ";
-                        echo "} ";
-                        echo "50% { ";
-                        echo "box-shadow: ";
-                        echo "0 0 {$ps1}px {$glow_color}, ";
-                        echo "0 0 {$ps2}px {$glow_color}, ";
-                        echo "0 0 {$ps3}px {$glow_color}, ";
-                        echo "inset 0 0 {$ps1}px rgba(255,255,255,0.15); ";
-                        echo "} ";
-                        echo "} ";
-                        echo ".jlg-all-in-one-block .jlg-aio-score-circle { ";
-                        echo "animation: jlg-aio-circle-glow-pulse {$speed}s infinite ease-in-out !important; ";
-                        echo "} ";
-                    }
-                    
-                    // Debug
-                    echo "/* AIO Circle Glow: Mode={$glow_mode}, Color={$glow_color}, Score={$average_score} */ ";
-                }
-            }
-            ?>
-
-            .jlg-aio-score-label {
-                font-size: 0.875rem;
-                text-transform: uppercase;
-                letter-spacing: 2px;
-                color: <?php echo esc_attr($palette['text_color_secondary']); ?>;
-                font-weight: 600;
-            }
-
-            /* Barres de notation détaillées */
-            .jlg-aio-scores-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-                gap: 20px;
-                margin-top: 25px;
-            }
-
-            .jlg-aio-score-item {
-                display: flex;
-                flex-direction: column;
-                gap: 8px;
-            }
-
-            .jlg-aio-score-header {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                font-size: 0.875rem;
-            }
-
-            .jlg-aio-score-label {
-                font-weight: 600;
-                color: <?php echo esc_attr($palette['text_color']); ?>;
-            }
-
-            .jlg-aio-score-number {
-                color: <?php echo esc_attr($palette['text_color_secondary']); ?>;
-                font-weight: 500;
-            }
-
-            .jlg-aio-score-bar-bg {
-                height: 8px;
-                background: <?php echo esc_attr($palette['bg_color_secondary']); ?>;
-                border-radius: 999px;
-                overflow: hidden;
-                box-shadow: inset 0 1px 3px rgba(0,0,0,0.1);
-            }
-
-            .jlg-aio-score-bar {
-                height: 100%;
-                border-radius: 999px;
-                transition: width 0.8s cubic-bezier(0.25, 1, 0.5, 1);
-                background: var(--bar-color);
-            }
-
-            /* Section points forts/faibles */
-            .jlg-aio-points {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 2px;
-                background: <?php echo esc_attr($palette['border_color']); ?>;
-                border-top: 2px solid <?php echo esc_attr($palette['border_color']); ?>;
-            }
-
-            .jlg-aio-points-col {
-                background: <?php echo esc_attr($palette['bg_color']); ?>;
-                padding: 25px;
-            }
-
-            .jlg-aio-points-col.pros {
-                border-right: 1px solid <?php echo esc_attr($palette['border_color']); ?>;
-            }
-
-            .jlg-aio-points-title {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                font-size: 1.125rem;
-                font-weight: 600;
-                margin-bottom: 15px;
-                color: <?php echo esc_attr($palette['text_color']); ?>;
-            }
-
-            .jlg-aio-points-icon {
-                width: 32px;
-                height: 32px;
-                border-radius: 50%;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                font-size: 1.25rem;
-                font-weight: bold;
-            }
-
-            .jlg-aio-points-icon.pros {
-                background: <?php echo esc_attr($options['color_high']); ?>20;
-                color: <?php echo esc_attr($options['color_high']); ?>;
-            }
-
-            .jlg-aio-points-icon.cons {
-                background: <?php echo esc_attr($options['color_low']); ?>20;
-                color: <?php echo esc_attr($options['color_low']); ?>;
-            }
-
-            .jlg-aio-points-list {
-                list-style: none;
-                padding: 0;
-                margin: 0;
-            }
-
-            .jlg-aio-points-list li {
-                position: relative;
-                padding-left: 24px;
-                margin-bottom: 12px;
-                color: <?php echo esc_attr($palette['text_color_secondary']); ?>;
-                line-height: 1.5;
-            }
-
-            .jlg-aio-points-list li::before {
-                content: '▸';
-                position: absolute;
-                left: 0;
-                font-weight: bold;
-            }
-
-            .jlg-aio-points-col.pros .jlg-aio-points-list li::before {
-                color: <?php echo esc_attr($options['color_high']); ?>;
-            }
-
-            .jlg-aio-points-col.cons .jlg-aio-points-list li::before {
-                color: <?php echo esc_attr($options['color_low']); ?>;
-            }
-
-            /* Responsive */
-            @media (max-width: 640px) {
-                .jlg-aio-points {
-                    grid-template-columns: 1fr;
-                }
-                
-                .jlg-aio-points-col.pros {
-                    border-right: none;
-                    border-bottom: 1px solid <?php echo esc_attr($palette['border_color']); ?>;
-                }
-
-                .jlg-aio-tagline {
-                    padding: 0 40px;
-                }
-
-                .jlg-aio-score-value {
-                    font-size: 3rem;
+            if (!empty($options['circle_border_enabled'])) {
+                $border_width = max(0, intval($options['circle_border_width'] ?? 0));
+                $border_color = $this->sanitize_color_value($options['circle_border_color'] ?? '', $accent_color);
+                if ($border_width > 0 && $border_color !== '') {
+                    $css_vars['--jlg-aio-circle-border'] = $border_width . 'px solid ' . $border_color;
                 }
             }
 
-            /* Animations */
-            <?php if ($options['enable_animations']): ?>
-            .jlg-all-in-one-block.animate-in .jlg-aio-score-bar {
-                width: 0 !important;
+            if (!empty($options['circle_glow_enabled'])) {
+                $css_vars = $this->apply_circle_glow($css_vars, $average_score, $options);
             }
-
-            .jlg-all-in-one-block.animate-in.is-visible .jlg-aio-score-bar {
-                width: var(--bar-width) !important;
+        } else {
+            if (!empty($options['text_glow_enabled'])) {
+                $css_vars = $this->apply_text_glow($css_vars, $average_score, $options);
             }
+        }
 
-            .jlg-all-in-one-block.animate-in .jlg-aio-score-value {
-                opacity: 0;
-                transform: scale(0.8);
-                transition: all 0.6s cubic-bezier(0.25, 1, 0.5, 1);
-            }
+        $css_vars['--jlg-aio-circle-background'] = sprintf('linear-gradient(135deg, %s, %s)', $circle_start, $circle_end);
 
-            .jlg-all-in-one-block.animate-in.is-visible .jlg-aio-score-value {
-                opacity: 1;
-                transform: scale(1);
-            }
+        return $css_vars;
+    }
 
-            @keyframes slideInLeft {
-                from {
-                    opacity: 0;
-                    transform: translateX(-20px);
-                }
-                to {
-                    opacity: 1;
-                    transform: translateX(0);
-                }
-            }
+    private function apply_text_glow(array $css_vars, $average_score, array $options) {
+        $glow_mode = $options['text_glow_color_mode'] ?? 'dynamic';
+        $glow_color = ($glow_mode === 'dynamic')
+            ? $this->sanitize_color_value(JLG_Helpers::calculate_color_from_note($average_score, $options), '#60a5fa')
+            : $this->sanitize_color_value($options['text_glow_custom_color'] ?? '', '#60a5fa');
 
-            @keyframes slideInRight {
-                from {
-                    opacity: 0;
-                    transform: translateX(20px);
-                }
-                to {
-                    opacity: 1;
-                    transform: translateX(0);
-                }
-            }
+        if ($glow_color === '') {
+            $glow_color = '#60a5fa';
+        }
 
-            .jlg-all-in-one-block.animate-in.is-visible .jlg-aio-points-col.pros {
-                animation: slideInLeft 0.6s ease-out;
-            }
+        $intensity = isset($options['text_glow_intensity']) ? max(0, intval($options['text_glow_intensity'])) : 15;
+        $s1 = round($intensity * 0.5);
+        $s2 = $intensity;
+        $s3 = round($intensity * 1.5);
 
-            .jlg-all-in-one-block.animate-in.is-visible .jlg-aio-points-col.cons {
-                animation: slideInRight 0.6s ease-out;
-            }
-            <?php endif; ?>
+        $base_shadow = sprintf('0 0 %1$dpx %2$s, 0 0 %3$dpx %2$s, 0 0 %4$dpx %2$s', $s1, $glow_color, $s2, $s3);
+        $css_vars['--jlg-aio-text-glow'] = $base_shadow;
+        $css_vars['--jlg-aio-text-glow-start'] = $base_shadow;
+        $css_vars['--jlg-aio-text-glow-mid'] = $base_shadow;
 
-            /* Style compact */
-            .jlg-all-in-one-block.style-compact {
-                border-radius: 12px;
-            }
+        if (!empty($options['text_glow_pulse'])) {
+            $ps1 = round($intensity * 0.7);
+            $ps2 = round($intensity * 1.5);
+            $ps3 = round($intensity * 2.5);
+            $mid_shadow = sprintf('0 0 %1$dpx %2$s, 0 0 %3$dpx %2$s, 0 0 %4$dpx %2$s', $ps1, $glow_color, $ps2, $ps3);
+            $css_vars['--jlg-aio-text-glow-mid'] = $mid_shadow;
+            $speed = isset($options['text_glow_speed']) ? $this->format_float($options['text_glow_speed']) : '2.5';
+            $css_vars['--jlg-aio-text-glow-animation'] = 'jlg-aio-text-glow-pulse ' . $speed . 's infinite ease-in-out';
+        }
 
-            .jlg-all-in-one-block.style-compact .jlg-aio-header {
-                padding: 20px;
-            }
+        return $css_vars;
+    }
 
-            .jlg-all-in-one-block.style-compact .jlg-aio-rating {
-                padding: 20px;
-            }
+    private function apply_circle_glow(array $css_vars, $average_score, array $options) {
+        $glow_mode = $options['circle_glow_color_mode'] ?? 'dynamic';
+        $glow_color = ($glow_mode === 'dynamic')
+            ? $this->sanitize_color_value(JLG_Helpers::calculate_color_from_note($average_score, $options), '#60a5fa')
+            : $this->sanitize_color_value($options['circle_glow_custom_color'] ?? '', '#60a5fa');
 
-            .jlg-all-in-one-block.style-compact .jlg-aio-points-col {
-                padding: 20px;
-            }
+        if ($glow_color === '') {
+            $glow_color = '#60a5fa';
+        }
 
-            .jlg-all-in-one-block.style-compact .jlg-aio-score-value {
-                font-size: 3rem;
-            }
+        $intensity = isset($options['circle_glow_intensity']) ? max(0, intval($options['circle_glow_intensity'])) : 15;
+        $s1 = round($intensity * 0.5);
+        $s2 = $intensity;
+        $s3 = round($intensity * 1.5);
 
-            /* Style classique */
-            .jlg-all-in-one-block.style-classique {
-                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-                border-radius: 8px;
-            }
+        $base_glow = sprintf(
+            '0 0 %1$dpx %2$s, 0 0 %3$dpx %2$s, 0 0 %4$dpx %2$s, inset 0 0 %1$dpx rgba(255,255,255,0.1)',
+            $s1,
+            $glow_color,
+            $s2,
+            $s3
+        );
 
-            .jlg-all-in-one-block.style-classique .jlg-aio-header {
-                background: <?php echo esc_attr($palette['bg_color_secondary']); ?>;
-            }
-        </style>
+        $css_vars['--jlg-aio-circle-glow'] = $base_glow;
+        $css_vars['--jlg-aio-circle-glow-start'] = $base_glow;
+        $css_vars['--jlg-aio-circle-glow-mid'] = $base_glow;
 
-        <div class="jlg-all-in-one-block style-<?php echo esc_attr($atts['style']); ?> <?php echo $options['enable_animations'] ? 'animate-in' : ''; ?>">
-            
-            <?php if ($atts['afficher_tagline'] === 'oui' && (!empty($tagline_fr) || !empty($tagline_en))): ?>
-            <!-- Header avec Tagline -->
-            <div class="jlg-aio-header">
-                <?php if (!empty($tagline_fr) && !empty($tagline_en)): ?>
-                <div class="jlg-aio-flags">
-                    <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'; ?>" 
-                         class="jlg-aio-flag active" 
-                         data-lang="fr" 
-                         alt="Français">
-                    <img src="<?php echo JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'; ?>" 
-                         class="jlg-aio-flag" 
-                         data-lang="en" 
-                         alt="English">
-                </div>
-                <?php endif; ?>
-                
-                <?php if (!empty($tagline_fr)): ?>
-                <div class="jlg-aio-tagline" data-lang="fr">
-                    <?php echo wp_kses_post($tagline_fr); ?>
-                </div>
-                <?php endif; ?>
-                
-                <?php if (!empty($tagline_en)): ?>
-                <div class="jlg-aio-tagline" data-lang="en" style="display:none;">
-                    <?php echo wp_kses_post($tagline_en); ?>
-                </div>
-                <?php endif; ?>
-            </div>
-            <?php endif; ?>
+        if (!empty($options['circle_glow_pulse'])) {
+            $ps1 = round($intensity * 0.7);
+            $ps2 = round($intensity * 1.5);
+            $ps3 = round($intensity * 2.5);
+            $mid_glow = sprintf(
+                '0 0 %1$dpx %2$s, 0 0 %3$dpx %2$s, 0 0 %4$dpx %2$s, inset 0 0 %1$dpx rgba(255,255,255,0.15)',
+                $ps1,
+                $glow_color,
+                $ps2,
+                $ps3
+            );
+            $css_vars['--jlg-aio-circle-glow-mid'] = $mid_glow;
+            $speed = isset($options['circle_glow_speed']) ? $this->format_float($options['circle_glow_speed']) : '2.5';
+            $css_vars['--jlg-aio-circle-glow-animation'] = 'jlg-aio-circle-glow-pulse ' . $speed . 's infinite ease-in-out';
+        }
 
-            <?php if ($atts['afficher_notation'] === 'oui' && $average_score !== null): ?>
-            <!-- Section Notation -->
-            <div class="jlg-aio-rating">
-                <div class="jlg-aio-main-score">
-                    <?php if ($options['score_layout'] === 'circle'): ?>
-                    <div class="jlg-aio-score-circle">
-                        <div class="jlg-aio-score-value"><?php echo number_format($average_score, 1, ',', ' '); ?></div>
-                        <div class="jlg-aio-score-label">Note Globale</div>
-                    </div>
-                    <?php else: ?>
-                    <div class="jlg-aio-score-value"><?php echo number_format($average_score, 1, ',', ' '); ?></div>
-                    <div class="jlg-aio-score-label">Note Globale</div>
-                    <?php endif; ?>
-                </div>
-
-                <!-- Barres de notation détaillées -->
-                <div class="jlg-aio-scores-grid">
-                    <?php foreach ($scores as $key => $score_value): 
-                        $bar_color = JLG_Helpers::calculate_color_from_note($score_value, $options);
-                    ?>
-                    <div class="jlg-aio-score-item">
-                        <div class="jlg-aio-score-header">
-                            <span class="jlg-aio-score-label"><?php echo esc_html($categories[$key]); ?></span>
-                            <span class="jlg-aio-score-number"><?php echo number_format($score_value, 1, ',', ' '); ?> / 10</span>
-                        </div>
-                        <div class="jlg-aio-score-bar-bg">
-                            <div class="jlg-aio-score-bar" 
-                                 style="--bar-color: <?php echo esc_attr($bar_color); ?>; --bar-width: <?php echo esc_attr($score_value * 10); ?>%; width: <?php echo esc_attr($score_value * 10); ?>%;">
-                            </div>
-                        </div>
-                    </div>
-                    <?php endforeach; ?>
-                </div>
-            </div>
-            <?php endif; ?>
-
-            <?php if ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !empty($cons_list))): ?>
-            <!-- Section Points Forts/Faibles -->
-            <div class="jlg-aio-points">
-                <?php if (!empty($pros_list)): ?>
-                <div class="jlg-aio-points-col pros">
-                    <div class="jlg-aio-points-title">
-                        <span class="jlg-aio-points-icon pros">+</span>
-                        <span><?php echo esc_html($atts['titre_points_forts']); ?></span>
-                    </div>
-                    <ul class="jlg-aio-points-list">
-                        <?php foreach ($pros_list as $pro): ?>
-                        <li><?php echo esc_html(trim($pro)); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-                <?php endif; ?>
-                
-                <?php if (!empty($cons_list)): ?>
-                <div class="jlg-aio-points-col cons">
-                    <div class="jlg-aio-points-title">
-                        <span class="jlg-aio-points-icon cons">−</span>
-                        <span><?php echo esc_html($atts['titre_points_faibles']); ?></span>
-                    </div>
-                    <ul class="jlg-aio-points-list">
-                        <?php foreach ($cons_list as $con): ?>
-                        <li><?php echo esc_html(trim($con)); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-                <?php endif; ?>
-            </div>
-            <?php endif; ?>
-        </div>
-
-        <?php if (!empty($tagline_fr) && !empty($tagline_en)): ?>
-        <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Gestion du changement de langue
-            const allFlags = document.querySelectorAll('.jlg-aio-flag');
-
-            allFlags.forEach(flag => {
-                const block = flag.closest('.jlg-all-in-one-block');
-                if (!block) {
-                    return;
-                }
-
-                const blockFlags = block.querySelectorAll('.jlg-aio-flag');
-                const blockTaglines = block.querySelectorAll('.jlg-aio-tagline');
-
-                flag.addEventListener('click', function() {
-                    const selectedLang = this.dataset.lang;
-
-                    // Mettre à jour les drapeaux actifs du bloc courant
-                    blockFlags.forEach(f => f.classList.remove('active'));
-                    this.classList.add('active');
-
-                    // Afficher la bonne tagline pour le bloc courant
-                    blockTaglines.forEach(t => {
-                        if (t.dataset.lang === selectedLang) {
-                            t.style.display = 'block';
-                        } else {
-                            t.style.display = 'none';
-                        }
-                    });
-                });
-            });
-
-            <?php if ($options['enable_animations']): ?>
-            // Animation à l'apparition
-            const observer = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('is-visible');
-                        observer.unobserve(entry.target);
-                    }
-                });
-            }, {
-                threshold: 0.2
-            });
-
-            const animatedBlocks = document.querySelectorAll('.jlg-all-in-one-block.animate-in');
-            animatedBlocks.forEach(block => observer.observe(block));
-            <?php endif; ?>
-        });
-        </script>
-        <?php endif; ?>
-
-        <?php
-        return ob_get_clean();
+        return $css_vars;
     }
 }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -1,0 +1,167 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+$block_classes = ['jlg-all-in-one-block'];
+$style_key = isset($atts['style']) ? sanitize_html_class($atts['style']) : 'moderne';
+$block_classes[] = 'style-' . $style_key;
+
+if (!empty($options['enable_animations'])) {
+    $block_classes[] = 'animate-in';
+}
+
+$style_attr = '';
+if (!empty($css_variables) && is_array($css_variables)) {
+    $style_parts = [];
+    foreach ($css_variables as $name => $value) {
+        if ($value === '' || $value === null) {
+            continue;
+        }
+        $style_parts[] = $name . ':' . $value;
+    }
+
+    if (!empty($style_parts)) {
+        $style_attr = implode(';', $style_parts) . ';';
+    }
+}
+?>
+<div id="<?php echo esc_attr($block_id); ?>" class="<?php echo esc_attr(implode(' ', array_filter($block_classes))); ?>"<?php if ($style_attr) : ?> style="<?php echo esc_attr($style_attr); ?>"<?php endif; ?>>
+    <?php if ($atts['afficher_tagline'] === 'oui' && (!empty($tagline_fr) || !empty($tagline_en))) : ?>
+    <div class="jlg-aio-header">
+        <?php if ($has_multiple_taglines) : ?>
+        <div class="jlg-aio-flags">
+            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'); ?>"
+                 class="jlg-aio-flag active"
+                 data-lang="fr"
+                 alt="<?php esc_attr_e('Français', 'notation-jlg'); ?>">
+            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'); ?>"
+                 class="jlg-aio-flag"
+                 data-lang="en"
+                 alt="<?php esc_attr_e('English', 'notation-jlg'); ?>">
+        </div>
+        <?php endif; ?>
+
+        <?php if (!empty($tagline_fr)) : ?>
+        <div class="jlg-aio-tagline" data-lang="fr"><?php echo wp_kses_post($tagline_fr); ?></div>
+        <?php endif; ?>
+
+        <?php if (!empty($tagline_en)) : ?>
+        <div class="jlg-aio-tagline" data-lang="en"<?php if ($has_multiple_taglines) : ?> style="display:none;"<?php endif; ?>><?php echo wp_kses_post($tagline_en); ?></div>
+        <?php endif; ?>
+    </div>
+    <?php endif; ?>
+
+    <?php if ($atts['afficher_notation'] === 'oui' && $average_score !== null) : ?>
+    <div class="jlg-aio-rating">
+        <div class="jlg-aio-main-score">
+            <?php if (($options['score_layout'] ?? 'text') === 'circle') : ?>
+            <div class="jlg-aio-score-circle">
+                <div class="jlg-aio-score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+                <div class="jlg-aio-score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
+            </div>
+            <?php else : ?>
+            <div class="jlg-aio-score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+            <div class="jlg-aio-score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
+            <?php endif; ?>
+        </div>
+
+        <?php if (!empty($scores)) : ?>
+        <div class="jlg-aio-scores-grid">
+            <?php foreach ($scores as $key => $score_value) :
+                if (!isset($categories[$key])) {
+                    continue;
+                }
+                $bar_color = JLG_Helpers::calculate_color_from_note($score_value, $options);
+                $width = max(0, min(100, $score_value * 10));
+            ?>
+            <div class="jlg-aio-score-item">
+                <div class="jlg-aio-score-header">
+                    <span class="jlg-aio-score-label"><?php echo esc_html($categories[$key]); ?></span>
+                    <span class="jlg-aio-score-number"><?php echo esc_html(number_format($score_value, 1, ',', ' ')); ?> / 10</span>
+                </div>
+                <div class="jlg-aio-score-bar-bg">
+                    <div class="jlg-aio-score-bar" style="--bar-color: <?php echo esc_attr($bar_color); ?>; --bar-width: <?php echo esc_attr($width); ?>%; width: <?php echo esc_attr($width); ?>%;"></div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
+    </div>
+    <?php endif; ?>
+
+    <?php if ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !empty($cons_list))) : ?>
+    <div class="jlg-aio-points">
+        <?php if (!empty($pros_list)) : ?>
+        <div class="jlg-aio-points-col pros">
+            <div class="jlg-aio-points-title">
+                <span class="jlg-aio-points-icon pros">+</span>
+                <span><?php echo esc_html($atts['titre_points_forts']); ?></span>
+            </div>
+            <ul class="jlg-aio-points-list">
+                <?php foreach ($pros_list as $pro) : ?>
+                <li><?php echo esc_html(trim($pro)); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <?php endif; ?>
+
+        <?php if (!empty($cons_list)) : ?>
+        <div class="jlg-aio-points-col cons">
+            <div class="jlg-aio-points-title">
+                <span class="jlg-aio-points-icon cons">−</span>
+                <span><?php echo esc_html($atts['titre_points_faibles']); ?></span>
+            </div>
+            <ul class="jlg-aio-points-list">
+                <?php foreach ($cons_list as $con) : ?>
+                <li><?php echo esc_html(trim($con)); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <?php endif; ?>
+    </div>
+    <?php endif; ?>
+</div>
+
+<?php if ($has_multiple_taglines || !empty($options['enable_animations'])) : ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const block = document.getElementById('<?php echo esc_js($block_id); ?>');
+    if (!block) {
+        return;
+    }
+
+    <?php if ($has_multiple_taglines) : ?>
+    const flags = block.querySelectorAll('.jlg-aio-flag');
+    const taglines = block.querySelectorAll('.jlg-aio-tagline');
+
+    flags.forEach(function(flag) {
+        flag.addEventListener('click', function() {
+            const selectedLang = this.dataset.lang;
+
+            flags.forEach(function(currentFlag) {
+                currentFlag.classList.toggle('active', currentFlag === flag);
+            });
+
+            taglines.forEach(function(tagline) {
+                tagline.style.display = (tagline.dataset.lang === selectedLang) ? 'block' : 'none';
+            });
+        });
+    });
+    <?php endif; ?>
+
+    <?php if (!empty($options['enable_animations'])) : ?>
+    if (block.classList.contains('animate-in')) {
+        const observer = new IntersectionObserver(function(entries, obs) {
+            entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    obs.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.2 });
+
+        observer.observe(block);
+    }
+    <?php endif; ?>
+});
+</script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- extract the all-in-one shortcode styles into a dedicated stylesheet that relies on CSS custom properties
- add a template to render the shortcode markup and per-block behaviour similar to other shortcodes
- refactor the shortcode class to enqueue the stylesheet, prepare dynamic CSS variables, and render the new template while updating template defaults

## Testing
- php -l plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
- php -l plugin-notation-jeux_V4/templates/shortcode-all-in-one.php

------
https://chatgpt.com/codex/tasks/task_e_68cdb940bbfc832eb900d83264d0b3e3