### PR TITLE
Empêcher les votes multiples par IP

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -443,17 +443,13 @@ class JLG_Frontend {
 
         $user_ip = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP);
         $user_ip_hash = $user_ip ? wp_hash($user_ip) : '';
+        $ip_log = [];
 
-        $token_hash = self::hash_user_rating_token($token);
+        if ($user_ip_hash !== '') {
+            $stored_ip_log = get_post_meta($post_id, '_jlg_user_rating_ips', true);
 
-        $ratings_meta = [];
-        $ratings = self::get_post_user_rating_tokens($post_id, $ratings_meta);
-
-        if ($user_ip_hash) {
-            $ip_log = get_post_meta($post_id, '_jlg_user_rating_ips', true);
-
-            if (!is_array($ip_log)) {
-                $ip_log = [];
+            if (is_array($stored_ip_log)) {
+                $ip_log = $stored_ip_log;
             }
 
             if (isset($ip_log[$user_ip_hash]) && (!is_array($ip_log[$user_ip_hash]) || empty($ip_log[$user_ip_hash]['legacy']))) {
@@ -462,6 +458,11 @@ class JLG_Frontend {
                 ], 409);
             }
         }
+
+        $token_hash = self::hash_user_rating_token($token);
+
+        $ratings_meta = [];
+        $ratings = self::get_post_user_rating_tokens($post_id, $ratings_meta);
 
         if (isset($ratings[$token_hash])) {
             wp_send_json_error(['message' => esc_html__('Vous avez déjà voté !', 'notation-jlg')]);

--- a/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
@@ -67,6 +67,12 @@ class FrontendUserRatingTest extends TestCase
             $this->assertNull($exception->status);
         }
 
+        $ip_hash = wp_hash('198.51.100.42');
+        $this->assertArrayHasKey($post_id, $GLOBALS['jlg_test_meta']);
+        $this->assertArrayHasKey('_jlg_user_rating_ips', $GLOBALS['jlg_test_meta'][$post_id]);
+        $this->assertArrayHasKey($ip_hash, $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_ips']);
+        $this->assertArrayNotHasKey('legacy', $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_ips'][$ip_hash]);
+
         $first_updates_count = count($GLOBALS['jlg_test_meta_updates']);
 
         $_POST = [
@@ -76,6 +82,7 @@ class FrontendUserRatingTest extends TestCase
             'rating'  => '5',
         ];
         $_COOKIE = [];
+        unset($_COOKIE['jlg_user_rating_token']);
         $_SERVER['REMOTE_ADDR'] = '198.51.100.42';
 
         try {


### PR DESCRIPTION
## Summary
- empêche `handle_user_rating()` d'enregistrer un vote si l'adresse IP est déjà présente dans le journal (hors entrées legacy) avant l'ajout de la note
- conserve la mise à jour du journal IP uniquement après la validation et couvre le scénario via un test de double vote bloqué

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2c418e1dc832eb52c98953f632a23