### PR TITLE
Sanitize admin AJAX search with wp_unslash and add test

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -42,7 +42,7 @@ class JLG_Admin_Ajax {
             wp_send_json_error('Permissions insuffisantes.');
         }
 
-        $search_term = isset($_POST['search']) ? sanitize_text_field($_POST['search']) : '';
+        $search_term = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
         
         if (empty($search_term)) {
             wp_send_json_error('Terme de recherche vide.');

--- a/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AdminAjaxSearchTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_POST = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = [];
+        parent::tearDown();
+    }
+
+    public function test_handle_rawg_search_accepts_special_characters(): void
+    {
+        $_POST['search'] = addslashes('The "Legend" & Co.');
+        $_POST['nonce'] = 'dummy-nonce';
+
+        $ajax = new JLG_Admin_Ajax();
+
+        try {
+            $ajax->handle_rawg_search();
+            $this->fail('Expected WP_Send_Json_Exception to be thrown.');
+        } catch (WP_Send_Json_Exception $exception) {
+            $this->assertTrue($exception->success);
+            $this->assertArrayHasKey('games', $exception->data);
+            $this->assertIsArray($exception->data['games']);
+            $this->assertNotEmpty($exception->data['games']);
+
+            $game = $exception->data['games'][0];
+
+            $this->assertArrayHasKey('name', $game);
+            $this->assertSame('The "Legend" & Co. - Résultat simulé', $game['name']);
+        }
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -54,7 +54,17 @@ if (!function_exists('sanitize_text_field')) {
 
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value) {
-        return $value;
+        if (is_array($value)) {
+            return array_map('wp_unslash', $value);
+        }
+
+        return is_string($value) ? stripslashes($value) : $value;
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($capability) {
+        return true;
     }
 }
 
@@ -193,3 +203,5 @@ if (!function_exists('wp_send_json_success')) {
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-settings.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+require_once __DIR__ . '/../includes/utils/class-jlg-validator.php';
+require_once __DIR__ . '/../includes/admin/class-jlg-admin-ajax.php';


### PR DESCRIPTION
## Summary
- ensure the admin RAWG search handler unslashes incoming POST data before sanitizing it
- improve the test bootstrap with realistic stubs and required classes for the AJAX handler
- cover the AJAX search with a PHPUnit test verifying that quoted search terms are returned correctly

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d045d15854832eab1bb543aab654ef