### PR TITLE
Ajoute un fallback pour la note en vue grille

### DIFF
--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -72,9 +72,11 @@ if ($layout === 'grid') :
                 if (empty($cover_url)) {
                     $cover_url = get_the_post_thumbnail_url($post_id, 'medium_large');
                 }
+                /* translators: Abbreviation meaning that the average score is not available. */
+                $score_display = $score ?: __('N/A', 'notation-jlg');
                 ?>
                 <a href="<?php the_permalink(); ?>" class="jlg-game-card">
-                    <div class="jlg-game-card-score"><?php echo esc_html($score); ?></div>
+                    <div class="jlg-game-card-score"><?php echo esc_html($score_display); ?></div>
                     <?php if ($cover_url) : ?>
                         <img src="<?php echo esc_url($cover_url); ?>" alt="<?php the_title_attribute(); ?>" loading="lazy">
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- applique un fallback "N/A" dans la vue grille lorsque la note est absente
- réutilise le domaine de traduction `notation-jlg` pour le texte de remplacement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce743fb49c832e83796f6523f9da15