### PR TITLE
Support localized already voted message detection

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -98,6 +98,7 @@ class JLG_Assets {
             return [
                 'successMessage'      => __('Merci pour votre vote !', 'notation-jlg'),
                 'genericErrorMessage' => __('Erreur. Veuillez réessayer.', 'notation-jlg'),
+                'alreadyVotedMessage' => __('Vous avez déjà voté !', 'notation-jlg'),
             ];
         });
 


### PR DESCRIPTION
## Summary
- add the already voted notice to the localized user rating messages
- detect translated already voted notices on the front-end, falling back to wp.i18n and adding generic heuristics

## Testing
- composer test
- node - <<'NODE' …

------
https://chatgpt.com/codex/tasks/task_e_68d14ccd79a4832eb12e83c577eed16b