### PR TITLE
Stop user ratings when feature disabled

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -353,7 +353,11 @@ class JLG_Frontend {
             wp_send_json_error(['message' => esc_html__('Article introuvable ou non disponible pour la notation.', 'notation-jlg')], 404);
         }
 
-        $allows_user_rating = apply_filters('jlg_post_allows_user_rating', $this->post_allows_user_rating($post), $post);
+        $allows_user_rating = apply_filters(
+            'jlg_post_allows_user_rating',
+            $this->post_allows_user_rating($post, $options),
+            $post
+        );
 
         if (!$allows_user_rating) {
             wp_send_json_error(['message' => esc_html__('La notation des lecteurs est désactivée pour ce contenu.', 'notation-jlg')], 403);
@@ -399,12 +403,14 @@ class JLG_Frontend {
     /**
      * Détermine si un article est éligible aux votes des lecteurs.
      */
-    private function post_allows_user_rating($post) {
+    private function post_allows_user_rating($post, $options = null) {
         if (!($post instanceof WP_Post)) {
             return false;
         }
 
-        $options = JLG_Helpers::get_plugin_options();
+        if (!is_array($options)) {
+            $options = JLG_Helpers::get_plugin_options();
+        }
 
         if (empty($options['user_rating_enabled'])) {
             return false;


### PR DESCRIPTION
## Summary
- stop AJAX rating requests early when the feature is disabled in plugin options
- reuse plugin options inside `post_allows_user_rating` to avoid missing the same validation

## Testing
- composer test *(fails: phpunit not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d057e35e94832eb870a3933b23d428