### PR TITLE
Secure user rating endpoint for invalid posts

### DIFF
--- a/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FrontendUserRatingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_POST    = [];
+        $_COOKIE  = [];
+        $_SERVER  = [];
+        $GLOBALS['jlg_test_posts']       = [];
+        $GLOBALS['jlg_test_meta']        = [];
+        $GLOBALS['jlg_test_meta_updates'] = [];
+    }
+
+    public function test_handle_user_rating_rejects_unavailable_post(): void
+    {
+        $_POST['token']   = str_repeat('a', 32);
+        $_POST['nonce']   = 'nonce';
+        $_POST['post_id'] = '999';
+        $_POST['rating']  = '5';
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $frontend = new JLG_Frontend();
+
+        try {
+            $frontend->handle_user_rating();
+            $this->fail('Une réponse JSON devait être envoyée.');
+        } catch (WP_Send_Json_Exception $exception) {
+            $this->assertFalse($exception->success);
+            $this->assertSame(404, $exception->status);
+            $this->assertIsArray($exception->data);
+            $this->assertStringContainsString('introuvable', $exception->data['message']);
+        }
+
+        $this->assertSame([], $GLOBALS['jlg_test_meta_updates']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -10,6 +10,18 @@ if (!function_exists('add_action')) {
     }
 }
 
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+        // No-op stub for WordPress filter registration in tests.
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value) {
+        return $value;
+    }
+}
+
 if (!function_exists('register_setting')) {
     function register_setting($option_group, $option_name, $args = []) {
         // No-op stub used during tests.
@@ -40,6 +52,12 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        return $value;
+    }
+}
+
 if (!function_exists('sanitize_hex_color')) {
     function sanitize_hex_color($color) {
         if (!is_string($color)) {
@@ -62,5 +80,116 @@ if (!function_exists('wp_strip_all_tags')) {
     }
 }
 
+if (!function_exists('check_ajax_referer')) {
+    function check_ajax_referer($action, $query_arg = false, $die = true) {
+        return true;
+    }
+}
+
+if (!function_exists('wp_hash')) {
+    function wp_hash($data) {
+        return md5((string) $data);
+    }
+}
+
+if (!function_exists('has_shortcode')) {
+    function has_shortcode($content, $tag) {
+        if (!is_string($content) || $content === '') {
+            return false;
+        }
+
+        return strpos($content, '[' . $tag) !== false;
+    }
+}
+
+if (!class_exists('WP_Post')) {
+    class WP_Post
+    {
+        public function __construct(array $data = [])
+        {
+            foreach ($data as $key => $value) {
+                $this->$key = $value;
+            }
+        }
+    }
+}
+
+if (!function_exists('get_post')) {
+    function get_post($post_id)
+    {
+        $posts = $GLOBALS['jlg_test_posts'] ?? [];
+
+        return $posts[$post_id] ?? null;
+    }
+}
+
+if (!function_exists('get_post_meta')) {
+    function get_post_meta($post_id, $key, $single = false)
+    {
+        $meta = $GLOBALS['jlg_test_meta'] ?? [];
+
+        if (!isset($meta[$post_id][$key])) {
+            return $single ? '' : [];
+        }
+
+        $value = $meta[$post_id][$key];
+
+        if ($single && is_array($value)) {
+            return reset($value);
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('update_post_meta')) {
+    function update_post_meta($post_id, $key, $value)
+    {
+        if (!isset($GLOBALS['jlg_test_meta_updates'])) {
+            $GLOBALS['jlg_test_meta_updates'] = [];
+        }
+
+        $GLOBALS['jlg_test_meta_updates'][] = [
+            'post_id' => $post_id,
+            'key'     => $key,
+            'value'   => $value,
+        ];
+
+        $GLOBALS['jlg_test_meta'][$post_id][$key] = $value;
+
+        return true;
+    }
+}
+
+class WP_Send_Json_Exception extends Exception
+{
+    public $data;
+    public $status;
+    public $success;
+
+    public function __construct($data, $status = null, $success = false)
+    {
+        parent::__construct('JSON response sent.');
+        $this->data    = $data;
+        $this->status  = $status;
+        $this->success = $success;
+    }
+}
+
+if (!function_exists('wp_send_json_error')) {
+    function wp_send_json_error($data = null, $status_code = null)
+    {
+        throw new WP_Send_Json_Exception($data, $status_code, false);
+    }
+}
+
+if (!function_exists('wp_send_json_success')) {
+    function wp_send_json_success($data = null, $status_code = null)
+    {
+        throw new WP_Send_Json_Exception($data, $status_code, true);
+    }
+}
+
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-settings.php';
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';


### PR DESCRIPTION
## Summary
- validate the requested post before updating user rating metadata and bail on trashed, unpublished, or non-post content
- expose a `jlg_post_allows_user_rating` filter with a default shortcode-based check to prevent voting on pages without the feature
- extend the test bootstrap with WordPress stubs and cover the AJAX handler rejection path for invalid post IDs

## Testing
- `cd plugin-notation-jeux_V4 && ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68cfdf7ba2a0832e88bb92f701f276e4