### PR TITLE
Load plugin textdomain

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -21,6 +21,10 @@ define('JLG_NOTATION_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('JLG_NOTATION_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('JLG_NOTATION_PLUGIN_BASENAME', plugin_basename(__FILE__));
 
+add_action('plugins_loaded', function() {
+    load_plugin_textdomain('notation-jlg', false, dirname(JLG_NOTATION_PLUGIN_BASENAME) . '/languages');
+});
+
 // Vérifications de compatibilité
 if (version_compare(PHP_VERSION, '7.4', '<')) {
     add_action('admin_notices', function() {


### PR DESCRIPTION
## Summary
- load the plugin text domain during the plugins_loaded hook for the Notation JLG plugin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6d7a0cc8832eab96e838f0dd267d