### PR TITLE
Escape HTTP method output in admin platforms page

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -408,7 +408,7 @@ class JLG_Admin_Platforms {
                         <li>Page actuelle : <?php echo esc_html($_GET['page'] ?? 'non définie'); ?></li>
                         <li>Onglet actuel : <?php echo esc_html($_GET['tab'] ?? 'non défini'); ?></li>
                         <li>URL actuelle : <?php echo esc_url($_SERVER['REQUEST_URI']); ?></li>
-                        <li>Méthode HTTP : <?php echo $_SERVER['REQUEST_METHOD']; ?></li>
+                        <li>Méthode HTTP : <?php echo esc_html($_SERVER['REQUEST_METHOD'] ?? ''); ?></li>
                         <li>Plateformes sauvegardées : <?php echo count(get_option($this->option_name, [])); ?> personnalisées</li>
                         <li>Total plateformes : <?php echo count($platforms); ?></li>
                         <li>Hook admin_init exécuté : <?php echo did_action('admin_init'); ?> fois</li>


### PR DESCRIPTION
## Summary
- escape the HTTP method value displayed in the debug "Informations système" list to prevent unsafe output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9bf6feb0832e83ab960257702986