### PR TITLE
Normalize summary sort posts per page handling

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -320,8 +320,27 @@ class JLG_Frontend {
             wp_send_json_error(['message' => esc_html__('Le shortcode requis est indisponible.', 'notation-jlg')], 500);
         }
 
+        $default_atts = JLG_Shortcode_Summary_Display::get_default_atts();
+        $default_posts_per_page = isset($default_atts['posts_per_page']) ? intval($default_atts['posts_per_page']) : 12;
+        if ($default_posts_per_page < 1) {
+            $default_posts_per_page = 1;
+        }
+
+        $posts_per_page_input = isset($_POST['posts_per_page']) ? wp_unslash($_POST['posts_per_page']) : null;
+        $posts_per_page = null;
+
+        if ($posts_per_page_input !== null && !is_array($posts_per_page_input)) {
+            $posts_per_page = intval($posts_per_page_input);
+        }
+
+        if ($posts_per_page === null || $posts_per_page < 1) {
+            $posts_per_page = $default_posts_per_page;
+        }
+
+        $posts_per_page = max(1, min($posts_per_page, 50));
+
         $atts = [
-            'posts_per_page' => isset($_POST['posts_per_page']) ? intval($_POST['posts_per_page']) : 12,
+            'posts_per_page' => $posts_per_page,
             'layout'         => isset($_POST['layout']) ? sanitize_text_field(wp_unslash($_POST['layout'])) : 'table',
             'categorie'      => isset($_POST['categorie']) ? sanitize_text_field(wp_unslash($_POST['categorie'])) : '',
             'colonnes'       => isset($_POST['colonnes']) ? sanitize_text_field(wp_unslash($_POST['colonnes'])) : 'titre,date,note',

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -103,7 +103,7 @@ class JLG_Shortcode_Summary_Display {
         ];
     }
 
-    protected static function get_default_atts() {
+    public static function get_default_atts() {
         return [
             'posts_per_page' => 12,
             'layout'         => 'table',


### PR DESCRIPTION
## Summary
- clamp the summary AJAX posts_per_page parameter to a sane range with shortcode defaults as fallback
- expose the summary shortcode default attributes helper for reuse

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-frontend.php
- php -l plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbd58aa48832eb63f4856eb225a86