### PR TITLE
Enable sorting by metadata in summary shortcode

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -56,7 +56,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 - `[jlg_points_forts_faibles]` - Points positifs et négatifs
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
-- `[jlg_tableau_recap]` - Tableau/grille récapitulatif
+- `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les en-têtes permettent désormais de trier par titre, date, note moyenne ainsi que par métadonnées développeur/éditeur via les paramètres `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
 
 ### Utilisation dans les widgets et blocs
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -53,7 +53,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 * `[jlg_points_forts_faibles]` - Points positifs et négatifs
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
-* `[jlg_tableau_recap]` - Tableau/grille récapitulatif
+* `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les entêtes sont triables par titre, date, note moyenne et métadonnées développeur/éditeur via `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
 
 == Utilisation dans les widgets et blocs ==
 

--- a/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
@@ -130,6 +130,8 @@ if (!defined('ABSPATH')) exit;
             <li><strong>editeur</strong> : Éditeur</li>
         </ul>
 
+        <p><strong>Tri :</strong> les en-têtes sont cliquables pour ordonner les résultats par titre (`orderby=title`), date (`orderby=date`), note moyenne (`orderby=average_score`) ainsi que par métadonnées développeur ou éditeur (`orderby=meta__jlg_developpeur`, `orderby=meta__jlg_editeur`).</p>
+
         <h4>Exemples :</h4>
         <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
 [jlg_tableau_recap]

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -32,7 +32,14 @@ if (!function_exists('jlg_print_sortable_header')) {
             return;
         }
 
-        $sort_key = isset($col_info['key']) ? $col_info['key'] : $col;
+        $sort_key = $col;
+        if (isset($col_info['sort']['key'])) {
+            $sort_key = $col_info['sort']['key'];
+        } elseif (isset($col_info['key'])) {
+            $sort_key = $col_info['key'];
+        }
+
+        $sort_key = sanitize_key($sort_key);
         $new_order = ($current_orderby === $sort_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
         $url = add_query_arg([
             'orderby' => $sort_key,
@@ -45,14 +52,24 @@ if (!function_exists('jlg_print_sortable_header')) {
         }
 
         $indicator = '';
-        if ($current_orderby === $sort_key || $current_orderby === $col) {
+        $is_active = ($current_orderby === $sort_key || $current_orderby === $col);
+        if (!$is_active && isset($col_info['sort']['aliases']) && is_array($col_info['sort']['aliases'])) {
+            foreach ($col_info['sort']['aliases'] as $alias) {
+                if ($current_orderby === sanitize_key($alias)) {
+                    $is_active = true;
+                    break;
+                }
+            }
+        }
+
+        if ($is_active) {
             $indicator = $current_order === 'ASC'
                 ? esc_html__(' ▲', 'notation-jlg')
                 : esc_html__(' ▼', 'notation-jlg');
         }
 
         $class = 'sortable';
-        if ($current_orderby === $sort_key || $current_orderby === $col) {
+        if ($is_active) {
             $class .= ' sorted ' . strtolower($current_order);
         }
 

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('WP_Query')) {
+    class WP_Query
+    {
+        public $args;
+        public $max_num_pages = 1;
+
+        public function __construct($args = [])
+        {
+            $this->args = $args;
+        }
+
+        public function have_posts()
+        {
+            return false;
+        }
+
+        public function the_post()
+        {
+            // No-op in tests.
+        }
+    }
+}
+
+if (!function_exists('get_posts')) {
+    function get_posts($args)
+    {
+        return [];
+    }
+}
+
+if (!function_exists('get_query_var')) {
+    function get_query_var($var, $default = 0)
+    {
+        return $default;
+    }
+}
+
+if (!function_exists('add_query_arg')) {
+    function add_query_arg($args, $url = '')
+    {
+        $base = $url === '' ? 'https://example.com/' : $url;
+        $query = http_build_query($args);
+
+        return $base . (strpos($base, '?') === false ? '?' : '&') . $query;
+    }
+}
+
+if (!function_exists('remove_query_arg')) {
+    function remove_query_arg($key, $url)
+    {
+        return $url;
+    }
+}
+
+if (!function_exists('paginate_links')) {
+    function paginate_links($args = [])
+    {
+        return '';
+    }
+}
+
+if (!function_exists('get_pagenum_link')) {
+    function get_pagenum_link($id)
+    {
+        return 'https://example.com/page/' . (int) $id;
+    }
+}
+
+class ShortcodeSummarySortingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['wpdb'] = new class {
+            public $postmeta = 'wp_postmeta';
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_col($query)
+            {
+                return [101, 202];
+            }
+        };
+
+        $GLOBALS['jlg_test_meta'] = [
+            101 => [
+                '_note_cat1' => 8,
+                '_jlg_developpeur' => 'Studio A',
+                '_jlg_editeur' => 'Publisher A',
+            ],
+            202 => [
+                '_note_cat1' => 6,
+                '_jlg_developpeur' => 'Studio B',
+                '_jlg_editeur' => 'Publisher B',
+            ],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb'], $GLOBALS['jlg_test_meta']);
+        parent::tearDown();
+    }
+
+    public function test_sorting_by_developer_uses_meta_arguments()
+    {
+        $context = JLG_Shortcode_Summary_Display::get_render_context([], [
+            'orderby' => 'meta__jlg_developpeur',
+            'order'   => 'ASC',
+        ]);
+
+        $this->assertInstanceOf(WP_Query::class, $context['query']);
+        $this->assertSame('meta_value', $context['query']->args['orderby']);
+        $this->assertSame('_jlg_developpeur', $context['query']->args['meta_key']);
+        $this->assertSame('CHAR', $context['query']->args['meta_type']);
+        $this->assertSame('meta__jlg_developpeur', $context['orderby']);
+        $this->assertSame('ASC', $context['order']);
+    }
+
+    public function test_sorting_alias_for_note_maps_to_average_score_meta()
+    {
+        $context = JLG_Shortcode_Summary_Display::get_render_context([], [
+            'orderby' => 'note',
+        ]);
+
+        $this->assertInstanceOf(WP_Query::class, $context['query']);
+        $this->assertSame('meta_value_num', $context['query']->args['orderby']);
+        $this->assertSame('_jlg_average_score', $context['query']->args['meta_key']);
+        $this->assertSame('meta_value_num', $context['query']->args['orderby']);
+        $this->assertSame('average_score', $context['orderby']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -213,6 +213,19 @@ if (!function_exists('sanitize_text_field')) {
     }
 }
 
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        if (!is_string($key)) {
+            return '';
+        }
+
+        $key = strtolower($key);
+        $key = preg_replace('/[^a-z0-9_]/', '', $key);
+
+        return (string) $key;
+    }
+}
+
 if (!function_exists('sanitize_title')) {
     function sanitize_title($title) {
         $title = strtolower((string) $title);
@@ -220,6 +233,22 @@ if (!function_exists('sanitize_title')) {
         $title = preg_replace('/[\s-]+/', '-', $title);
 
         return trim($title, '-');
+    }
+}
+
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($class, $fallback = '') {
+        if (!is_string($class)) {
+            $class = '';
+        }
+
+        $sanitized = preg_replace('/[^A-Za-z0-9_-]/', '', $class);
+
+        if ($sanitized === '' && $fallback !== '') {
+            return sanitize_html_class($fallback);
+        }
+
+        return $sanitized;
     }
 }
 
@@ -472,3 +501,4 @@ require_once __DIR__ . '/../includes/admin/class-jlg-admin-platforms.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
 require_once __DIR__ . '/../includes/utils/class-jlg-validator.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-ajax.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-summary-display.php';


### PR DESCRIPTION
## Summary
- allow the summary shortcode to describe sortable meta columns and resolve the proper WP_Query arguments
- update the summary table template and documentation so new orderby keys drive developer/publisher sorting
- add PHPUnit coverage and supporting stubs to exercise the enriched sorting behaviour

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d1b86b521c832ea81d57f876dfec94