### PR TITLE
Handle aborted summary sort requests without showing error

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -141,7 +141,10 @@ jQuery(document).ready(function($) {
             if (shouldUpdateHistory && targetUrl) {
                 updateHistory(targetUrl);
             }
-        }).fail(function() {
+        }).fail(function(_, textStatus) {
+            if (textStatus === 'abort') {
+                return;
+            }
             showError($wrapper, jlgSummarySort.strings.genericError);
         }).always(function() {
             $wrapper.removeClass('jlg-summary-loading');


### PR DESCRIPTION
## Summary
- prevent the generic error message from displaying when a summary sort AJAX request is intentionally aborted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdc85160a0832ebb2e37f210d714db