### PR TITLE
Add letter and genre filtering to summary view

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -45,7 +45,26 @@
 .jlg-game-info-box .platforms-list span{display:inline-block;background:var(--jlg-border-color);padding:3px 8px;border-radius:4px;font-size:0.9em;margin:2px;}
 
 /* Summary Display */
-.jlg-summary-filters{margin-bottom:20px;text-align:right;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
+.jlg-summary-filters{margin-bottom:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:flex;flex-direction:column;gap:12px;}
+.jlg-summary-letter-filter{display:flex;flex-wrap:wrap;gap:6px;align-items:center;}
+.jlg-summary-letter-filter button{border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color);color:var(--jlg-secondary-text-color);padding:6px 10px;border-radius:4px;font-size:0.85rem;cursor:pointer;transition:all .2s ease;}
+.jlg-summary-letter-filter button:hover{background-color:var(--jlg-table-row-hover-color);}
+.jlg-summary-letter-filter button.is-active{background-color:var(--jlg-score-gradient-1);border-color:var(--jlg-score-gradient-1);color:#fff;}
+.jlg-summary-filters-form{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:flex-end;}
+.jlg-summary-filters-form select{min-width:180px;}
+.jlg-active-filters{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:15px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
+.jlg-active-filter-badge{background-color:var(--jlg-border-color);color:var(--jlg-secondary-text-color);border-radius:9999px;padding:4px 10px;font-size:0.8rem;text-transform:uppercase;letter-spacing:.05em;}
+.jlg-genre-badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;}
+.jlg-genre-badge{background-color:var(--jlg-border-color);color:var(--jlg-secondary-text-color);border-radius:9999px;padding:2px 10px;font-size:0.75rem;text-transform:uppercase;letter-spacing:.05em;display:inline-flex;align-items:center;}
+.jlg-summary-table .jlg-genre-badges{margin-top:6px;}
+.jlg-summary-table .jlg-genre-badge{background-color:var(--jlg-bg-color-secondary);}
+.jlg-game-card .jlg-genre-badges{position:absolute;left:15px;right:15px;bottom:15px;z-index:2;gap:6px;pointer-events:none;}
+.jlg-game-card .jlg-genre-badge{background-color:rgba(0,0,0,.65);color:#fff;}
+.jlg-game-card-title{position:absolute;bottom:0;left:0;right:0;z-index:2;background:linear-gradient(to top,rgba(0,0,0,.9) 0%,rgba(0,0,0,0) 100%);padding:30px 15px 60px;}
+.jlg-summary-wrapper .jlg-summary-letter-filter button:focus{outline:2px solid var(--jlg-score-gradient-1);outline-offset:2px;}
+.jlg-summary-wrapper .jlg-summary-letter-filter button.is-active:focus{outline:2px solid rgba(255,255,255,.9);}
+.jlg-summary-filters-form input[type="submit"]{margin-left:auto;}
+@media (min-width:768px){.jlg-summary-filters{flex-direction:row;align-items:flex-start;justify-content:space-between;}.jlg-summary-filters-form{justify-content:flex-end;}}
 .jlg-summary-filters select,
 .jlg-summary-filters input[type="submit"]{padding:8px 12px;border-radius:4px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color);color:var(--jlg-main-text-color);vertical-align:middle;transition:all .2s ease;}
 .jlg-summary-filters input[type="submit"]{background-color:var(--jlg-score-gradient-1);color:#fff;border-color:var(--jlg-score-gradient-1);cursor:pointer;}
@@ -64,7 +83,6 @@
 .jlg-game-card img{width:100%;height:100%;object-fit:cover;transition:transform .3s ease;}
 .jlg-game-card:hover img{transform:scale(1.05);}
 .jlg-game-card-score{position:absolute;top:10px;right:10px;z-index:2;background:rgba(0,0,0,.8);color:#fff;font-weight:bold;font-size:1.2rem;padding:5px 10px;border-radius:6px;backdrop-filter:blur(5px);}
-.jlg-game-card-title{position:absolute;bottom:0;left:0;right:0;z-index:2;background:linear-gradient(to top,rgba(0,0,0,.9) 0%,rgba(0,0,0,0) 100%);padding:30px 15px 15px;}
 .jlg-game-card-title span{color:#fff;font-weight:600;text-decoration:none;font-size:1.1rem;}
 .jlg-pagination{text-align:center;margin-top:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-pagination .page-numbers{padding:8px 12px;margin:0 2px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color-secondary);color:var(--jlg-secondary-text-color);text-decoration:none;border-radius:4px;}

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -751,6 +751,8 @@ class JLG_Frontend {
             'categorie'      => isset($_POST['categorie']) ? sanitize_text_field(wp_unslash($_POST['categorie'])) : '',
             'colonnes'       => isset($_POST['colonnes']) ? sanitize_text_field(wp_unslash($_POST['colonnes'])) : 'titre,date,note',
             'id'             => isset($_POST['table_id']) ? sanitize_html_class(wp_unslash($_POST['table_id'])) : 'jlg-table-' . uniqid(),
+            'letter_filter'  => isset($_POST['letter_filter']) ? JLG_Shortcode_Summary_Display::normalize_letter_filter(wp_unslash($_POST['letter_filter'])) : '',
+            'genre_filter'   => isset($_POST['genre_filter']) ? sanitize_text_field(wp_unslash($_POST['genre_filter'])) : '',
         ];
 
         $request = [
@@ -758,6 +760,8 @@ class JLG_Frontend {
             'order'      => isset($_POST['order']) ? sanitize_text_field(wp_unslash($_POST['order'])) : 'DESC',
             'cat_filter' => isset($_POST['cat_filter']) ? intval($_POST['cat_filter']) : 0,
             'paged'      => isset($_POST['paged']) ? intval($_POST['paged']) : 1,
+            'letter_filter' => isset($_POST['letter_filter']) ? JLG_Shortcode_Summary_Display::normalize_letter_filter(wp_unslash($_POST['letter_filter'])) : '',
+            'genre_filter'  => isset($_POST['genre_filter']) ? sanitize_text_field(wp_unslash($_POST['genre_filter'])) : '',
         ];
 
         $current_url = isset($_POST['current_url']) ? esc_url_raw(wp_unslash($_POST['current_url'])) : '';
@@ -781,6 +785,8 @@ class JLG_Frontend {
             'order'      => $context['order'] ?? 'DESC',
             'paged'      => $context['paged'] ?? 1,
             'cat_filter' => $context['cat_filter'] ?? 0,
+            'letter_filter' => $context['letter_filter'] ?? '',
+            'genre_filter'  => $context['genre_filter'] ?? '',
             'total_pages' => 0,
         ];
 

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -18,9 +18,29 @@ $columns = is_array($colonnes) ? $colonnes : [];
 $available_columns = is_array($colonnes_disponibles) ? $colonnes_disponibles : [];
 $current_orderby = !empty($orderby) ? $orderby : 'date';
 $current_order = !empty($order) ? $order : 'DESC';
-$show_filters = ($atts['layout'] === 'table' && empty($atts['categorie']));
+$current_letter_filter = isset($letter_filter) ? sanitize_text_field($letter_filter) : (isset($atts['letter_filter']) ? sanitize_text_field($atts['letter_filter']) : '');
+$current_genre_filter = isset($genre_filter) ? sanitize_text_field($genre_filter) : (isset($atts['genre_filter']) ? sanitize_text_field($atts['genre_filter']) : '');
+$show_filters = empty($atts['categorie']);
 $current_cat_filter = ($show_filters && isset($cat_filter)) ? intval($cat_filter) : 0;
 $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $columns)) : '';
+$genre_taxonomy = apply_filters('jlg_summary_genre_taxonomy', 'jlg_game_genre');
+$has_genre_taxonomy = !empty($genre_taxonomy) && taxonomy_exists($genre_taxonomy);
+$genre_terms = [];
+
+if ($show_filters && $has_genre_taxonomy) {
+    $genre_terms = get_terms([
+        'taxonomy'   => $genre_taxonomy,
+        'hide_empty' => false,
+        'orderby'    => 'name',
+        'order'      => 'ASC',
+    ]);
+
+    if (is_wp_error($genre_terms)) {
+        $genre_terms = [];
+    }
+}
+
+$letters = range('A', 'Z');
 ?>
 
 <div
@@ -34,25 +54,58 @@ $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $colum
     data-order="<?php echo esc_attr($current_order); ?>"
     data-paged="<?php echo esc_attr(intval($paged)); ?>"
     data-cat-filter="<?php echo esc_attr($current_cat_filter); ?>"
+    data-letter-filter="<?php echo esc_attr($current_letter_filter); ?>"
+    data-genre-filter="<?php echo esc_attr($current_genre_filter); ?>"
 >
-    
+
     <?php if ($show_filters) : ?>
         <!-- Filtres -->
         <div class="jlg-summary-filters">
-            <form method="get" action="">
+            <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e('Filtrer par lettre', 'notation-jlg'); ?>">
+                <button type="button" class="<?php echo $current_letter_filter === '' ? 'is-active' : ''; ?>" data-letter="">
+                    <?php esc_html_e('Tous', 'notation-jlg'); ?>
+                </button>
+                <?php foreach ($letters as $letter) : ?>
+                    <button type="button" data-letter="<?php echo esc_attr($letter); ?>" class="<?php echo ($current_letter_filter === $letter) ? 'is-active' : ''; ?>">
+                        <?php echo esc_html($letter); ?>
+                    </button>
+                <?php endforeach; ?>
+                <button type="button" data-letter="#" class="<?php echo ($current_letter_filter === '#') ? 'is-active' : ''; ?>">
+                    <?php esc_html_e('0-9', 'notation-jlg'); ?>
+                </button>
+            </div>
+
+            <form method="get" action="" class="jlg-summary-filters-form">
                 <input type="hidden" name="orderby" value="<?php echo esc_attr($current_orderby); ?>">
                 <input type="hidden" name="order" value="<?php echo esc_attr($current_order); ?>">
+                <input type="hidden" name="letter_filter" value="<?php echo esc_attr($current_letter_filter); ?>">
                 <?php
                 wp_dropdown_categories([
                     'show_option_all' => __('Toutes les catégories', 'notation-jlg'),
                     'orderby' => 'name',
                     'hide_empty' => 1,
                     'name' => 'cat_filter',
-                    'id' => 'jlg_cat_filter',
+                    'id' => $table_id . '_cat_filter',
                     'selected' => $current_cat_filter,
-                    'hierarchical' => true
+                    'hierarchical' => true,
+                    'class' => 'jlg-cat-filter-select',
                 ]);
                 ?>
+                <?php if ($has_genre_taxonomy && !empty($genre_terms)) : ?>
+                    <label for="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="screen-reader-text">
+                        <?php esc_html_e('Filtrer par genre', 'notation-jlg'); ?>
+                    </label>
+                    <select name="genre_filter" id="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="jlg-genre-filter-select">
+                        <option value="" <?php selected($current_genre_filter, ''); ?>><?php esc_html_e('Tous les genres', 'notation-jlg'); ?></option>
+                        <?php foreach ($genre_terms as $term) : ?>
+                            <option value="<?php echo esc_attr($term->slug); ?>" <?php selected($current_genre_filter, $term->slug); ?>>
+                                <?php echo esc_html($term->name); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php else : ?>
+                    <input type="hidden" name="genre_filter" value="<?php echo esc_attr($current_genre_filter); ?>">
+                <?php endif; ?>
                 <input type="submit" value="<?php echo esc_attr__('Filtrer', 'notation-jlg'); ?>">
             </form>
         </div>


### PR DESCRIPTION
## Summary
- extend the summary shortcode context to accept letter and genre filters and apply them to the underlying query
- refresh the shortcode and fragment templates to expose A–Z filtering, a genre selector, active-filter indicators, and genre badges
- update the AJAX sorting script and front-end styles to handle the new filters, URL/history updates, and visual states

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e222fe4c832e9fb055705a0be0f8