### PR TITLE
Ensure average score meta during migration and ordering

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -50,6 +50,12 @@ class JLG_Shortcode_Summary_Display {
         }
 
         $rated_post_ids = JLG_Helpers::get_rated_post_ids();
+
+        if (($orderby === 'average_score' || $orderby === 'note') && !empty($rated_post_ids)) {
+            foreach ($rated_post_ids as $post_id) {
+                JLG_Helpers::get_resolved_average_score($post_id);
+            }
+        }
         if (empty($rated_post_ids)) {
             $no_results = '<p>' . esc_html__('Aucun article noté trouvé.', 'notation-jlg') . '</p>';
 

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -142,9 +142,18 @@ final class JLG_Plugin_De_Notation_Main {
     }
 
     private function migrate_from_v4() {
-        // Les données existantes sont préservées automatiquement
-        // Aucune action requise - rétrocompatibilité totale
-        
+        $rated_post_ids = JLG_Helpers::get_rated_post_ids();
+
+        if (!empty($rated_post_ids) && is_array($rated_post_ids)) {
+            foreach ($rated_post_ids as $post_id) {
+                $post_id = intval($post_id);
+
+                if ($post_id > 0) {
+                    JLG_Helpers::get_resolved_average_score($post_id);
+                }
+            }
+        }
+
         add_option('jlg_migration_v5_completed', current_time('mysql'));
     }
 }


### PR DESCRIPTION
## Summary
- populate the _jlg_average_score meta for all previously rated posts during the v4 to v5 migration
- warm the average score meta before running the summary shortcode query when sorting by rating

## Testing
- php -l plugin-notation-jeux_V4/plugin-notation-jeux.php
- php -l plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php

------
https://chatgpt.com/codex/tasks/task_e_68cf4121b534832e9df9a97d804222c1