### PR TITLE
Internationalize admin strings and regenerate POT

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -150,7 +150,8 @@ class JLG_Admin_Menu {
                     'edit_link' => get_edit_post_link($post_id),
                     'view_link' => get_permalink($post_id),
                     'date' => get_the_date('d/m/Y', $post_id),
-                    'score_display' => $score_data['formatted'] ?? 'N/A',
+                    /* translators: Abbreviation meaning that the user rating is not available. */
+                    'score_display' => $score_data['formatted'] ?? __('N/A', 'notation-jlg'),
                     'score_color' => $score_color,
                     'categories' => $cat_names,
                 ];
@@ -200,15 +201,15 @@ class JLG_Admin_Menu {
             'columns' => $this->get_sortable_columns($orderby, $order),
             'posts' => $posts,
             'pagination' => $pagination,
-            'print_button_label' => '🖨️ Imprimer cette liste',
+            'print_button_label' => __('🖨️ Imprimer cette liste', 'notation-jlg'),
         ]);
     }
 
     private function get_sortable_columns($current_orderby, $current_order) {
         $columns = [
-            ['label' => 'Titre', 'key' => 'title'],
-            ['label' => 'Date', 'key' => 'date'],
-            ['label' => 'Note', 'key' => 'score'],
+            ['label' => __('Titre', 'notation-jlg'), 'key' => 'title'],
+            ['label' => __('Date', 'notation-jlg'), 'key' => 'date'],
+            ['label' => __('Note', 'notation-jlg'), 'key' => 'score'],
         ];
 
         $results = [];
@@ -246,7 +247,7 @@ class JLG_Admin_Menu {
 
     private function get_platforms_tab_content() {
         ob_start();
-        echo '<h2 class="title">🎮 Gestion des Plateformes</h2>';
+        echo '<h2 class="title">' . esc_html__('🎮 Gestion des Plateformes', 'notation-jlg') . '</h2>';
         $this->render_platforms_tab();
         return ob_get_clean();
     }
@@ -265,10 +266,10 @@ class JLG_Admin_Menu {
                     $platforms_manager = JLG_Admin_Platforms::get_instance();
                     $platforms_manager->render_platforms_page();
                 } else {
-                    echo '<div class="notice notice-error"><p>La classe de gestion des plateformes n\'a pas pu être chargée.</p></div>';
+                    echo '<div class="notice notice-error"><p>' . esc_html__('La classe de gestion des plateformes n\'a pas pu être chargée.', 'notation-jlg') . '</p></div>';
                 }
             } else {
-                echo '<div class="notice notice-error"><p>Fichier class-jlg-admin-platforms.php introuvable.</p></div>';
+                echo '<div class="notice notice-error"><p>' . esc_html__('Fichier class-jlg-admin-platforms.php introuvable.', 'notation-jlg') . '</p></div>';
             }
         }
     }
@@ -280,91 +281,91 @@ class JLG_Admin_Menu {
     private function get_tutorials_tab_content() {
         $tutorials = [
             [
-                'title' => '⚡ Démarrage rapide avec le Bloc Complet',
-                'content' => 'La méthode la plus simple pour créer un test professionnel.',
+                'title' => __('⚡ Démarrage rapide avec le Bloc Complet', 'notation-jlg'),
+                'content' => __('La méthode la plus simple pour créer un test professionnel.', 'notation-jlg'),
                 'steps' => [
-                    'Créer un nouvel article',
-                    'Remplir les notes dans la metabox (colonne droite)',
-                    'Ajouter tagline et points forts/faibles',
-                    'Insérer [jlg_bloc_complet] dans le contenu',
-                    'C\'est tout ! Publiez votre test',
+                    __('Créer un nouvel article', 'notation-jlg'),
+                    __('Remplir les notes dans la metabox (colonne droite)', 'notation-jlg'),
+                    __('Ajouter tagline et points forts/faibles', 'notation-jlg'),
+                    __('Insérer [jlg_bloc_complet] dans le contenu', 'notation-jlg'),
+                    __('C\'est tout ! Publiez votre test', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '🎮 Créer un test détaillé (méthode classique)',
-                'content' => 'Guide pas-à-pas pour un contrôle total.',
+                'title' => __('🎮 Créer un test détaillé (méthode classique)', 'notation-jlg'),
+                'content' => __('Guide pas-à-pas pour un contrôle total.', 'notation-jlg'),
                 'steps' => [
-                    'Créer un nouvel article',
-                    'Remplir la metabox "Notation" (colonne droite)',
-                    'Ajouter les détails du jeu (metabox principale)',
-                    'Intégrer les shortcodes séparés si besoin',
-                    'Publier et vérifier l\'affichage',
+                    __('Créer un nouvel article', 'notation-jlg'),
+                    __('Remplir la metabox "Notation" (colonne droite)', 'notation-jlg'),
+                    __('Ajouter les détails du jeu (metabox principale)', 'notation-jlg'),
+                    __('Intégrer les shortcodes séparés si besoin', 'notation-jlg'),
+                    __('Publier et vérifier l\'affichage', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '🎨 Personnalisation du Bloc Complet',
-                'content' => 'Créez un rendu unique.',
+                'title' => __('🎨 Personnalisation du Bloc Complet', 'notation-jlg'),
+                'content' => __('Créez un rendu unique.', 'notation-jlg'),
                 'steps' => [
-                    'Choisir le style (moderne/classique/compact)',
-                    'Définir une couleur d\'accent personnalisée',
-                    'Activer/désactiver les sections',
-                    'Personnaliser les titres des sections',
-                    'Combiner avec d\'autres shortcodes si besoin',
+                    __('Choisir le style (moderne/classique/compact)', 'notation-jlg'),
+                    __('Définir une couleur d\'accent personnalisée', 'notation-jlg'),
+                    __('Activer/désactiver les sections', 'notation-jlg'),
+                    __('Personnaliser les titres des sections', 'notation-jlg'),
+                    __('Combiner avec d\'autres shortcodes si besoin', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '🎨 Personnalisation visuelle globale',
-                'content' => 'Ajuster l\'apparence générale.',
+                'title' => __('🎨 Personnalisation visuelle globale', 'notation-jlg'),
+                'content' => __('Ajuster l\'apparence générale.', 'notation-jlg'),
                 'steps' => [
-                    'Choisir le thème (clair/sombre)',
-                    'Activer les effets Neon/Glow',
-                    'Configurer la pulsation',
-                    'Personnaliser les couleurs',
-                    'Ajouter du CSS personnalisé',
+                    __('Choisir le thème (clair/sombre)', 'notation-jlg'),
+                    __('Activer les effets Neon/Glow', 'notation-jlg'),
+                    __('Configurer la pulsation', 'notation-jlg'),
+                    __('Personnaliser les couleurs', 'notation-jlg'),
+                    __('Ajouter du CSS personnalisé', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '📊 Tableau récapitulatif avancé',
-                'content' => 'Maîtriser le shortcode tableau.',
+                'title' => __('📊 Tableau récapitulatif avancé', 'notation-jlg'),
+                'content' => __('Maîtriser le shortcode tableau.', 'notation-jlg'),
                 'steps' => [
-                    'Choisir entre table et grille',
-                    'Sélectionner les colonnes à afficher',
-                    'Filtrer par catégorie',
-                    'Ajuster la pagination',
-                    'Personnaliser les couleurs dans Réglages',
+                    __('Choisir entre table et grille', 'notation-jlg'),
+                    __('Sélectionner les colonnes à afficher', 'notation-jlg'),
+                    __('Filtrer par catégorie', 'notation-jlg'),
+                    __('Ajuster la pagination', 'notation-jlg'),
+                    __('Personnaliser les couleurs dans Réglages', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '⚡ Optimisations',
-                'content' => 'Améliorer les performances.',
+                'title' => __('⚡ Optimisations', 'notation-jlg'),
+                'content' => __('Améliorer les performances.', 'notation-jlg'),
                 'steps' => [
-                    'Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes',
-                    'Activer un plugin de cache',
-                    'Optimiser les images de couverture',
-                    'Limiter le nombre d\'articles affichés',
-                    'Désactiver les animations si non nécessaires',
+                    __('Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes', 'notation-jlg'),
+                    __('Activer un plugin de cache', 'notation-jlg'),
+                    __('Optimiser les images de couverture', 'notation-jlg'),
+                    __('Limiter le nombre d\'articles affichés', 'notation-jlg'),
+                    __('Désactiver les animations si non nécessaires', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '🔧 Intégration dans le thème',
-                'content' => 'Pour les développeurs.',
+                'title' => __('🔧 Intégration dans le thème', 'notation-jlg'),
+                'content' => __('Pour les développeurs.', 'notation-jlg'),
                 'steps' => [
-                    'Ajouter jlg_display_thumbnail_score() dans les templates',
-                    'Utiliser jlg_get_post_rating() pour récupérer la note',
-                    'Personnaliser les templates dans /templates/',
-                    'Créer des hooks personnalisés',
-                    'Surcharger les styles CSS du plugin',
+                    __('Ajouter jlg_display_thumbnail_score() dans les templates', 'notation-jlg'),
+                    __('Utiliser jlg_get_post_rating() pour récupérer la note', 'notation-jlg'),
+                    __('Personnaliser les templates dans /templates/', 'notation-jlg'),
+                    __('Créer des hooks personnalisés', 'notation-jlg'),
+                    __('Surcharger les styles CSS du plugin', 'notation-jlg'),
                 ],
             ],
             [
-                'title' => '❓ Dépannage',
-                'content' => 'Résoudre les problèmes courants.',
+                'title' => __('❓ Dépannage', 'notation-jlg'),
+                'content' => __('Résoudre les problèmes courants.', 'notation-jlg'),
                 'steps' => [
-                    'Vérifier les conflits de plugins',
-                    'Vider le cache navigateur et site',
-                    'Vérifier les permissions utilisateur',
-                    'Consulter les logs d\'erreur',
-                    'Réinitialiser les réglages si nécessaire',
+                    __('Vérifier les conflits de plugins', 'notation-jlg'),
+                    __('Vider le cache navigateur et site', 'notation-jlg'),
+                    __('Vérifier les permissions utilisateur', 'notation-jlg'),
+                    __('Consulter les logs d\'erreur', 'notation-jlg'),
+                    __('Réinitialiser les réglages si nécessaire', 'notation-jlg'),
                 ],
             ],
         ];

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -164,23 +164,38 @@ class JLG_Admin_Metaboxes {
         echo '<p><strong>' . esc_html__('Plateformes :', 'notation-jlg') . '</strong></p>';
         
         // Récupérer les plateformes depuis la classe JLG_Admin_Platforms
-        $platforms_list = ['PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch', 'PlayStation 4', 'Xbox One'];
-        
+        $platforms_list = [
+            ['value' => 'PC', 'label' => __('PC', 'notation-jlg')],
+            ['value' => 'PlayStation 5', 'label' => __('PlayStation 5', 'notation-jlg')],
+            ['value' => 'Xbox Series S/X', 'label' => __('Xbox Series S/X', 'notation-jlg')],
+            ['value' => 'Nintendo Switch', 'label' => __('Nintendo Switch', 'notation-jlg')],
+            ['value' => 'PlayStation 4', 'label' => __('PlayStation 4', 'notation-jlg')],
+            ['value' => 'Xbox One', 'label' => __('Xbox One', 'notation-jlg')],
+        ];
+
         if (class_exists('JLG_Admin_Platforms')) {
             $platforms_manager = JLG_Admin_Platforms::get_instance();
             $all_platforms = $platforms_manager->get_platform_names();
             if (!empty($all_platforms)) {
-                $platforms_list = array_values($all_platforms);
+                $platforms_list = [];
+                foreach ($all_platforms as $platform_name) {
+                    $platforms_list[] = [
+                        'value' => $platform_name,
+                        'label' => $platform_name,
+                    ];
+                }
             }
         }
-        
+
         $selected = is_array($meta['plateformes']) ? $meta['plateformes'] : [];
-        
+
         foreach ($platforms_list as $platform) {
-            $checked = in_array($platform, $selected) ? 'checked' : '';
+            $value = $platform['value'];
+            $label = $platform['label'];
+            $checked = in_array($value, $selected, true) ? 'checked' : '';
             echo '<label style="margin-right:15px;">';
-            echo '<input type="checkbox" name="jlg_plateformes[]" value="' . esc_attr($platform) . '" ' . $checked . '> ';
-            echo esc_html($platform);
+            echo '<input type="checkbox" name="jlg_plateformes[]" value="' . esc_attr($value) . '" ' . $checked . '> ';
+            echo esc_html($label);
             echo '</label>';
         }
         echo '</div>';
@@ -312,7 +327,11 @@ class JLG_Admin_Metaboxes {
                                 /* translators: %s is a list of allowed PEGI values */
                                 __('PEGI invalide. Valeurs acceptées : %s.', 'notation-jlg'),
                                 implode(', ', array_map(function($rating) {
-                                    return 'PEGI ' . $rating;
+                                    return sprintf(
+                                        /* translators: %s: PEGI rating value. */
+                                        __('PEGI %s', 'notation-jlg'),
+                                        $rating
+                                    );
                                 }, JLG_Validator::get_allowed_pegi_values()))
                             );
                             continue;

--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-09-23T10:59:14+00:00\n"
+"POT-Creation-Date: 2025-09-23T11:28:56+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: notation-jlg\n"
@@ -72,8 +72,268 @@ msgstr ""
 msgid "📚 Tutoriels"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:178
+#. translators: Abbreviation meaning that the user rating is not available.
+#: includes/admin/class-jlg-admin-menu.php:154
+#: includes/class-jlg-assets.php:117
+#: templates/shortcode-user-rating.php:15
+#: templates/summary-table-fragment.php:97
+#: templates/summary-table-fragment.php:157
+msgid "N/A"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:179
 msgid "Page "
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:204
+msgid "🖨️ Imprimer cette liste"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:210
+msgid "Titre"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:211
+#: includes/shortcodes/class-jlg-shortcode-summary-display.php:184
+msgid "Date"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:212
+#: includes/shortcodes/class-jlg-shortcode-summary-display.php:192
+msgid "Note"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:250
+msgid "🎮 Gestion des Plateformes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:269
+msgid "La classe de gestion des plateformes n'a pas pu être chargée."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:272
+msgid "Fichier class-jlg-admin-platforms.php introuvable."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:284
+msgid "⚡ Démarrage rapide avec le Bloc Complet"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:285
+msgid "La méthode la plus simple pour créer un test professionnel."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:287
+#: includes/admin/class-jlg-admin-menu.php:298
+msgid "Créer un nouvel article"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:288
+msgid "Remplir les notes dans la metabox (colonne droite)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:289
+msgid "Ajouter tagline et points forts/faibles"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:290
+msgid "Insérer [jlg_bloc_complet] dans le contenu"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:291
+msgid "C'est tout ! Publiez votre test"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:295
+msgid "🎮 Créer un test détaillé (méthode classique)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:296
+msgid "Guide pas-à-pas pour un contrôle total."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:299
+msgid "Remplir la metabox \"Notation\" (colonne droite)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:300
+msgid "Ajouter les détails du jeu (metabox principale)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:301
+msgid "Intégrer les shortcodes séparés si besoin"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:302
+msgid "Publier et vérifier l'affichage"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:306
+msgid "🎨 Personnalisation du Bloc Complet"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:307
+msgid "Créez un rendu unique."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:309
+msgid "Choisir le style (moderne/classique/compact)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:310
+msgid "Définir une couleur d'accent personnalisée"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:311
+msgid "Activer/désactiver les sections"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:312
+msgid "Personnaliser les titres des sections"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:313
+msgid "Combiner avec d'autres shortcodes si besoin"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:317
+msgid "🎨 Personnalisation visuelle globale"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:318
+msgid "Ajuster l'apparence générale."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:320
+msgid "Choisir le thème (clair/sombre)"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:321
+msgid "Activer les effets Neon/Glow"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:322
+msgid "Configurer la pulsation"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:323
+msgid "Personnaliser les couleurs"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:324
+msgid "Ajouter du CSS personnalisé"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:328
+msgid "📊 Tableau récapitulatif avancé"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:329
+msgid "Maîtriser le shortcode tableau."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:331
+msgid "Choisir entre table et grille"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:332
+msgid "Sélectionner les colonnes à afficher"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:333
+msgid "Filtrer par catégorie"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:334
+msgid "Ajuster la pagination"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:335
+msgid "Personnaliser les couleurs dans Réglages"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:339
+msgid "⚡ Optimisations"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:340
+msgid "Améliorer les performances."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:342
+msgid "Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:343
+msgid "Activer un plugin de cache"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:344
+msgid "Optimiser les images de couverture"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:345
+msgid "Limiter le nombre d'articles affichés"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:346
+msgid "Désactiver les animations si non nécessaires"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:350
+msgid "🔧 Intégration dans le thème"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:351
+msgid "Pour les développeurs."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:353
+msgid "Ajouter jlg_display_thumbnail_score() dans les templates"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:354
+msgid "Utiliser jlg_get_post_rating() pour récupérer la note"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:355
+msgid "Personnaliser les templates dans /templates/"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:356
+msgid "Créer des hooks personnalisés"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:357
+msgid "Surcharger les styles CSS du plugin"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:361
+msgid "❓ Dépannage"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:362
+msgid "Résoudre les problèmes courants."
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:364
+msgid "Vérifier les conflits de plugins"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:365
+msgid "Vider le cache navigateur et site"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:366
+msgid "Vérifier les permissions utilisateur"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:367
+msgid "Consulter les logs d'erreur"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-menu.php:368
+msgid "Réinitialiser les réglages si nécessaire"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:31
@@ -132,7 +392,7 @@ msgid "Note moyenne :"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:132
-#: includes/admin/class-jlg-admin-metaboxes.php:268
+#: includes/admin/class-jlg-admin-metaboxes.php:283
 msgid "Nom du jeu"
 msgstr ""
 
@@ -145,32 +405,32 @@ msgid "📋 Fiche Technique"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:142
-#: includes/admin/class-jlg-admin-metaboxes.php:269
+#: includes/admin/class-jlg-admin-metaboxes.php:284
 msgid "Développeur(s)"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:143
-#: includes/admin/class-jlg-admin-metaboxes.php:270
+#: includes/admin/class-jlg-admin-metaboxes.php:285
 msgid "Éditeur(s)"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:144
-#: includes/admin/class-jlg-admin-metaboxes.php:271
+#: includes/admin/class-jlg-admin-metaboxes.php:286
 msgid "Date de sortie"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:145
-#: includes/admin/class-jlg-admin-metaboxes.php:272
+#: includes/admin/class-jlg-admin-metaboxes.php:287
 msgid "Version testée"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:146
-#: includes/admin/class-jlg-admin-metaboxes.php:273
+#: includes/admin/class-jlg-admin-metaboxes.php:288
 msgid "PEGI"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-metaboxes.php:147
-#: includes/admin/class-jlg-admin-metaboxes.php:274
+#: includes/admin/class-jlg-admin-metaboxes.php:289
 msgid "Temps de jeu"
 msgstr ""
 
@@ -182,56 +442,86 @@ msgstr ""
 msgid "Plateformes :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:189
+#: includes/admin/class-jlg-admin-metaboxes.php:168
+msgid "PC"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:169
+msgid "PlayStation 5"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:170
+msgid "Xbox Series S/X"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:171
+msgid "Nintendo Switch"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:172
+msgid "PlayStation 4"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:173
+msgid "Xbox One"
+msgstr ""
+
+#: includes/admin/class-jlg-admin-metaboxes.php:204
 msgid "💬 Taglines"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:192
+#: includes/admin/class-jlg-admin-metaboxes.php:207
 msgid "Française :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:196
+#: includes/admin/class-jlg-admin-metaboxes.php:211
 msgid "Anglaise :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:202
+#: includes/admin/class-jlg-admin-metaboxes.php:217
 msgid "⚖️ Points Forts & Faibles"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:203
+#: includes/admin/class-jlg-admin-metaboxes.php:218
 msgid "Un point par ligne"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:206
+#: includes/admin/class-jlg-admin-metaboxes.php:221
 msgid "Points Forts :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:207
+#: includes/admin/class-jlg-admin-metaboxes.php:222
 msgid ""
 "Gameplay addictif\n"
 "Graphismes superbes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:210
+#: includes/admin/class-jlg-admin-metaboxes.php:225
 msgid "Points Faibles :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:211
+#: includes/admin/class-jlg-admin-metaboxes.php:226
 msgid ""
 "Durée de vie courte\n"
 "Bugs occasionnels"
 msgstr ""
 
 #. translators: %s is the field label.
-#: includes/admin/class-jlg-admin-metaboxes.php:298
+#: includes/admin/class-jlg-admin-metaboxes.php:313
 #, php-format
 msgid "%s : format de date invalide. Utilisez AAAA-MM-JJ."
 msgstr ""
 
 #. translators: %s is a list of allowed PEGI values
-#: includes/admin/class-jlg-admin-metaboxes.php:313
+#: includes/admin/class-jlg-admin-metaboxes.php:328
 #, php-format
 msgid "PEGI invalide. Valeurs acceptées : %s."
+msgstr ""
+
+#. translators: %s: PEGI rating value.
+#: includes/admin/class-jlg-admin-metaboxes.php:332
+#, php-format
+msgid "PEGI %s"
 msgstr ""
 
 #: includes/admin/class-jlg-admin-platforms.php:199
@@ -242,69 +532,69 @@ msgstr ""
 msgid "Erreur de sécurité"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:246
+#: includes/admin/class-jlg-admin-platforms.php:257
 msgid "Plateformes réinitialisées avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:274
+#: includes/admin/class-jlg-admin-platforms.php:288
 msgid "Le nom de la plateforme est requis."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:287
+#: includes/admin/class-jlg-admin-platforms.php:301
 msgid "Nom de plateforme invalide."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:335
+#: includes/admin/class-jlg-admin-platforms.php:349
 #, php-format
 msgid "Plateforme '%s' ajoutée avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:341
+#: includes/admin/class-jlg-admin-platforms.php:355
 msgid "Erreur lors de la sauvegarde."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:355
+#: includes/admin/class-jlg-admin-platforms.php:369
 msgid "Clé de plateforme manquante."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:364
+#: includes/admin/class-jlg-admin-platforms.php:378
 msgid "Plateforme introuvable."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:374
+#: includes/admin/class-jlg-admin-platforms.php:388
 #, php-format
 msgid "La plateforme '%s' est une plateforme par défaut et ne peut pas être supprimée."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:392
+#: includes/admin/class-jlg-admin-platforms.php:406
 #, php-format
 msgid "Plateforme '%s' supprimée avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:398
+#: includes/admin/class-jlg-admin-platforms.php:412
 msgid "Erreur lors de la suppression."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:412
+#: includes/admin/class-jlg-admin-platforms.php:426
 msgid "Données d'ordre manquantes."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:421
+#: includes/admin/class-jlg-admin-platforms.php:435
 msgid "Ordre soumis invalide."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:443
+#: includes/admin/class-jlg-admin-platforms.php:457
 msgid "Aucune plateforme valide reçue."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:464
+#: includes/admin/class-jlg-admin-platforms.php:478
 msgid "Ordre des plateformes mis à jour !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:467
+#: includes/admin/class-jlg-admin-platforms.php:481
 msgid "Erreur lors de la mise à jour."
 msgstr ""
 
@@ -361,14 +651,6 @@ msgstr ""
 
 #: includes/class-jlg-assets.php:116
 msgid "Fiche technique remplie !"
-msgstr ""
-
-#. translators: Abbreviation meaning that the user rating is not available.
-#: includes/class-jlg-assets.php:117
-#: templates/shortcode-user-rating.php:15
-#: templates/summary-table-fragment.php:97
-#: templates/summary-table-fragment.php:157
-msgid "N/A"
 msgstr ""
 
 #: includes/class-jlg-frontend.php:380
@@ -437,14 +719,6 @@ msgstr ""
 
 #: includes/shortcodes/class-jlg-shortcode-summary-display.php:175
 msgid "Titre du jeu"
-msgstr ""
-
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:184
-msgid "Date"
-msgstr ""
-
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:192
-msgid "Note"
 msgstr ""
 
 #: includes/shortcodes/class-jlg-shortcode-summary-display.php:202


### PR DESCRIPTION
## Summary
- Wrap the admin menu labels, tab titles, tutorials, and platform notices in translation functions.
- Localize metabox copy, default platform labels, and PEGI validation messages while using locale-aware formatting.
- Regenerate the notation-jlg.pot catalog so translators can work on the new strings.

## Testing
- php -l includes/admin/class-jlg-admin-menu.php
- php -l includes/admin/class-jlg-admin-metaboxes.php

------
https://chatgpt.com/codex/tasks/task_e_68d2833bd064832ead58d320fa41b664