### PR TITLE
Localize user rating average formatting

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -395,7 +395,7 @@ class JLG_Frontend {
         update_post_meta($post_id, '_jlg_user_rating_count', count($ratings));
 
         wp_send_json_success([
-            'new_average' => number_format($new_average, 2),
+            'new_average' => number_format_i18n($new_average, 2),
             'new_count' => count($ratings)
         ]);
     }

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) exit;
     <div class="jlg-user-rating-summary">
         <?php
         /* translators: Abbreviation meaning that the user rating is not available. */
-        $average_display = !empty($avg_rating) ? number_format(floatval($avg_rating), 2) : __('N/A', 'notation-jlg');
+        $average_display = !empty($avg_rating) ? number_format_i18n(floatval($avg_rating), 2) : __('N/A', 'notation-jlg');
         $votes_display = !empty($count) ? intval($count) : 0;
         /* translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes. */
         $summary_template = __(


### PR DESCRIPTION
## Summary
- update the user rating shortcode to use `number_format_i18n` so the average respects the site locale
- format the AJAX response average with `number_format_i18n` for consistency between dynamic and static displays

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d14ccec73c832eae7fb84a15f40580