### PR TITLE
Use number_format_i18n for score outputs

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -171,7 +171,7 @@ function jlg_get_post_rating($post_id = null) {
 function jlg_display_post_rating($post_id = null) {
     $score = jlg_get_post_rating($post_id);
     if ($score !== null) {
-        echo '<span class="jlg-post-rating">' . esc_html(number_format($score, 1)) . '/10</span>';
+        echo '<span class="jlg-post-rating">' . esc_html(number_format_i18n($score, 1)) . '/10</span>';
     }
 }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -47,11 +47,11 @@ $show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !em
         <div class="jlg-aio-main-score">
             <?php if ($score_layout === 'circle'): ?>
             <div class="jlg-aio-score-circle">
-                <div class="jlg-aio-score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+                <div class="jlg-aio-score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
                 <div class="jlg-aio-score-label"><?php echo esc_html__('Note Globale', 'notation-jlg'); ?></div>
             </div>
             <?php else: ?>
-            <div class="jlg-aio-score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+            <div class="jlg-aio-score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
             <div class="jlg-aio-score-label"><?php echo esc_html__('Note Globale', 'notation-jlg'); ?></div>
             <?php endif; ?>
         </div>
@@ -62,7 +62,7 @@ $show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !em
             <div class="jlg-aio-score-item">
                 <div class="jlg-aio-score-header">
                     <span class="jlg-aio-score-label"><?php echo esc_html($categories[$key]); ?></span>
-                    <span class="jlg-aio-score-number"><?php echo esc_html(number_format($score_value, 1, ',', ' ')); ?> / 10</span>
+                    <span class="jlg-aio-score-number"><?php echo esc_html(number_format_i18n($score_value, 1)); ?> / 10</span>
                 </div>
                 <div class="jlg-aio-score-bar-bg">
                     <div class="jlg-aio-score-bar"

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -18,12 +18,12 @@ $options = JLG_Helpers::get_plugin_options();
     <div class="global-score-wrapper">
         <?php if($options['score_layout'] === 'circle'): ?>
             <div class="score-circle">
-                <div class="score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+                <div class="score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
                 <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
             </div>
         <?php else: ?>
             <div class="global-score-text">
-                <div class="score-value"><?php echo esc_html(number_format($average_score, 1, ',', ' ')); ?></div>
+                <div class="score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
                 <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
             </div>
         <?php endif; ?>
@@ -40,7 +40,7 @@ $options = JLG_Helpers::get_plugin_options();
                     <span><?php echo esc_html($categories[$key]); ?></span>
                     <span>
                         <?php
-                        $formatted_score_value = esc_html(number_format($score_value, 1, ',', ' '));
+                        $formatted_score_value = esc_html(number_format_i18n($score_value, 1));
                         printf(
                             /* translators: 1: Rating value for a specific category. 2: Maximum possible rating. */
                             esc_html__('%1$s / %2$s', 'notation-jlg'),

--- a/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
+++ b/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
@@ -27,7 +27,7 @@ $score_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
     position: relative;
     z-index: 10;
 ">
-    <?php echo esc_html(number_format($average_score, 1)); ?>
+    <?php echo esc_html(number_format_i18n($average_score, 1)); ?>
     <span style="font-size: 0.8em; opacity: 0.9;">
         <?php
         printf(

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -28,6 +28,54 @@ if (!function_exists('register_setting')) {
     }
 }
 
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        $options = $GLOBALS['jlg_test_options'] ?? [];
+
+        return $options[$option] ?? $default;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = []) {
+        if (is_object($args)) {
+            $args = get_object_vars($args);
+        }
+
+        if (is_array($args)) {
+            return array_merge($defaults, $args);
+        }
+
+        parse_str((string) $args, $parsed_args);
+
+        return array_merge($defaults, $parsed_args);
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default') {
+        return (string) $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = 'default') {
+        return esc_html(__($text, $domain));
+    }
+}
+
+if (!function_exists('esc_html_e')) {
+    function esc_html_e($text, $domain = 'default') {
+        echo esc_html__($text, $domain);
+    }
+}
+
 if (!function_exists('add_settings_section')) {
     function add_settings_section($id, $title, $callback, $page) {
         // No-op stub used during tests.
@@ -49,6 +97,15 @@ if (!function_exists('sanitize_text_field')) {
         $filtered = filter_var($str, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 
         return is_string($filtered) ? trim($filtered) : '';
+    }
+}
+
+if (!function_exists('number_format_i18n')) {
+    function number_format_i18n($number, $decimals = 0) {
+        $number   = (float) $number;
+        $decimals = (int) $decimals;
+
+        return number_format($number, $decimals, '.', ',');
     }
 }
 


### PR DESCRIPTION
## Summary
- replace manual number_format usage in front-end templates and helper with WordPress number_format_i18n for localized scores
- extend the test bootstrap with WordPress stubs, including number_format_i18n, translation, and option helpers to support the new formatting

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d0585a2cc4832eb14464a2253e1310