### PR TITLE
Add fallback handling for missing average scores

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -126,11 +126,11 @@ class JLG_Admin_Menu {
             while ($query->have_posts()) {
                 $query->the_post();
                 $post_id = get_the_ID();
-                $score = get_post_meta($post_id, '_jlg_average_score', true);
+                $score_data = JLG_Helpers::get_resolved_average_score($post_id);
+                $score_value = $score_data['value'];
 
                 $score_color = '#0073aa';
-                if ($score !== '' && is_numeric($score)) {
-                    $score_value = (float) $score;
+                if ($score_value !== null) {
                     if ($score_value >= 8) {
                         $score_color = '#22c55e';
                     } elseif ($score_value >= 5) {
@@ -150,7 +150,7 @@ class JLG_Admin_Menu {
                     'edit_link' => get_edit_post_link($post_id),
                     'view_link' => get_permalink($post_id),
                     'date' => get_the_date('d/m/Y', $post_id),
-                    'score_display' => ($score !== '' && $score !== null) ? $score : 'N/A',
+                    'score_display' => $score_data['formatted'] ?? 'N/A',
                     'score_color' => $score_color,
                     'categories' => $cat_names,
                 ];

--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -162,7 +162,7 @@ class JLG_Helpers {
     public static function get_average_score_for_post($post_id) {
         $total_score = 0;
         $count = 0;
-        
+
         foreach (self::$category_keys as $key) {
             $score = get_post_meta($post_id, '_note_' . $key, true);
             if ($score !== '' && is_numeric($score)) {
@@ -170,8 +170,44 @@ class JLG_Helpers {
                 $count++;
             }
         }
-        
+
         return ($count > 0) ? round($total_score / $count, 1) : null;
+    }
+
+    /**
+     * Retrieve the stored average score, falling back to a computed value when necessary.
+     *
+     * @param int $post_id The post ID.
+     * @return array{value: float|null, formatted: string|null}
+     */
+    public static function get_resolved_average_score($post_id) {
+        $stored_score = get_post_meta($post_id, '_jlg_average_score', true);
+
+        if ($stored_score !== '' && $stored_score !== null && is_numeric($stored_score)) {
+            $score_value = (float) $stored_score;
+
+            return [
+                'value' => $score_value,
+                'formatted' => number_format_i18n($score_value, 1),
+            ];
+        }
+
+        $fallback_score = self::get_average_score_for_post($post_id);
+
+        if ($fallback_score !== null && is_numeric($fallback_score)) {
+            update_post_meta($post_id, '_jlg_average_score', $fallback_score);
+            $fallback_value = (float) $fallback_score;
+
+            return [
+                'value' => $fallback_value,
+                'formatted' => number_format_i18n($fallback_value, 1),
+            ];
+        }
+
+        return [
+            'value' => null,
+            'formatted' => null,
+        ];
     }
 
     public static function get_rating_categories() {

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -67,13 +67,16 @@ if ($layout === 'grid') :
         <?php if ($query instanceof WP_Query && $query->have_posts()) :
             while ($query->have_posts()) : $query->the_post();
                 $post_id = get_the_ID();
-                $score = get_post_meta($post_id, '_jlg_average_score', true);
+                $score_data = JLG_Helpers::get_resolved_average_score($post_id);
                 $cover_url = get_post_meta($post_id, '_jlg_cover_image_url', true);
                 if (empty($cover_url)) {
                     $cover_url = get_the_post_thumbnail_url($post_id, 'medium_large');
                 }
                 /* translators: Abbreviation meaning that the average score is not available. */
-                $score_display = $score ?: __('N/A', 'notation-jlg');
+                $score_display = $score_data['formatted'] ?? '';
+                if ($score_display === '') {
+                    $score_display = __('N/A', 'notation-jlg');
+                }
                 ?>
                 <a href="<?php the_permalink(); ?>" class="jlg-game-card">
                     <div class="jlg-game-card-score"><?php echo esc_html($score_display); ?></div>
@@ -127,9 +130,12 @@ else :
                                         echo esc_html(get_the_date());
                                         break;
                                     case 'note':
-                                        $score = get_post_meta($post_id, '_jlg_average_score', true);
+                                        $score_data = JLG_Helpers::get_resolved_average_score($post_id);
                                         /* translators: Abbreviation meaning that the average score is not available. */
-                                        $score_display = $score ?: __('N/A', 'notation-jlg');
+                                        $score_display = $score_data['formatted'] ?? '';
+                                        if ($score_display === '') {
+                                            $score_display = __('N/A', 'notation-jlg');
+                                        }
                                         echo '<strong>' . esc_html($score_display) . '</strong> ';
                                         printf(
                                             /* translators: %s: Maximum possible rating value. */


### PR DESCRIPTION
## Summary
- add a helper to resolve average scores that recalculates and caches missing values
- use the resolved score when rendering the public summary grid/table
- rely on the resolved score in the admin posts list so colours and sorting use real values

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-helpers.php
- php -l plugin-notation-jeux_V4/templates/summary-table-fragment.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8a1b7404832ea51b44cc09c45681