### PR TITLE
Adjust all-in-one animations priority handling

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -103,7 +103,7 @@
     line-height: 1;
     margin-bottom: 8px;
     text-shadow: var(--jlg-aio-text-shadow, none);
-    animation: var(--jlg-aio-text-animation, none);
+    animation: var(--jlg-aio-text-animation, none) !important;
 }
 
 .jlg-aio-score-circle {
@@ -118,7 +118,7 @@
     background: var(--jlg-aio-circle-bg, transparent);
     box-shadow: var(--jlg-aio-circle-shadow, none);
     border: var(--jlg-aio-circle-border, none);
-    animation: var(--jlg-aio-circle-animation, none);
+    animation: var(--jlg-aio-circle-animation, none) !important;
 }
 
 .jlg-aio-score-circle .jlg-aio-score-value {

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -223,7 +223,7 @@ class JLG_Shortcode_All_In_One {
                 $css_variables['--jlg-aio-text-glow-ps1'] = $ps1 . 'px';
                 $css_variables['--jlg-aio-text-glow-ps2'] = $ps2 . 'px';
                 $css_variables['--jlg-aio-text-glow-ps3'] = $ps3 . 'px';
-                $css_variables['--jlg-aio-text-animation'] = 'jlg-aio-text-glow-pulse ' . $speed . 's infinite ease-in-out !important';
+                $css_variables['--jlg-aio-text-animation'] = 'jlg-aio-text-glow-pulse ' . $speed . 's infinite ease-in-out';
             }
         } elseif ($score_layout === 'circle' && !empty($options['circle_glow_enabled'])) {
             $glow_mode = isset($options['circle_glow_color_mode']) ? $options['circle_glow_color_mode'] : 'dynamic';
@@ -266,7 +266,7 @@ class JLG_Shortcode_All_In_One {
                 $css_variables['--jlg-aio-circle-glow-ps1'] = $ps1 . 'px';
                 $css_variables['--jlg-aio-circle-glow-ps2'] = $ps2 . 'px';
                 $css_variables['--jlg-aio-circle-glow-ps3'] = $ps3 . 'px';
-                $css_variables['--jlg-aio-circle-animation'] = 'jlg-aio-circle-glow-pulse ' . $speed . 's infinite ease-in-out !important';
+                $css_variables['--jlg-aio-circle-animation'] = 'jlg-aio-circle-glow-pulse ' . $speed . 's infinite ease-in-out';
             }
         }
 


### PR DESCRIPTION
## Summary
- remove `!important` from the animation variable definitions in the all-in-one shortcode
- apply `!important` to the animation properties in the all-in-one stylesheet to keep high priority

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b2443808832eb54de07b0cdfc4c3