### PR TITLE
Ajout de redirection après actions plateformes

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -217,6 +217,17 @@ class JLG_Admin_Platforms {
         $action = $sanitized_action;
         $platforms = $this->get_stored_platform_data();
         self::$debug_messages[] = "📦 Plateformes actuelles dans la DB : " . count($platforms['custom_platforms']) . " personnalisées";
+
+        $redirect_args = [
+            'page' => 'notation_jlg_settings',
+            'tab' => 'plateformes',
+        ];
+
+        if (isset($_GET['debug'])) {
+            $redirect_args['debug'] = sanitize_text_field(wp_unslash($_GET['debug']));
+        }
+
+        $redirect_url = add_query_arg($redirect_args, admin_url('admin.php'));
         
         $success = false;
         $message = '';
@@ -256,9 +267,12 @@ class JLG_Admin_Platforms {
             set_transient('jlg_platforms_message', ['type' => 'error', 'message' => $message], 30);
             self::$debug_messages[] = "❌ Erreur : " . $message;
         }
-        
+
         // Stocker les messages de debug dans un transient
         set_transient('jlg_platforms_debug', self::$debug_messages, 60);
+
+        wp_safe_redirect($redirect_url);
+        exit;
     }
     
     /**


### PR DESCRIPTION
## Summary
- construites des paramètres de redirection vers l'onglet plateformes tout en conservant le drapeau de debug
- déclenchée une redirection sécurisée immédiatement après l'enregistrement du message flash pour éviter la répétition des requêtes POST

## Testing
- non effectué (environnement WordPress non disponible)


------
https://chatgpt.com/codex/tasks/task_e_68d27cbd526c832e91405ce63e2f2658