### PR TITLE
Use persistent tokens for user ratings

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -18,10 +18,7 @@ class JLG_Shortcode_User_Rating {
         }
 
         $post_id = get_the_ID();
-        $ratings = get_post_meta($post_id, '_jlg_user_ratings', true);
-        $user_ip = isset($_SERVER['REMOTE_ADDR']) ? filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP) : false;
-        $user_ip_hash = $user_ip ? wp_hash($user_ip) : '';
-        $has_voted = (is_array($ratings) && $user_ip_hash && isset($ratings[$user_ip_hash]));
+        list($has_voted, $user_vote) = JLG_Frontend::get_user_vote_for_post($post_id);
 
         JLG_Frontend::mark_shortcode_rendered();
 
@@ -31,7 +28,7 @@ class JLG_Shortcode_User_Rating {
             'avg_rating' => get_post_meta($post_id, '_jlg_user_rating_avg', true),
             'count' => get_post_meta($post_id, '_jlg_user_rating_count', true),
             'has_voted' => $has_voted,
-            'user_vote' => $has_voted ? $ratings[$user_ip_hash] : 0
+            'user_vote' => $user_vote
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- switch the user rating storage to keyed hashes of the persistent token instead of IP addresses
- migrate legacy IP-keyed ratings, keep an auxiliary IP log, and recalculate stats from token-based entries
- expose helpers so the shortcode checks vote status with the token cookie

## Testing
- `composer test` *(fails: phpunit: not found)*
- `php -l includes/class-jlg-frontend.php`
- `php -l includes/shortcodes/class-jlg-shortcode-user-rating.php`


------
https://chatgpt.com/codex/tasks/task_e_68d25db0568c832ea56bb18915dc6709