### PR TITLE
Escape widget title output

### DIFF
--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit;
 echo $widget_args['before_widget'];
 
 if (!empty($title)) {
-    echo $widget_args['before_title'] . $title . $widget_args['after_title'];
+    echo $widget_args['before_title'] . esc_html($title) . $widget_args['after_title'];
 }
 
 if ($latest_reviews->have_posts()) {


### PR DESCRIPTION
## Summary
- escape the Latest Reviews widget title output with esc_html to prevent unescaped HTML

## Testing
- php -l plugin-notation-jeux_V4/templates/widget-latest-reviews.php

------
https://chatgpt.com/codex/tasks/task_e_68d1813c3fe4832e93dd495adc7973bd