### PR TITLE
Allow overriding game titles across frontend outputs

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -25,6 +25,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 - **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
 - **Notation utilisateurs** : Permettez à vos lecteurs de voter
 - **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage
+- **Nom de jeu personnalisé** : Remplacez le titre WordPress dans les tableaux, widgets et données structurées
 - **Widget** : Affichez vos derniers tests notés
 - **API RAWG** : Remplissage automatique des informations de jeu
 - **SEO optimisé** : Support schema.org pour les rich snippets Google
@@ -44,6 +45,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 - La **date de sortie** est vérifiée avec `DateTime::createFromFormat('Y-m-d')`. Une valeur invalide est rejetée, la méta correspondante est supprimée et une alerte d'administration liste les erreurs détectées.
 - Le champ **PEGI** n'accepte que les mentions officielles `PEGI 3`, `PEGI 7`, `PEGI 12`, `PEGI 16` et `PEGI 18`. Toute autre valeur est ignorée et signalée via la même notice.
+- Le champ **Nom du jeu** est nettoyé (espaces superflus, longueur maximale) avant sauvegarde pour garantir un affichage cohérent.
 - Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
 
 ### Shortcodes disponibles

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -22,6 +22,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 * **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
 * **Notation utilisateurs** : Permettez à vos lecteurs de voter
 * **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage
+* **Nom de jeu personnalisé** : Remplacez le titre WordPress dans les tableaux, widgets et données structurées
 * **Widget** : Affichez vos derniers tests notés
 * **API RAWG** : Remplissage automatique des informations de jeu
 * **SEO optimisé** : Support schema.org pour les rich snippets Google
@@ -41,6 +42,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 * La **date de sortie** est vérifiée avec `DateTime::createFromFormat('Y-m-d')`. Une valeur invalide est rejetée, la méta concernée est supprimée et une notice d'administration affiche les erreurs repérées.
 * Le champ **PEGI** n'accepte que les mentions officielles `PEGI 3`, `PEGI 7`, `PEGI 12`, `PEGI 16` et `PEGI 18`. Toute autre valeur est ignorée et signalée via la même notice.
+* Le champ **Nom du jeu** est normalisé (espaces superflus, longueur maximale) avant sauvegarde pour garantir un affichage homogène.
 * Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
 
 = Shortcodes disponibles =

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -146,7 +146,7 @@ class JLG_Admin_Menu {
                 }, $categories);
 
                 $posts[] = [
-                    'title' => get_the_title(),
+                    'title' => JLG_Helpers::get_game_title($post_id),
                     'edit_link' => get_edit_post_link($post_id),
                     'view_link' => get_permalink($post_id),
                     'date' => get_the_date('d/m/Y', $post_id),

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -116,17 +116,23 @@ class JLG_Admin_Metaboxes {
         
         // Récupérer les métadonnées
         $meta = [];
-        $keys = ['tagline_fr', 'tagline_en', 'points_forts', 'points_faibles', 'developpeur', 'editeur', 'date_sortie', 'version', 'pegi', 'temps_de_jeu', 'plateformes', 'cover_image_url'];
+        $keys = ['game_title', 'tagline_fr', 'tagline_en', 'points_forts', 'points_faibles', 'developpeur', 'editeur', 'date_sortie', 'version', 'pegi', 'temps_de_jeu', 'plateformes', 'cover_image_url'];
         foreach ($keys as $key) {
             $meta[$key] = get_post_meta($post->ID, '_jlg_' . $key, true);
         }
-        
+
         echo '<div class="jlg-metabox-details">';
-        
+
+        echo '<div style="margin-bottom:20px;">';
+        echo '<label for="jlg_game_title"><strong>' . esc_html__('Nom du jeu', 'notation-jlg') . ' :</strong></label><br>';
+        echo '<input type="text" id="jlg_game_title" name="jlg_game_title" value="' . esc_attr($meta['game_title'] ?? '') . '" style="width:100%;">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__('Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée.', 'notation-jlg') . '</p>';
+        echo '</div>';
+
         // Fiche technique
         echo '<h3>📋 Fiche Technique</h3>';
         echo '<div style="display:grid; grid-template-columns:repeat(3,1fr); gap:15px; margin-bottom:20px;">';
-        
+
         $fields = [
             'developpeur' => 'Développeur(s)',
             'editeur' => 'Éditeur(s)',
@@ -254,6 +260,7 @@ class JLG_Admin_Metaboxes {
         if (isset($_POST['jlg_details_nonce']) && wp_verify_nonce($_POST['jlg_details_nonce'], 'jlg_save_details_data')) {
             // Champs texte simples
             $text_fields = [
+                'game_title' => __('Nom du jeu', 'notation-jlg'),
                 'developpeur' => __('Développeur(s)', 'notation-jlg'),
                 'editeur' => __('Éditeur(s)', 'notation-jlg'),
                 'date_sortie' => __('Date de sortie', 'notation-jlg'),
@@ -265,6 +272,13 @@ class JLG_Admin_Metaboxes {
                 if (isset($_POST['jlg_' . $field])) {
                     $raw_value = wp_unslash($_POST['jlg_' . $field]);
                     $value = sanitize_text_field($raw_value);
+                    if ($field === 'game_title' && $value !== '') {
+                        if (function_exists('mb_substr')) {
+                            $value = mb_substr($value, 0, 150);
+                        } else {
+                            $value = substr($value, 0, 150);
+                        }
+                    }
                     if ($value === '') {
                         delete_post_meta($post_id, '_jlg_' . $field);
                         continue;

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -553,7 +553,7 @@ class JLG_Frontend {
         $schema = [
             '@context'      => 'https://schema.org',
             '@type'         => 'Game',
-            'name'          => get_the_title($post_id),
+            'name'          => JLG_Helpers::get_game_title($post_id),
             'review'        => [
                 '@type'         => 'Review',
                 'reviewRating'  => [

--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -129,6 +129,39 @@ class JLG_Helpers {
         return wp_parse_args($saved_options, $defaults);
     }
 
+    /**
+     * Retrieve the preferred title for a review.
+     *
+     * @param int $post_id The post identifier.
+     * @return string The stored game title if available, otherwise the WordPress post title.
+     */
+    public static function get_game_title($post_id) {
+        $post_id = (int) $post_id;
+
+        if ($post_id <= 0) {
+            return '';
+        }
+
+        $raw_meta_title = get_post_meta($post_id, '_jlg_game_title', true);
+        $resolved_title = '';
+
+        if (is_string($raw_meta_title)) {
+            $meta_title = sanitize_text_field($raw_meta_title);
+            if ($meta_title !== '') {
+                $resolved_title = $meta_title;
+            }
+        }
+
+        if ($resolved_title === '') {
+            $fallback_title = get_the_title($post_id);
+            if (is_string($fallback_title)) {
+                $resolved_title = $fallback_title;
+            }
+        }
+
+        return apply_filters('jlg_game_title', (string) $resolved_title, $post_id, $raw_meta_title);
+    }
+
     public static function get_color_palette() {
         $options = self::get_plugin_options();
         $theme = $options['visual_theme'] ?? 'dark';

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -68,6 +68,7 @@ if ($layout === 'grid') :
         <?php if ($query instanceof WP_Query && $query->have_posts()) :
             while ($query->have_posts()) : $query->the_post();
                 $post_id = get_the_ID();
+                $game_title = JLG_Helpers::get_game_title($post_id);
                 $score_data = JLG_Helpers::get_resolved_average_score($post_id);
                 $cover_url = get_post_meta($post_id, '_jlg_cover_image_url', true);
                 if (empty($cover_url)) {
@@ -82,10 +83,10 @@ if ($layout === 'grid') :
                 <a href="<?php the_permalink(); ?>" class="jlg-game-card">
                     <div class="jlg-game-card-score"><?php echo esc_html($score_display); ?></div>
                     <?php if ($cover_url) : ?>
-                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php the_title_attribute(); ?>" loading="lazy">
+                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php echo esc_attr($game_title); ?>" loading="lazy">
                     <?php endif; ?>
                     <div class="jlg-game-card-title">
-                        <span><?php the_title(); ?></span>
+                        <span><?php echo esc_html($game_title); ?></span>
                     </div>
                 </a>
             <?php endwhile;
@@ -125,7 +126,8 @@ else :
 
                                 switch ($col) {
                                     case 'titre':
-                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html(get_the_title()) . '</a>';
+                                        $game_title = JLG_Helpers::get_game_title($post_id);
+                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a>';
                                         break;
                                     case 'date':
                                         echo esc_html(get_the_date());

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -11,7 +11,9 @@ if ($latest_reviews->have_posts()) {
     echo '<ul>';
     while ($latest_reviews->have_posts()) {
         $latest_reviews->the_post();
-        echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></li>';
+        $post_id = get_the_ID();
+        $game_title = JLG_Helpers::get_game_title($post_id);
+        echo '<li><a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a></li>';
     }
     echo '</ul>';
 } else {

--- a/plugin-notation-jeux_V4/tests/HelpersGameTitleTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersGameTitleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersGameTitleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+    }
+
+    public function test_returns_custom_game_title_when_meta_present(): void
+    {
+        $post_id = 42;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_game_title'] = '  Custom Game Title  ';
+
+        $this->assertSame('Custom Game Title', JLG_Helpers::get_game_title($post_id));
+    }
+
+    public function test_falls_back_to_wordpress_title_when_meta_missing(): void
+    {
+        $post_id = 101;
+        $GLOBALS['jlg_test_posts'][$post_id] = (object) [
+            'ID' => $post_id,
+            'post_title' => 'Original WP Title',
+        ];
+
+        $this->assertSame('Original WP Title', JLG_Helpers::get_game_title($post_id));
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -40,6 +40,39 @@ if (!function_exists('get_the_ID')) {
     }
 }
 
+if (!function_exists('get_the_title')) {
+    function get_the_title($post = 0) {
+        if (is_object($post) && isset($post->post_title)) {
+            return (string) $post->post_title;
+        }
+
+        if (is_array($post) && isset($post['post_title'])) {
+            return (string) $post['post_title'];
+        }
+
+        $post_id = (int) $post;
+        if ($post_id <= 0) {
+            return '';
+        }
+
+        $posts = $GLOBALS['jlg_test_posts'] ?? [];
+
+        if (isset($posts[$post_id])) {
+            $stored_post = $posts[$post_id];
+
+            if (is_object($stored_post) && isset($stored_post->post_title)) {
+                return (string) $stored_post->post_title;
+            }
+
+            if (is_array($stored_post) && isset($stored_post['post_title'])) {
+                return (string) $stored_post['post_title'];
+            }
+        }
+
+        return '';
+    }
+}
+
 if (!function_exists('add_filter')) {
     function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
         // No-op stub for WordPress filter registration in tests.


### PR DESCRIPTION
## Summary
- add a "Nom du jeu" field to the review details metabox and persist the `_jlg_game_title` meta with sanitisation
- expose `JLG_Helpers::get_game_title()` and use it everywhere titles are rendered (summary table, widget, admin list, schema)
- document the new metadata and cover it with dedicated unit tests

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1b648a170832eb515bcbf24a9f3f6