### PR TITLE
Refactor platform storage and add tests

### DIFF
--- a/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AdminPlatformsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_options'] = [];
+        $GLOBALS['jlg_test_transients'] = [];
+        $_POST = [];
+        $_GET = [];
+
+        $instanceProperty = new ReflectionProperty(JLG_Admin_Platforms::class, 'instance');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null, null);
+
+        $debugProperty = new ReflectionProperty(JLG_Admin_Platforms::class, 'debug_messages');
+        $debugProperty->setAccessible(true);
+        $debugProperty->setValue(null, []);
+    }
+
+    private function invokePrivateMethod($object, string $method, array $args = [])
+    {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($object, $args);
+    }
+
+    private function setDefaultPlatforms(JLG_Admin_Platforms $admin, array $platforms): void
+    {
+        $property = new ReflectionProperty(JLG_Admin_Platforms::class, 'default_platforms');
+        $property->setAccessible(true);
+        $property->setValue($admin, $platforms);
+    }
+
+    public function test_add_platform_persists_custom_definition_and_order(): void
+    {
+        $admin = new JLG_Admin_Platforms();
+
+        $_POST['new_platform_name'] = 'Amiga 500';
+        $_POST['new_platform_icon'] = '🕹️';
+
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $result = $this->invokePrivateMethod($admin, 'add_platform', [&$storage]);
+
+        $this->assertTrue($result['success']);
+
+        $option = get_option('jlg_platforms_list');
+        $this->assertArrayHasKey('custom_platforms', $option);
+        $this->assertArrayHasKey('amiga-500', $option['custom_platforms']);
+        $this->assertSame('Amiga 500', $option['custom_platforms']['amiga-500']['name']);
+        $this->assertSame('🕹️', $option['custom_platforms']['amiga-500']['icon']);
+        $this->assertArrayHasKey('order', $option);
+        $this->assertArrayHasKey('amiga-500', $option['order']);
+
+        $platforms = $admin->get_platforms();
+        $this->assertArrayHasKey('amiga-500', $platforms);
+        $this->assertSame('Amiga 500', $platforms['amiga-500']['name']);
+        $this->assertSame($option['order']['amiga-500'], $platforms['amiga-500']['order']);
+    }
+
+    public function test_delete_platform_removes_custom_definition_and_order(): void
+    {
+        $admin = new JLG_Admin_Platforms();
+
+        $_POST['new_platform_name'] = 'Amiga 500';
+        $_POST['new_platform_icon'] = '🕹️';
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $this->invokePrivateMethod($admin, 'add_platform', [&$storage]);
+
+        $_POST = ['platform_key' => 'amiga-500'];
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $result = $this->invokePrivateMethod($admin, 'delete_platform', [&$storage]);
+
+        $this->assertTrue($result['success']);
+
+        $option = get_option('jlg_platforms_list');
+        $this->assertArrayNotHasKey('amiga-500', $option['custom_platforms'] ?? []);
+        $this->assertArrayNotHasKey('amiga-500', $option['order'] ?? []);
+    }
+
+    public function test_update_platform_order_saves_only_order_map(): void
+    {
+        $admin = new JLG_Admin_Platforms();
+
+        $_POST['new_platform_name'] = 'Amiga 500';
+        $_POST['new_platform_icon'] = '🕹️';
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $this->invokePrivateMethod($admin, 'add_platform', [&$storage]);
+
+        $_POST = [
+            'platform_order' => ['playstation-5', 'pc', 'amiga-500'],
+        ];
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $result = $this->invokePrivateMethod($admin, 'update_platform_order', [&$storage]);
+
+        $this->assertTrue($result['success']);
+
+        $option = get_option('jlg_platforms_list');
+        $this->assertArrayHasKey('custom_platforms', $option);
+        $this->assertArrayHasKey('amiga-500', $option['custom_platforms']);
+        $this->assertArrayNotHasKey('pc', $option['custom_platforms']);
+        $this->assertSame(1, $option['order']['playstation-5']);
+        $this->assertSame(2, $option['order']['pc']);
+        $this->assertSame(3, $option['order']['amiga-500']);
+
+        $platforms = $admin->get_platforms();
+        $this->assertSame('PC', $platforms['pc']['name']);
+    }
+
+    public function test_reordered_platforms_reflect_updated_default_definitions(): void
+    {
+        update_option('jlg_platforms_list', [
+            'custom_platforms' => [],
+            'order' => [
+                'playstation-5' => 1,
+                'pc' => 2,
+            ],
+        ]);
+
+        $admin = new JLG_Admin_Platforms();
+
+        $this->setDefaultPlatforms($admin, [
+            'pc' => ['name' => 'PC Nouveau', 'icon' => '🖥️', 'order' => 2, 'custom' => false],
+            'playstation-5' => ['name' => 'PlayStation 5', 'icon' => '🕹️', 'order' => 1, 'custom' => false],
+            'mega-drive' => ['name' => 'Mega Drive', 'icon' => '🕹️', 'order' => 3, 'custom' => false],
+        ]);
+
+        $platforms = $admin->get_platforms();
+
+        $this->assertSame(['playstation-5', 'pc', 'mega-drive'], array_slice(array_keys($platforms), 0, 3));
+        $this->assertSame('PC Nouveau', $platforms['pc']['name']);
+        $this->assertSame('🕹️', $platforms['playstation-5']['icon']);
+        $this->assertArrayHasKey('mega-drive', $platforms);
+        $this->assertFalse($platforms['mega-drive']['custom']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -66,6 +66,56 @@ if (!function_exists('get_option')) {
     }
 }
 
+if (!function_exists('update_option')) {
+    function update_option($option, $value) {
+        if (!isset($GLOBALS['jlg_test_options'])) {
+            $GLOBALS['jlg_test_options'] = [];
+        }
+
+        $GLOBALS['jlg_test_options'][$option] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($option) {
+        if (isset($GLOBALS['jlg_test_options'][$option])) {
+            unset($GLOBALS['jlg_test_options'][$option]);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($transient, $value, $expiration = 0) {
+        if (!isset($GLOBALS['jlg_test_transients'])) {
+            $GLOBALS['jlg_test_transients'] = [];
+        }
+
+        $GLOBALS['jlg_test_transients'][$transient] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient($transient) {
+        return $GLOBALS['jlg_test_transients'][$transient] ?? false;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($transient) {
+        if (isset($GLOBALS['jlg_test_transients'][$transient])) {
+            unset($GLOBALS['jlg_test_transients'][$transient]);
+        }
+
+        return true;
+    }
+}
+
 if (!function_exists('wp_parse_args')) {
     function wp_parse_args($args, $defaults = []) {
         if (is_object($args)) {
@@ -130,6 +180,16 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('sanitize_title')) {
+    function sanitize_title($title) {
+        $title = strtolower((string) $title);
+        $title = preg_replace('/[^a-z0-9\s-]/', '', $title);
+        $title = preg_replace('/[\s-]+/', '-', $title);
+
+        return trim($title, '-');
+    }
+}
+
 if (!function_exists('number_format_i18n')) {
     function number_format_i18n($number, $decimals = 0) {
         $number   = (float) $number;
@@ -146,6 +206,18 @@ if (!function_exists('wp_unslash')) {
         }
 
         return is_string($value) ? stripslashes($value) : $value;
+    }
+}
+
+if (!function_exists('wp_verify_nonce')) {
+    function wp_verify_nonce($nonce, $action = -1) {
+        return true;
+    }
+}
+
+if (!function_exists('wp_die')) {
+    function wp_die($message = '') {
+        throw new RuntimeException((string) $message);
     }
 }
 
@@ -363,6 +435,7 @@ if (!function_exists('wp_send_json_success')) {
 
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-settings.php';
+require_once __DIR__ . '/../includes/admin/class-jlg-admin-platforms.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
 require_once __DIR__ . '/../includes/utils/class-jlg-validator.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-ajax.php';


### PR DESCRIPTION
## Summary
- refactor platform persistence to store custom definitions separately from order metadata while always using code-defined defaults
- update the admin platforms workflow to write only order maps and keep debug information accurate
- extend the PHPUnit bootstrap with required stubs and add coverage for adding, deleting, reordering and default updates of platforms

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1813e1e00832e810704a905d52ee6