### PR TITLE
Prevent duplicate votes from the same IP

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -449,6 +449,20 @@ class JLG_Frontend {
         $ratings_meta = [];
         $ratings = self::get_post_user_rating_tokens($post_id, $ratings_meta);
 
+        if ($user_ip_hash) {
+            $ip_log = get_post_meta($post_id, '_jlg_user_rating_ips', true);
+
+            if (!is_array($ip_log)) {
+                $ip_log = [];
+            }
+
+            if (isset($ip_log[$user_ip_hash]) && (!is_array($ip_log[$user_ip_hash]) || empty($ip_log[$user_ip_hash]['legacy']))) {
+                wp_send_json_error([
+                    'message' => esc_html__('Un vote depuis cette adresse IP a déjà été enregistré.', 'notation-jlg'),
+                ], 409);
+            }
+        }
+
         if (isset($ratings[$token_hash])) {
             wp_send_json_error(['message' => esc_html__('Vous avez déjà voté !', 'notation-jlg')]);
         }

--- a/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
@@ -37,4 +37,60 @@ class FrontendUserRatingTest extends TestCase
 
         $this->assertSame([], $GLOBALS['jlg_test_meta_updates']);
     }
+
+    public function test_handle_user_rating_blocks_second_vote_from_same_ip(): void
+    {
+        $post_id = 321;
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'           => $post_id,
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+            'post_content' => '[notation_utilisateurs_jlg]',
+        ]);
+
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+
+        $frontend = new JLG_Frontend();
+
+        $_POST = [
+            'token'   => str_repeat('a', 32),
+            'nonce'   => 'nonce',
+            'post_id' => (string) $post_id,
+            'rating'  => '4',
+        ];
+
+        try {
+            $frontend->handle_user_rating();
+            $this->fail('Une réponse JSON devait être envoyée.');
+        } catch (WP_Send_Json_Exception $exception) {
+            $this->assertTrue($exception->success);
+            $this->assertNull($exception->status);
+        }
+
+        $first_updates_count = count($GLOBALS['jlg_test_meta_updates']);
+
+        $_POST = [
+            'token'   => str_repeat('b', 32),
+            'nonce'   => 'nonce',
+            'post_id' => (string) $post_id,
+            'rating'  => '5',
+        ];
+        $_COOKIE = [];
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+
+        try {
+            $frontend->handle_user_rating();
+            $this->fail('Une réponse JSON devait être envoyée.');
+        } catch (WP_Send_Json_Exception $exception) {
+            $this->assertFalse($exception->success);
+            $this->assertSame(409, $exception->status);
+            $this->assertIsArray($exception->data);
+            $this->assertSame(
+                'Un vote depuis cette adresse IP a déjà été enregistré.',
+                $exception->data['message']
+            );
+        }
+
+        $this->assertSame($first_updates_count, count($GLOBALS['jlg_test_meta_updates']));
+    }
 }

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -261,6 +261,30 @@ if (!function_exists('number_format_i18n')) {
     }
 }
 
+if (!function_exists('current_time')) {
+    function current_time($type, $gmt = 0) {
+        $timestamp = time();
+
+        if ($type === 'timestamp' || $type === 'U') {
+            return $timestamp;
+        }
+
+        if ($gmt) {
+            return gmdate($type === 'mysql' ? 'Y-m-d H:i:s' : (is_string($type) && $type !== '' ? $type : 'Y-m-d H:i:s'), $timestamp);
+        }
+
+        if ($type === 'mysql') {
+            return date('Y-m-d H:i:s', $timestamp);
+        }
+
+        if (is_string($type) && $type !== '') {
+            return date($type, $timestamp);
+        }
+
+        return $timestamp;
+    }
+}
+
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value) {
         if (is_array($value)) {
@@ -439,11 +463,15 @@ if (!function_exists('get_post_meta')) {
 
         $value = $meta[$post_id][$key];
 
-        if ($single && is_array($value)) {
-            return reset($value);
+        if ($single) {
+            return $value;
         }
 
-        return $value;
+        if (is_array($value)) {
+            return $value;
+        }
+
+        return [$value];
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent duplicate user ratings by checking the stored IP log before accepting a vote
- expose WordPress test stubs for `current_time()` and `get_post_meta()` to support the new flow
- cover the duplicate IP scenario with a PHPUnit test

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2bd6feb0c832ea357fea73800425f