### PR TITLE
Handle malformed platform order input

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -298,10 +298,31 @@ class JLG_Admin_Platforms {
             return ['success' => false, 'message' => 'Données d\'ordre manquantes.'];
         }
 
-        $raw_order = array_filter(wp_unslash($_POST['platform_order']), 'strlen');
+        $raw_order = [];
+
+        foreach ($_POST['platform_order'] as $index => $value) {
+            $unslashed_value = wp_unslash($value);
+
+            if (!is_scalar($unslashed_value)) {
+                self::$debug_messages[] = "⚠️ Valeur non scalaire ignorée pour l'indice $index";
+                continue;
+            }
+
+            if (!is_string($unslashed_value)) {
+                self::$debug_messages[] = "⚠️ Valeur non chaîne ignorée pour l'indice $index";
+                continue;
+            }
+
+            if ($unslashed_value === '') {
+                continue;
+            }
+
+            $raw_order[] = $unslashed_value;
+        }
+
         $submitted_order = array_map(function($value) {
             return sanitize_text_field($value);
-        }, array_values($raw_order));
+        }, $raw_order);
         if (empty($submitted_order)) {
             self::$debug_messages[] = "❌ Ordre soumis vide";
             return ['success' => false, 'message' => 'Ordre soumis invalide.'];

--- a/plugin-notation-jeux_V4/tests/AdminPlatformsOrderTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPlatformsOrderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AdminPlatformsOrderTest extends TestCase
+{
+    private JLG_Admin_Platforms $platforms;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->platforms = new JLG_Admin_Platforms();
+
+        $GLOBALS['jlg_test_options'] = [
+            'jlg_platforms_list' => [
+                'custom-platform' => [
+                    'name'  => 'Custom Platform',
+                    'icon'  => '🎮',
+                    'order' => 99,
+                ],
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($GLOBALS['jlg_test_options'], $_POST['platform_order']);
+    }
+
+    public function test_update_platform_order_handles_malformed_payload(): void
+    {
+        $_POST['platform_order'] = [
+            ['nested' => 'value'],
+            new stdClass(),
+            123,
+        ];
+
+        $platforms = $GLOBALS['jlg_test_options']['jlg_platforms_list'];
+
+        $reflection = new ReflectionClass($this->platforms);
+        $method = $reflection->getMethod('update_platform_order');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($this->platforms, [&$platforms]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame("Ordre soumis invalide.", $result['message']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -58,6 +58,55 @@ if (!function_exists('wp_unslash')) {
     }
 }
 
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        $options = $GLOBALS['jlg_test_options'] ?? [];
+
+        if (array_key_exists($option, $options)) {
+            return $options[$option];
+        }
+
+        return $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($option, $value) {
+        if (!isset($GLOBALS['jlg_test_options'])) {
+            $GLOBALS['jlg_test_options'] = [];
+        }
+
+        $GLOBALS['jlg_test_options'][$option] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($option) {
+        if (isset($GLOBALS['jlg_test_options'][$option])) {
+            unset($GLOBALS['jlg_test_options'][$option]);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($transient, $value, $expiration = 0) {
+        if (!isset($GLOBALS['jlg_test_transients'])) {
+            $GLOBALS['jlg_test_transients'] = [];
+        }
+
+        $GLOBALS['jlg_test_transients'][$transient] = [
+            'value'      => $value,
+            'expiration' => $expiration,
+        ];
+
+        return true;
+    }
+}
+
 if (!function_exists('sanitize_hex_color')) {
     function sanitize_hex_color($color) {
         if (!is_string($color)) {
@@ -193,3 +242,4 @@ if (!function_exists('wp_send_json_success')) {
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-settings.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+require_once __DIR__ . '/../includes/admin/class-jlg-admin-platforms.php';


### PR DESCRIPTION
## Summary
- guard platform order updates against non-string values before sanitization
- extend the test bootstrap with WordPress option and transient stubs needed by admin platform tests
- add a PHPUnit regression test covering malformed platform_order payloads

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d045cc88f0832e94084ff3beef3c1a