### PR TITLE
I18n admin UI strings and update POT

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -17,8 +17,8 @@ class JLG_Admin_Menu {
 
     public function add_admin_menu() {
         add_menu_page(
-            'Notation JLG',
-            'Notation - JLG',
+            _x('Notation JLG', 'Admin page title', 'notation-jlg'),
+            _x('Notation - JLG', 'Admin menu title', 'notation-jlg'),
             'manage_options',
             $this->page_slug,
             [$this, 'render_admin_page'],
@@ -29,7 +29,7 @@ class JLG_Admin_Menu {
 
     public function render_admin_page() {
         if (!current_user_can('manage_options')) {
-            wp_die('Accès refusé.');
+            wp_die(esc_html__('Accès refusé.', 'notation-jlg'));
         }
 
         $tabs = $this->get_tabs();
@@ -42,7 +42,7 @@ class JLG_Admin_Menu {
         $tab_content = $this->get_tab_content($active_tab);
 
         JLG_Template_Loader::display_admin_template('admin-page', [
-            'page_title' => '⭐ Notation JLG v5.0',
+            'page_title' => __('⭐ Notation JLG v5.0', 'notation-jlg'),
             'tab_navigation' => $tab_navigation,
             'tab_content' => $tab_content,
         ]);
@@ -50,11 +50,11 @@ class JLG_Admin_Menu {
 
     private function get_tabs() {
         return [
-            'reglages' => '⚙️ Réglages',
-            'articles_notes' => '📊 Articles Notés',
-            'plateformes' => '🎮 Plateformes',
-            'shortcodes' => '📝 Shortcodes',
-            'tutoriels' => '📚 Tutoriels',
+            'reglages' => __('⚙️ Réglages', 'notation-jlg'),
+            'articles_notes' => __('📊 Articles Notés', 'notation-jlg'),
+            'plateformes' => __('🎮 Plateformes', 'notation-jlg'),
+            'shortcodes' => __('📝 Shortcodes', 'notation-jlg'),
+            'tutoriels' => __('📚 Tutoriels', 'notation-jlg'),
         ];
     }
 
@@ -175,7 +175,7 @@ class JLG_Admin_Menu {
                 'end_size' => 1,
                 'mid_size' => 2,
                 'type' => 'plain',
-                'before_page_number' => '<span class="screen-reader-text">Page </span>',
+                'before_page_number' => '<span class="screen-reader-text">' . esc_html__('Page ', 'notation-jlg') . '</span>',
             ];
 
             if (isset($_GET['orderby'])) {

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -43,7 +43,7 @@ class JLG_Admin_Metaboxes {
 
         add_meta_box(
             'notation_jlg_metabox',
-            '⭐ Notation du Jeu Vidéo',
+            esc_html__('⭐ Notation du Jeu Vidéo', 'notation-jlg'),
             [$this, 'render_notation_metabox'],
             $post_type,
             'side',
@@ -52,7 +52,7 @@ class JLG_Admin_Metaboxes {
 
         add_meta_box(
             'jlg_details_metabox',
-            '🎮 Détails du Test',
+            esc_html__('🎮 Détails du Test', 'notation-jlg'),
             [$this, 'render_details_metabox'],
             $post_type,
             'normal',
@@ -70,12 +70,12 @@ class JLG_Admin_Metaboxes {
         
         // Récupérer les catégories de notation
         $categories = [
-            'cat1' => 'Gameplay',
-            'cat2' => 'Graphismes',
-            'cat3' => 'Bande-son',
-            'cat4' => 'Durée de vie',
-            'cat5' => 'Scénario',
-            'cat6' => 'Originalité'
+            'cat1' => __('Gameplay', 'notation-jlg'),
+            'cat2' => __('Graphismes', 'notation-jlg'),
+            'cat3' => __('Bande-son', 'notation-jlg'),
+            'cat4' => __('Durée de vie', 'notation-jlg'),
+            'cat5' => __('Scénario', 'notation-jlg'),
+            'cat6' => __('Originalité', 'notation-jlg')
         ];
         
         // Si la classe Helpers existe, on l'utilise
@@ -87,19 +87,24 @@ class JLG_Admin_Metaboxes {
         }
         
         echo '<div class="jlg-metabox-notation">';
-        echo '<p>Entrez les notes sur 10. Laissez vide si non pertinent.</p>';
+        echo '<p>' . esc_html__('Entrez les notes sur 10. Laissez vide si non pertinent.', 'notation-jlg') . '</p>';
         
         foreach ($categories as $key => $label) {
             $value = get_post_meta($post->ID, '_note_' . $key, true);
             echo '<div style="margin-bottom:10px;">';
             echo '<label><strong>' . esc_html($label) . ' :</strong></label><br>';
-            echo '<input type="number" step="0.1" min="0" max="10" name="_note_' . esc_attr($key) . '" value="' . esc_attr($value) . '" style="width:80px;" /> / 10';
+            echo '<input type="number" step="0.1" min="0" max="10" name="_note_' . esc_attr($key) . '" value="' . esc_attr($value) . '" style="width:80px;" /> ' . esc_html_x('/ 10', 'score input suffix', 'notation-jlg');
             echo '</div>';
         }
         
         if ($average_score !== null) {
             echo '<div style="background:#f0f6fc; padding:10px; margin-top:15px; border-radius:4px;">';
-            echo '<strong>Note moyenne :</strong> <span style="color:#0073aa; font-size:16px;">' . number_format($average_score, 1) . ' / 10</span>';
+            $average_display = sprintf(
+                /* translators: %s: average score value. */
+                __('%s / 10', 'notation-jlg'),
+                number_format_i18n($average_score, 1)
+            );
+            echo '<strong>' . esc_html__('Note moyenne :', 'notation-jlg') . '</strong> <span style="color:#0073aa; font-size:16px;">' . esc_html($average_display) . '</span>';
             echo '</div>';
         }
         
@@ -130,17 +135,17 @@ class JLG_Admin_Metaboxes {
         echo '</div>';
 
         // Fiche technique
-        echo '<h3>📋 Fiche Technique</h3>';
+        echo '<h3>' . esc_html__('📋 Fiche Technique', 'notation-jlg') . '</h3>';
         echo '<div style="display:grid; grid-template-columns:repeat(3,1fr); gap:15px; margin-bottom:20px;">';
 
         $fields = [
-            'developpeur' => 'Développeur(s)',
-            'editeur' => 'Éditeur(s)',
-            'date_sortie' => 'Date de sortie',
-            'version' => 'Version testée',
-            'pegi' => 'PEGI',
-            'temps_de_jeu' => 'Temps de jeu',
-            'cover_image_url' => 'URL de la jaquette'
+            'developpeur' => __('Développeur(s)', 'notation-jlg'),
+            'editeur' => __('Éditeur(s)', 'notation-jlg'),
+            'date_sortie' => __('Date de sortie', 'notation-jlg'),
+            'version' => __('Version testée', 'notation-jlg'),
+            'pegi' => __('PEGI', 'notation-jlg'),
+            'temps_de_jeu' => __('Temps de jeu', 'notation-jlg'),
+            'cover_image_url' => __('URL de la jaquette', 'notation-jlg')
         ];
 
         foreach ($fields as $key => $label) {
@@ -156,7 +161,7 @@ class JLG_Admin_Metaboxes {
         
         // Plateformes
         echo '<div style="margin-bottom:20px;">';
-        echo '<p><strong>Plateformes :</strong></p>';
+        echo '<p><strong>' . esc_html__('Plateformes :', 'notation-jlg') . '</strong></p>';
         
         // Récupérer les plateformes depuis la classe JLG_Admin_Platforms
         $platforms_list = ['PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch', 'PlayStation 4', 'Xbox One'];
@@ -181,29 +186,29 @@ class JLG_Admin_Metaboxes {
         echo '</div>';
         
         // Taglines
-        echo '<h3>💬 Taglines</h3>';
+        echo '<h3>' . esc_html__('💬 Taglines', 'notation-jlg') . '</h3>';
         echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px; margin-bottom:20px;">';
         echo '<div>';
-        echo '<label><strong>Française :</strong></label><br>';
+        echo '<label><strong>' . esc_html__('Française :', 'notation-jlg') . '</strong></label><br>';
         echo '<textarea name="jlg_tagline_fr" rows="3" style="width:100%;">' . esc_textarea($meta['tagline_fr'] ?? '') . '</textarea>';
         echo '</div>';
         echo '<div>';
-        echo '<label><strong>Anglaise :</strong></label><br>';
+        echo '<label><strong>' . esc_html__('Anglaise :', 'notation-jlg') . '</strong></label><br>';
         echo '<textarea name="jlg_tagline_en" rows="3" style="width:100%;">' . esc_textarea($meta['tagline_en'] ?? '') . '</textarea>';
         echo '</div>';
         echo '</div>';
-        
+
         // Points forts/faibles
-        echo '<h3>⚖️ Points Forts & Faibles</h3>';
-        echo '<p style="font-style:italic;">Un point par ligne</p>';
+        echo '<h3>' . esc_html__('⚖️ Points Forts & Faibles', 'notation-jlg') . '</h3>';
+        echo '<p style="font-style:italic;">' . esc_html__('Un point par ligne', 'notation-jlg') . '</p>';
         echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px;">';
         echo '<div>';
-        echo '<label><strong>Points Forts :</strong></label><br>';
-        echo '<textarea name="jlg_points_forts" rows="8" style="width:100%;" placeholder="Gameplay addictif&#10;Graphismes superbes">' . esc_textarea($meta['points_forts'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__('Points Forts :', 'notation-jlg') . '</strong></label><br>';
+        echo '<textarea name="jlg_points_forts" rows="8" style="width:100%;" placeholder="' . esc_attr__("Gameplay addictif\nGraphismes superbes", 'notation-jlg') . '">' . esc_textarea($meta['points_forts'] ?? '') . '</textarea>';
         echo '</div>';
         echo '<div>';
-        echo '<label><strong>Points Faibles :</strong></label><br>';
-        echo '<textarea name="jlg_points_faibles" rows="8" style="width:100%;" placeholder="Durée de vie courte&#10;Bugs occasionnels">' . esc_textarea($meta['points_faibles'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__('Points Faibles :', 'notation-jlg') . '</strong></label><br>';
+        echo '<textarea name="jlg_points_faibles" rows="8" style="width:100%;" placeholder="' . esc_attr__("Durée de vie courte\nBugs occasionnels", 'notation-jlg') . '">' . esc_textarea($meta['points_faibles'] ?? '') . '</textarea>';
         echo '</div>';
         echo '</div>';
         

--- a/plugin-notation-jeux_V4/includes/class-jlg-widget.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-widget.php
@@ -6,13 +6,13 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
     public function __construct() {
         parent::__construct(
             'jlg_latest_reviews_widget',
-            'Notation JLG : Derniers Tests',
-            ['description' => 'Affiche les derniers articles ayant reçu une note.']
+            __('Notation JLG : Derniers Tests', 'notation-jlg'),
+            ['description' => __('Affiche les derniers articles ayant reçu une note.', 'notation-jlg')]
         );
     }
 
     public function widget($args, $instance) {
-        $title = apply_filters('widget_title', $instance['title'] ?? 'Derniers Tests');
+        $title = apply_filters('widget_title', $instance['title'] ?? __('Derniers Tests', 'notation-jlg'));
         $number = (!empty($instance['number'])) ? absint($instance['number']) : 5;
 
         $rated_post_ids = JLG_Helpers::get_rated_post_ids();
@@ -22,7 +22,7 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
             if (!empty($title)) {
                 echo $args['before_title'] . $title . $args['after_title'];
             }
-            echo '<p>Aucun test trouvé.</p>';
+            echo '<p>' . esc_html__('Aucun test trouvé.', 'notation-jlg') . '</p>';
             echo $args['after_widget'];
             return;
         }
@@ -47,19 +47,19 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
     }
 
     public function form($instance) {
-        $title = !empty($instance['title']) ? $instance['title'] : 'Derniers Tests';
+        $title = !empty($instance['title']) ? $instance['title'] : __('Derniers Tests', 'notation-jlg');
         $number = isset($instance['number']) ? absint($instance['number']) : 5;
         ?>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('title')); ?>">Titre :</label>
-            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" 
-                   name="<?php echo esc_attr($this->get_field_name('title')); ?>" 
+            <label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php echo esc_html__('Titre :', 'notation-jlg'); ?></label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('title')); ?>"
                    type="text" value="<?php echo esc_attr($title); ?>">
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('number')); ?>">Nombre d'articles à afficher :</label>
-            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('number')); ?>" 
-                   name="<?php echo esc_attr($this->get_field_name('number')); ?>" 
+            <label for="<?php echo esc_attr($this->get_field_id('number')); ?>"><?php echo esc_html__('Nombre d\'articles à afficher :', 'notation-jlg'); ?></label>
+            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('number')); ?>"
+                   name="<?php echo esc_attr($this->get_field_name('number')); ?>"
                    type="number" step="1" min="1" value="<?php echo esc_attr($number); ?>" size="3">
         </p>
         <?php

--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-09-23T10:18:50+00:00\n"
+"POT-Creation-Date: 2025-09-23T10:59:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: notation-jlg\n"
@@ -34,51 +34,202 @@ msgstr ""
 msgid "Jérôme Le Gousse"
 msgstr ""
 
+#: includes/admin/class-jlg-admin-menu.php:20
+msgctxt "Admin page title"
+msgid "Notation JLG"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:21
+msgctxt "Admin menu title"
+msgid "Notation - JLG"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:32
+msgid "Accès refusé."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:45
+msgid "⭐ Notation JLG v5.0"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:53
+msgid "⚙️ Réglages"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:54
+msgid "📊 Articles Notés"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:55
+msgid "🎮 Plateformes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:56
+msgid "📝 Shortcodes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:57
+msgid "📚 Tutoriels"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:178
+msgid "Page "
+msgstr ""
+
 #: includes/admin/class-jlg-admin-metaboxes.php:31
 msgid "Notation JLG"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:127
-#: includes/admin/class-jlg-admin-metaboxes.php:263
+#: includes/admin/class-jlg-admin-metaboxes.php:46
+msgid "⭐ Notation du Jeu Vidéo"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:55
+msgid "🎮 Détails du Test"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:73
+msgid "Gameplay"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:74
+msgid "Graphismes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:75
+msgid "Bande-son"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:76
+msgid "Durée de vie"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:77
+msgid "Scénario"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:78
+msgid "Originalité"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:90
+msgid "Entrez les notes sur 10. Laissez vide si non pertinent."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:96
+msgctxt "score input suffix"
+msgid "/ 10"
+msgstr ""
+
+#. translators: %s: average score value.
+#: includes/admin/class-jlg-admin-metaboxes.php:104
+#, php-format
+msgid "%s / 10"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:107
+msgid "Note moyenne :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:132
+#: includes/admin/class-jlg-admin-metaboxes.php:268
 msgid "Nom du jeu"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:129
+#: includes/admin/class-jlg-admin-metaboxes.php:134
 msgid "Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:264
+#: includes/admin/class-jlg-admin-metaboxes.php:138
+msgid "📋 Fiche Technique"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:142
+#: includes/admin/class-jlg-admin-metaboxes.php:269
 msgid "Développeur(s)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:265
+#: includes/admin/class-jlg-admin-metaboxes.php:143
+#: includes/admin/class-jlg-admin-metaboxes.php:270
 msgid "Éditeur(s)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:266
+#: includes/admin/class-jlg-admin-metaboxes.php:144
+#: includes/admin/class-jlg-admin-metaboxes.php:271
 msgid "Date de sortie"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:267
+#: includes/admin/class-jlg-admin-metaboxes.php:145
+#: includes/admin/class-jlg-admin-metaboxes.php:272
 msgid "Version testée"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:268
+#: includes/admin/class-jlg-admin-metaboxes.php:146
+#: includes/admin/class-jlg-admin-metaboxes.php:273
 msgid "PEGI"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:269
+#: includes/admin/class-jlg-admin-metaboxes.php:147
+#: includes/admin/class-jlg-admin-metaboxes.php:274
 msgid "Temps de jeu"
 msgstr ""
 
+#: includes/admin/class-jlg-admin-metaboxes.php:148
+msgid "URL de la jaquette"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:164
+msgid "Plateformes :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:189
+msgid "💬 Taglines"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:192
+msgid "Française :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:196
+msgid "Anglaise :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:202
+msgid "⚖️ Points Forts & Faibles"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:203
+msgid "Un point par ligne"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:206
+msgid "Points Forts :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:207
+msgid ""
+"Gameplay addictif\n"
+"Graphismes superbes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:210
+msgid "Points Faibles :"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:211
+msgid ""
+"Durée de vie courte\n"
+"Bugs occasionnels"
+msgstr ""
+
 #. translators: %s is the field label.
-#: includes/admin/class-jlg-admin-metaboxes.php:293
+#: includes/admin/class-jlg-admin-metaboxes.php:298
 #, php-format
 msgid "%s : format de date invalide. Utilisez AAAA-MM-JJ."
 msgstr ""
 
 #. translators: %s is a list of allowed PEGI values
-#: includes/admin/class-jlg-admin-metaboxes.php:308
+#: includes/admin/class-jlg-admin-metaboxes.php:313
 #, php-format
 msgid "PEGI invalide. Valeurs acceptées : %s."
 msgstr ""
@@ -167,7 +318,7 @@ msgid "Erreur. Veuillez réessayer."
 msgstr ""
 
 #: includes/class-jlg-assets.php:101
-#: includes/class-jlg-frontend.php:395
+#: includes/class-jlg-frontend.php:453
 #: assets/js/user-rating.js:12
 msgid "Vous avez déjà voté !"
 msgstr ""
@@ -220,38 +371,64 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: includes/class-jlg-frontend.php:322
+#: includes/class-jlg-frontend.php:380
 msgid "Une erreur est survenue. Merci de réessayer plus tard."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:343
+#: includes/class-jlg-frontend.php:401
 msgid "Jeton de sécurité manquant ou invalide."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:347
-#: includes/class-jlg-frontend.php:649
+#: includes/class-jlg-frontend.php:405
+#: includes/class-jlg-frontend.php:707
 msgid "La vérification de sécurité a échoué."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:354
+#: includes/class-jlg-frontend.php:412
 msgid "La notation des lecteurs est désactivée."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:361
-#: includes/class-jlg-frontend.php:383
+#: includes/class-jlg-frontend.php:419
+#: includes/class-jlg-frontend.php:441
 msgid "Données invalides."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:367
+#: includes/class-jlg-frontend.php:425
 msgid "Article introuvable ou non disponible pour la notation."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:377
+#: includes/class-jlg-frontend.php:435
 msgid "La notation des lecteurs est désactivée pour ce contenu."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:653
+#: includes/class-jlg-frontend.php:711
 msgid "Le shortcode requis est indisponible."
+msgstr ""
+
+#: includes/class-jlg-widget.php:9
+msgid "Notation JLG : Derniers Tests"
+msgstr ""
+
+#: includes/class-jlg-widget.php:10
+msgid "Affiche les derniers articles ayant reçu une note."
+msgstr ""
+
+#: includes/class-jlg-widget.php:15
+#: includes/class-jlg-widget.php:50
+msgid "Derniers Tests"
+msgstr ""
+
+#: includes/class-jlg-widget.php:25
+#: templates/widget-latest-reviews.php:20
+msgid "Aucun test trouvé."
+msgstr ""
+
+#: includes/class-jlg-widget.php:54
+msgid "Titre :"
+msgstr ""
+
+#: includes/class-jlg-widget.php:60
+msgid "Nombre d'articles à afficher :"
 msgstr ""
 
 #: includes/shortcodes/class-jlg-shortcode-summary-display.php:103
@@ -358,10 +535,6 @@ msgstr ""
 
 #: templates/summary-table-fragment.php:209
 msgid "Suivant »"
-msgstr ""
-
-#: templates/widget-latest-reviews.php:20
-msgid "Aucun test trouvé."
 msgstr ""
 
 #. translators: %s: Maximum rating value displayed with the thumbnail score.


### PR DESCRIPTION
## Summary
- wrap the admin menu labels and tab titles in translation functions for localization
- localize metabox UI strings and use the internationalized number formatter for the average score display
- translate the latest reviews widget text and regenerate the POT catalogue to expose the new strings

## Testing
- php wp-cli.phar i18n make-pot plugin-notation-jeux_V4 plugin-notation-jeux_V4/languages/notation-jlg.pot --exclude=tests,vendor --allow-root

------
https://chatgpt.com/codex/tasks/task_e_68d27cbcd9fc832e992761ab8e30ae3b