### PR TITLE
Ensure shortcode renders enqueue frontend assets

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -56,6 +56,16 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
 - `[jlg_tableau_recap]` - Tableau/grille récapitulatif
 
+### Utilisation dans les widgets et blocs
+
+- Les shortcodes du plugin peuvent être insérés dans les widgets classiques (Texte, Code) ou via le bloc **Shortcode** de
+  l'éditeur. Dès qu'un shortcode est exécuté, le plugin déclenche un indicateur global et charge automatiquement les
+  feuilles de styles ainsi que les scripts nécessaires, même lorsque le contenu principal ne contient pas de shortcode ou
+  que la page n'est pas un article classique.
+- Pour vérifier ce comportement, ajoutez par exemple le bloc **Shortcode** dans un gabarit ou un widget de barre latérale
+  avec `[jlg_tableau_recap]`, puis affichez une page ou une archive : les assets `jlg-frontend` et `jlg-user-rating`
+  sont maintenant chargés dès le rendu du bloc, garantissant le même affichage que dans le contenu principal.
+
 ## Installation
 
 1. Téléchargez le plugin et décompressez l'archive

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -53,6 +53,16 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
 * `[jlg_tableau_recap]` - Tableau/grille récapitulatif
 
+== Utilisation dans les widgets et blocs ==
+
+* Les shortcodes du plugin peuvent être insérés dans les widgets classiques (Texte, Code) ou via le bloc **Shortcode** de
+  l'éditeur. Dès que l'un d'eux est exécuté, un indicateur global est levé et déclenche le chargement des feuilles de style
+  et scripts requis, même si la page affichée n'est pas un article singulier ou que le contenu principal ne contient aucun
+  shortcode.
+* Pour valider le comportement, placez par exemple `[jlg_tableau_recap]` dans un widget ou un bloc de barre latérale et
+  affichez une page ou une archive : les assets `jlg-frontend` et `jlg-user-rating` sont chargés automatiquement dès le
+  rendu du widget, assurant la même mise en forme que dans un article.
+
 == Installation ==
 
 1. Téléchargez le plugin et décompressez l'archive

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -275,6 +275,8 @@ class JLG_Shortcode_All_In_One {
 
         $css_variables_string = $this->format_css_variables($css_variables);
 
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-all-in-one', [
             'options' => $options,
             'average_score' => $average_score,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -55,6 +55,8 @@ class JLG_Shortcode_Game_Info {
             return '';
         }
         
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-game-info', [
             'titre'             => sanitize_text_field($atts['titre']),
             'champs_a_afficher' => $data_to_display,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
@@ -21,6 +21,8 @@ class JLG_Shortcode_Pros_Cons {
             return '';
         }
         
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-pros-cons', [
             'pros_list' => !empty($pros) ? array_filter(explode("\n", $pros)) : [],
             'cons_list' => !empty($cons) ? array_filter(explode("\n", $cons)) : [],

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
@@ -35,6 +35,8 @@ class JLG_Shortcode_Rating_Block {
             }
         }
         
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-rating-block', [
             'options'       => JLG_Helpers::get_plugin_options(),
             'average_score' => $average_score,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -21,6 +21,8 @@ class JLG_Shortcode_Summary_Display {
             return $context['message'];
         }
 
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-summary-display', $context);
     }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
@@ -24,6 +24,8 @@ class JLG_Shortcode_Tagline {
             return '';
         }
         
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-tagline', [
             'options' => $options,
             'tagline_fr' => $tagline_fr,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -23,6 +23,8 @@ class JLG_Shortcode_User_Rating {
         $user_ip_hash = $user_ip ? wp_hash($user_ip) : '';
         $has_voted = (is_array($ratings) && $user_ip_hash && isset($ratings[$user_ip_hash]));
 
+        JLG_Frontend::mark_shortcode_rendered();
+
         return JLG_Frontend::get_template_html('shortcode-user-rating', [
             'options' => $options,
             'post_id' => $post_id,


### PR DESCRIPTION
## Summary
- add a global flag in `JLG_Frontend` and hook into `do_shortcode_tag` to detect shortcode rendering and enqueue assets when needed
- update each shortcode handler to mark its execution so assets are loaded even when shortcodes are rendered in widgets or blocks
- document the widget/block usage scenario in both READMEs

## Testing
- `php -l plugin-notation-jeux_V4/includes/class-jlg-frontend.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php`

------
https://chatgpt.com/codex/tasks/task_e_68cf185cdf20832ea8e90878b22bdbc8