### PR TITLE
Add admin genre management and filtering

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -39,15 +39,23 @@ jQuery(document).ready(function($) {
 
         if (state.orderby) {
             $wrapper.attr('data-orderby', state.orderby);
+            $wrapper.data('orderby', state.orderby);
         }
         if (state.order) {
             $wrapper.attr('data-order', state.order);
+            $wrapper.data('order', state.order);
         }
         if (state.paged) {
             $wrapper.attr('data-paged', state.paged);
+            $wrapper.data('paged', state.paged);
         }
         if (typeof state.cat_filter !== 'undefined') {
             $wrapper.attr('data-cat-filter', state.cat_filter);
+            $wrapper.data('catFilter', state.cat_filter);
+        }
+        if (typeof state.genre_filter !== 'undefined') {
+            $wrapper.attr('data-genre-filter', state.genre_filter);
+            $wrapper.data('genreFilter', state.genre_filter);
         }
 
         var $form = $wrapper.find('.jlg-summary-filters form');
@@ -60,6 +68,9 @@ jQuery(document).ready(function($) {
             }
             if (typeof state.cat_filter !== 'undefined') {
                 $form.find('select[name="cat_filter"]').val(state.cat_filter);
+            }
+            if (typeof state.genre_filter !== 'undefined') {
+                $form.find('select[name="genre_filter"]').val(state.genre_filter);
             }
         }
     }
@@ -118,6 +129,7 @@ jQuery(document).ready(function($) {
             paged = $wrapper.data('paged') || 1;
         }
         var catFilter = params.cat_filter;
+        var genreFilter = params.genre_filter;
 
         requestData.orderby = orderby;
         requestData.order = order;
@@ -127,13 +139,27 @@ jQuery(document).ready(function($) {
         }
 
         if (typeof catFilter === 'undefined' || catFilter === '') {
-            catFilter = $wrapper.data('catFilter');
+            var storedCatFilter = $wrapper.data('catFilter');
+            if (typeof storedCatFilter === 'undefined') {
+                storedCatFilter = $wrapper.attr('data-cat-filter');
+            }
+            catFilter = typeof storedCatFilter !== 'undefined' ? storedCatFilter : '';
         }
 
         requestData.cat_filter = parseInt(catFilter, 10);
         if (isNaN(requestData.cat_filter)) {
             requestData.cat_filter = 0;
         }
+
+        if (typeof genreFilter === 'undefined' || genreFilter === null) {
+            var storedGenreFilter = $wrapper.data('genreFilter');
+            if (typeof storedGenreFilter === 'undefined') {
+                storedGenreFilter = $wrapper.attr('data-genre-filter');
+            }
+            genreFilter = typeof storedGenreFilter !== 'undefined' ? storedGenreFilter : '';
+        }
+
+        requestData.genre_filter = genreFilter ? genreFilter.toString() : '';
 
         $wrapper.addClass('jlg-summary-loading');
 

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
@@ -7,6 +7,7 @@ class JLG_Admin_Core {
     private $metaboxes;
     private $settings;
     private $platforms;
+    private $genres;
 
     public static function get_instance() {
         if (self::$instance === null) {
@@ -26,7 +27,8 @@ class JLG_Admin_Core {
             'includes/admin/class-jlg-admin-metaboxes.php',
             'includes/admin/class-jlg-admin-settings.php',
             'includes/admin/class-jlg-admin-ajax.php',
-            'includes/admin/class-jlg-admin-platforms.php'  // Ajout de la classe Platforms
+            'includes/admin/class-jlg-admin-platforms.php',
+            'includes/admin/class-jlg-admin-genres.php'
         ];
 
         foreach ($admin_files as $file) {
@@ -58,6 +60,10 @@ class JLG_Admin_Core {
         if (class_exists('JLG_Admin_Platforms')) {
             $this->platforms = JLG_Admin_Platforms::get_instance();
         }
+
+        if (class_exists('JLG_Admin_Genres')) {
+            $this->genres = JLG_Admin_Genres::get_instance();
+        }
     }
 
     public function get_component($component_name) {
@@ -66,6 +72,7 @@ class JLG_Admin_Core {
             case 'metaboxes': return $this->metaboxes;
             case 'settings': return $this->settings;
             case 'platforms': return $this->platforms;
+            case 'genres': return $this->genres;
             default: return null;
         }
     }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-genres.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-genres.php
@@ -1,0 +1,596 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class JLG_Admin_Genres {
+    private static $instance = null;
+    private $option_name = 'jlg_genres_list';
+
+    public static function get_instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action('admin_init', [$this, 'handle_genre_actions'], 5);
+        add_action('admin_init', [$this, 'handle_notice_dismissal'], 1);
+        add_action('admin_notices', [$this, 'maybe_display_migration_notice']);
+    }
+
+    private function get_default_genre_definitions() {
+        if (method_exists('JLG_Helpers', 'get_default_genre_definitions')) {
+            return JLG_Helpers::get_default_genre_definitions();
+        }
+
+        return [];
+    }
+
+    private function get_stored_genre_data() {
+        $stored = get_option($this->option_name, []);
+
+        if (!is_array($stored)) {
+            $stored = [];
+        }
+
+        $defaults = [
+            'custom_genres' => [],
+            'order' => [],
+        ];
+
+        return wp_parse_args($stored, $defaults);
+    }
+
+    private function ensure_storage_structure(&$data) {
+        if (!isset($data['custom_genres']) || !is_array($data['custom_genres'])) {
+            $data['custom_genres'] = [];
+        }
+
+        if (!isset($data['order']) || !is_array($data['order'])) {
+            $data['order'] = [];
+        }
+    }
+
+    public function get_genres() {
+        $defaults = $this->get_default_genre_definitions();
+        $stored = $this->get_stored_genre_data();
+        $this->ensure_storage_structure($stored);
+
+        $genres = [];
+
+        foreach ($defaults as $slug => $genre) {
+            if (!is_array($genre)) {
+                continue;
+            }
+
+            $genres[$slug] = array_merge(
+                [
+                    'slug'   => $slug,
+                    'name'   => isset($genre['name']) ? sanitize_text_field($genre['name']) : $slug,
+                    'color'  => isset($genre['color']) ? sanitize_hex_color($genre['color']) : '#4b5563',
+                    'badge'  => isset($genre['badge']) ? sanitize_text_field($genre['badge']) : '',
+                    'order'  => isset($genre['order']) ? (int) $genre['order'] : PHP_INT_MAX,
+                    'custom' => false,
+                ],
+                $genre
+            );
+        }
+
+        foreach ($stored['custom_genres'] as $slug => $genre) {
+            if (!is_array($genre)) {
+                continue;
+            }
+
+            $slug = sanitize_title($slug);
+            if ($slug === '') {
+                continue;
+            }
+
+            $genres[$slug] = array_merge(
+                [
+                    'slug'   => $slug,
+                    'name'   => isset($genre['name']) ? sanitize_text_field($genre['name']) : $slug,
+                    'color'  => isset($genre['color']) ? sanitize_hex_color($genre['color']) : '#2563eb',
+                    'badge'  => isset($genre['badge']) ? sanitize_text_field($genre['badge']) : '',
+                    'order'  => isset($genre['order']) ? (int) $genre['order'] : PHP_INT_MAX,
+                    'custom' => true,
+                ],
+                $genre
+            );
+        }
+
+        $order_map = [];
+        foreach ($genres as $slug => $genre) {
+            $order_map[$slug] = isset($stored['order'][$slug])
+                ? (int) $stored['order'][$slug]
+                : (isset($genre['order']) ? (int) $genre['order'] : PHP_INT_MAX);
+        }
+
+        uasort($genres, function($a, $b) use ($order_map) {
+            $order_a = isset($order_map[$a['slug']]) ? $order_map[$a['slug']] : PHP_INT_MAX;
+            $order_b = isset($order_map[$b['slug']]) ? $order_map[$b['slug']] : PHP_INT_MAX;
+
+            if ($order_a === $order_b) {
+                return strcmp($a['name'], $b['name']);
+            }
+
+            return $order_a <=> $order_b;
+        });
+
+        return $genres;
+    }
+
+    public function get_genre_choices() {
+        $genres = $this->get_genres();
+        $choices = [];
+
+        foreach ($genres as $slug => $genre) {
+            $choices[$slug] = $genre['name'];
+        }
+
+        return $choices;
+    }
+
+    public function handle_genre_actions() {
+        if (!isset($_GET['page']) || $_GET['page'] !== 'notation_jlg_settings') {
+            return;
+        }
+
+        if (!isset($_GET['tab']) || $_GET['tab'] !== 'genres') {
+            return;
+        }
+
+        if (!isset($_POST['jlg_genre_action'])) {
+            return;
+        }
+
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Permissions insuffisantes', 'notation-jlg'));
+        }
+
+        $action = sanitize_key(wp_unslash($_POST['jlg_genre_action']));
+        $nonce  = isset($_POST['jlg_genre_nonce']) ? sanitize_text_field(wp_unslash($_POST['jlg_genre_nonce'])) : '';
+
+        if (!wp_verify_nonce($nonce, 'jlg_genre_action')) {
+            wp_die(esc_html__('La vérification de sécurité a échoué.', 'notation-jlg'));
+        }
+
+        $stored = $this->get_stored_genre_data();
+        $this->ensure_storage_structure($stored);
+        $message = ['type' => 'error', 'message' => esc_html__('Action inconnue.', 'notation-jlg')];
+
+        switch ($action) {
+            case 'add':
+                $message = $this->add_genre($stored);
+                break;
+            case 'delete':
+                $message = $this->delete_genre($stored);
+                break;
+            case 'update':
+                $message = $this->update_genre($stored);
+                break;
+            case 'update_order':
+                $message = $this->update_order($stored);
+                break;
+            case 'reset':
+                $message = $this->reset_genres();
+                break;
+        }
+
+        set_transient('jlg_genres_message', $message, 30);
+
+        wp_safe_redirect(add_query_arg(['page' => 'notation_jlg_settings', 'tab' => 'genres'], admin_url('admin.php')));
+        exit;
+    }
+
+    private function add_genre(&$stored) {
+        $name  = isset($_POST['new_genre_name']) ? sanitize_text_field(wp_unslash($_POST['new_genre_name'])) : '';
+        $slug  = isset($_POST['new_genre_slug']) ? sanitize_title(wp_unslash($_POST['new_genre_slug'])) : '';
+        $color = isset($_POST['new_genre_color']) ? sanitize_hex_color(wp_unslash($_POST['new_genre_color'])) : '';
+        $badge = isset($_POST['new_genre_badge']) ? sanitize_text_field(wp_unslash($_POST['new_genre_badge'])) : '';
+
+        if ($name === '') {
+            return ['type' => 'error', 'message' => esc_html__('Le nom du genre est requis.', 'notation-jlg')];
+        }
+
+        if ($slug === '') {
+            $slug = sanitize_title($name);
+        }
+
+        if ($slug === '') {
+            return ['type' => 'error', 'message' => esc_html__('Le slug du genre est invalide.', 'notation-jlg')];
+        }
+
+        $existing = $this->get_genres();
+        if (isset($existing[$slug])) {
+            return ['type' => 'error', 'message' => esc_html__('Ce slug de genre existe déjà.', 'notation-jlg')];
+        }
+
+        if ($color === '' || !preg_match('/^#[0-9a-fA-F]{6}$/', $color)) {
+            $color = '#2563eb';
+        }
+
+        $stored['custom_genres'][$slug] = [
+            'name'  => $name,
+            'color' => $color,
+            'badge' => $badge,
+            'custom' => true,
+        ];
+
+        $max_order = 0;
+        foreach ($stored['order'] as $value) {
+            $max_order = max($max_order, (int) $value);
+        }
+        $stored['order'][$slug] = $max_order + 1;
+
+        update_option($this->option_name, $stored);
+
+        return ['type' => 'success', 'message' => esc_html__('Genre ajouté avec succès.', 'notation-jlg')];
+    }
+
+    private function delete_genre(&$stored) {
+        $slug = isset($_POST['genre_slug']) ? sanitize_title(wp_unslash($_POST['genre_slug'])) : '';
+        if ($slug === '') {
+            return ['type' => 'error', 'message' => esc_html__('Genre introuvable.', 'notation-jlg')];
+        }
+
+        if (!isset($stored['custom_genres'][$slug])) {
+            return ['type' => 'error', 'message' => esc_html__('Seuls les genres personnalisés peuvent être supprimés.', 'notation-jlg')];
+        }
+
+        unset($stored['custom_genres'][$slug]);
+        unset($stored['order'][$slug]);
+        update_option($this->option_name, $stored);
+
+        return ['type' => 'success', 'message' => esc_html__('Genre supprimé avec succès.', 'notation-jlg')];
+    }
+
+    private function update_genre(&$stored) {
+        $original_slug = isset($_POST['edit_genre_original_slug']) ? sanitize_title(wp_unslash($_POST['edit_genre_original_slug'])) : '';
+        if ($original_slug === '') {
+            return ['type' => 'error', 'message' => esc_html__('Genre introuvable.', 'notation-jlg')];
+        }
+
+        if (!isset($stored['custom_genres'][$original_slug])) {
+            return ['type' => 'error', 'message' => esc_html__('Seuls les genres personnalisés peuvent être modifiés.', 'notation-jlg')];
+        }
+
+        $name  = isset($_POST['edit_genre_name']) ? sanitize_text_field(wp_unslash($_POST['edit_genre_name'])) : '';
+        $slug  = isset($_POST['edit_genre_slug']) ? sanitize_title(wp_unslash($_POST['edit_genre_slug'])) : '';
+        $color = isset($_POST['edit_genre_color']) ? sanitize_hex_color(wp_unslash($_POST['edit_genre_color'])) : '';
+        $badge = isset($_POST['edit_genre_badge']) ? sanitize_text_field(wp_unslash($_POST['edit_genre_badge'])) : '';
+
+        if ($name === '') {
+            return ['type' => 'error', 'message' => esc_html__('Le nom du genre est requis.', 'notation-jlg')];
+        }
+
+        if ($slug === '') {
+            $slug = sanitize_title($name);
+        }
+
+        if ($slug === '') {
+            return ['type' => 'error', 'message' => esc_html__('Le slug du genre est invalide.', 'notation-jlg')];
+        }
+
+        $existing = $this->get_genres();
+        if ($slug !== $original_slug && isset($existing[$slug])) {
+            return ['type' => 'error', 'message' => esc_html__('Ce slug de genre existe déjà.', 'notation-jlg')];
+        }
+
+        if ($color === '' || !preg_match('/^#[0-9a-fA-F]{6}$/', $color)) {
+            $color = '#2563eb';
+        }
+
+        $updated_data = [
+            'name'  => $name,
+            'color' => $color,
+            'badge' => $badge,
+            'custom' => true,
+        ];
+
+        if ($slug !== $original_slug) {
+            $stored['custom_genres'][$slug] = $updated_data;
+            unset($stored['custom_genres'][$original_slug]);
+
+            if (isset($stored['order'][$original_slug])) {
+                $stored['order'][$slug] = $stored['order'][$original_slug];
+                unset($stored['order'][$original_slug]);
+            }
+        } else {
+            $stored['custom_genres'][$slug] = array_merge($stored['custom_genres'][$slug], $updated_data);
+        }
+
+        update_option($this->option_name, $stored);
+
+        return ['type' => 'success', 'message' => esc_html__('Genre mis à jour avec succès.', 'notation-jlg')];
+    }
+
+    private function update_order(&$stored) {
+        if (!isset($_POST['genre_order']) || !is_array($_POST['genre_order'])) {
+            return ['type' => 'error', 'message' => esc_html__('Aucun ordre reçu.', 'notation-jlg')];
+        }
+
+        $raw_order = wp_unslash($_POST['genre_order']);
+        $new_order = [];
+
+        foreach ($raw_order as $slug => $position) {
+            $slug = sanitize_title($slug);
+            if ($slug === '') {
+                continue;
+            }
+
+            $new_order[$slug] = max(1, intval($position));
+        }
+
+        if (empty($new_order)) {
+            return ['type' => 'error', 'message' => esc_html__('Impossible de mettre à jour l\'ordre.', 'notation-jlg')];
+        }
+
+        asort($new_order, SORT_NUMERIC);
+
+        $normalized = [];
+        $position = 1;
+        foreach ($new_order as $slug => $value) {
+            $normalized[$slug] = $position++;
+        }
+
+        $stored['order'] = $normalized;
+        update_option($this->option_name, $stored);
+
+        return ['type' => 'success', 'message' => esc_html__('Ordre des genres mis à jour.', 'notation-jlg')];
+    }
+
+    private function reset_genres() {
+        delete_option($this->option_name);
+        return ['type' => 'success', 'message' => esc_html__('Genres réinitialisés avec succès.', 'notation-jlg')];
+    }
+
+    public function render_genres_page() {
+        $message = get_transient('jlg_genres_message');
+        if (!empty($message)) {
+            $class = ($message['type'] ?? '') === 'success' ? 'notice-success' : 'notice-error';
+            echo '<div class="notice ' . esc_attr($class) . ' is-dismissible"><p>' . esc_html($message['message']) . '</p></div>';
+            delete_transient('jlg_genres_message');
+        }
+
+        $genres = $this->get_genres();
+        $custom_genres = $this->get_stored_genre_data()['custom_genres'];
+        ?>
+        <div style="display:grid;grid-template-columns:2fr 1fr;gap:20px;">
+            <div style="background:#fff;padding:20px;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+                <h3><?php esc_html_e('🎭 Liste des genres disponibles', 'notation-jlg'); ?></h3>
+                <form method="post" action="">
+                    <?php wp_nonce_field('jlg_genre_action', 'jlg_genre_nonce'); ?>
+                    <input type="hidden" name="jlg_genre_action" value="update_order">
+                    <table class="wp-list-table widefat striped">
+                        <thead>
+                            <tr>
+                                <th><?php esc_html_e('Ordre', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Nom', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Slug', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Couleur', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Badge', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Type', 'notation-jlg'); ?></th>
+                                <th><?php esc_html_e('Actions', 'notation-jlg'); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($genres as $slug => $genre) :
+                                $order = isset($genre['order']) ? (int) $genre['order'] : '';
+                                $color = !empty($genre['color']) ? $genre['color'] : '#4b5563';
+                                ?>
+                                <tr>
+                                    <td>
+                                        <input type="number" name="genre_order[<?php echo esc_attr($slug); ?>]" value="<?php echo esc_attr($order); ?>" min="1" class="small-text">
+                                    </td>
+                                    <td>
+                                        <span style="display:inline-flex;align-items:center;gap:6px;">
+                                            <span style="display:inline-block;width:14px;height:14px;border-radius:999px;background:<?php echo esc_attr($color); ?>;"></span>
+                                            <strong><?php echo esc_html($genre['name']); ?></strong>
+                                        </span>
+                                    </td>
+                                    <td><code><?php echo esc_html($slug); ?></code></td>
+                                    <td><?php echo esc_html($color); ?></td>
+                                    <td><?php echo esc_html($genre['badge']); ?></td>
+                                    <td>
+                                        <?php echo !empty($genre['custom']) ? esc_html__('Personnalisé', 'notation-jlg') : esc_html__('Par défaut', 'notation-jlg'); ?>
+                                    </td>
+                                    <td>
+                                        <?php if (!empty($genre['custom'])) : ?>
+                                            <button type="button" class="button button-small" data-genre-edit="<?php echo esc_attr($slug); ?>"><?php esc_html_e('Modifier', 'notation-jlg'); ?></button>
+                                            <button type="button" class="button button-small button-link-delete" name="jlg_genre_action_delete" value="<?php echo esc_attr($slug); ?>"><?php esc_html_e('Supprimer', 'notation-jlg'); ?></button>
+                                        <?php else : ?>
+                                            <span style="color:#6b7280;">—</span>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                    <p>
+                        <button type="submit" class="button button-primary"><?php esc_html_e('💾 Enregistrer l\'ordre', 'notation-jlg'); ?></button>
+                    </p>
+                </form>
+            </div>
+            <div style="display:flex;flex-direction:column;gap:20px;">
+                <div style="background:#fff;padding:20px;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+                    <h3><?php esc_html_e('➕ Ajouter un genre', 'notation-jlg'); ?></h3>
+                    <form method="post" action="">
+                        <?php wp_nonce_field('jlg_genre_action', 'jlg_genre_nonce'); ?>
+                        <input type="hidden" name="jlg_genre_action" value="add">
+                        <p>
+                            <label for="new_genre_name"><strong><?php esc_html_e('Nom du genre', 'notation-jlg'); ?> *</strong></label><br>
+                            <input type="text" id="new_genre_name" name="new_genre_name" class="regular-text" required>
+                        </p>
+                        <p>
+                            <label for="new_genre_slug"><strong><?php esc_html_e('Slug', 'notation-jlg'); ?></strong></label><br>
+                            <input type="text" id="new_genre_slug" name="new_genre_slug" class="regular-text" placeholder="action-aventure">
+                            <span class="description"><?php esc_html_e('Laissez vide pour générer automatiquement à partir du nom.', 'notation-jlg'); ?></span>
+                        </p>
+                        <p>
+                            <label for="new_genre_color"><strong><?php esc_html_e('Couleur', 'notation-jlg'); ?></strong></label><br>
+                            <input type="color" id="new_genre_color" name="new_genre_color" value="#2563eb">
+                        </p>
+                        <p>
+                            <label for="new_genre_badge"><strong><?php esc_html_e('Badge (emoji ou texte court)', 'notation-jlg'); ?></strong></label><br>
+                            <input type="text" id="new_genre_badge" name="new_genre_badge" class="regular-text" placeholder="🔥">
+                        </p>
+                        <p>
+                            <button type="submit" class="button button-primary"><?php esc_html_e('Ajouter le genre', 'notation-jlg'); ?></button>
+                        </p>
+                    </form>
+                </div>
+                <div style="background:#fff;padding:20px;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+                    <h3><?php esc_html_e('✏️ Modifier un genre personnalisé', 'notation-jlg'); ?></h3>
+                    <form method="post" action="" id="jlg-edit-genre-form">
+                        <?php wp_nonce_field('jlg_genre_action', 'jlg_genre_nonce'); ?>
+                        <input type="hidden" name="jlg_genre_action" value="update">
+                        <input type="hidden" name="edit_genre_original_slug" id="edit_genre_original_slug" value="">
+                        <p>
+                            <label for="edit_genre_selector"><strong><?php esc_html_e('Sélectionnez un genre', 'notation-jlg'); ?></strong></label><br>
+                            <select id="edit_genre_selector" name="edit_genre_selector" class="regular-text">
+                                <option value=""><?php esc_html_e('— Choisir —', 'notation-jlg'); ?></option>
+                                <?php foreach ($custom_genres as $slug => $genre_data) : ?>
+                                    <option value="<?php echo esc_attr($slug); ?>" data-name="<?php echo esc_attr($genre_data['name'] ?? $slug); ?>" data-color="<?php echo esc_attr($genre_data['color'] ?? '#2563eb'); ?>" data-badge="<?php echo esc_attr($genre_data['badge'] ?? ''); ?>">
+                                        <?php echo esc_html($genre_data['name'] ?? $slug); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </p>
+                        <p>
+                            <label for="edit_genre_name"><strong><?php esc_html_e('Nom', 'notation-jlg'); ?></strong></label><br>
+                            <input type="text" id="edit_genre_name" name="edit_genre_name" class="regular-text">
+                        </p>
+                        <p>
+                            <label for="edit_genre_slug"><strong><?php esc_html_e('Slug', 'notation-jlg'); ?></strong></label><br>
+                            <input type="text" id="edit_genre_slug" name="edit_genre_slug" class="regular-text">
+                        </p>
+                        <p>
+                            <label for="edit_genre_color"><strong><?php esc_html_e('Couleur', 'notation-jlg'); ?></strong></label><br>
+                            <input type="color" id="edit_genre_color" name="edit_genre_color" value="#2563eb">
+                        </p>
+                        <p>
+                            <label for="edit_genre_badge"><strong><?php esc_html_e('Badge', 'notation-jlg'); ?></strong></label><br>
+                            <input type="text" id="edit_genre_badge" name="edit_genre_badge" class="regular-text">
+                        </p>
+                        <p>
+                            <button type="submit" class="button button-primary"><?php esc_html_e('Mettre à jour le genre', 'notation-jlg'); ?></button>
+                        </p>
+                    </form>
+                </div>
+                <div style="background:#fff;padding:20px;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+                    <h3><?php esc_html_e('⚙️ Actions', 'notation-jlg'); ?></h3>
+                    <form method="post" action="" onsubmit="return confirm('<?php echo esc_js(__('Êtes-vous sûr de vouloir réinitialiser les genres ? Cette action supprimera toutes les entrées personnalisées.', 'notation-jlg')); ?>');">
+                        <?php wp_nonce_field('jlg_genre_action', 'jlg_genre_nonce'); ?>
+                        <input type="hidden" name="jlg_genre_action" value="reset">
+                        <button type="submit" class="button"><?php esc_html_e('🔄 Réinitialiser les genres', 'notation-jlg'); ?></button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <script>
+        (function($){
+            $('#jlg-edit-genre-form').on('submit', function(){
+                return $('#edit_genre_original_slug').val() !== '';
+            });
+
+            $('[data-genre-edit]').on('click', function(){
+                var slug = $(this).data('genre-edit');
+                var $option = $('#edit_genre_selector option[value="' + slug + '"]');
+                if (!$option.length) {
+                    return;
+                }
+                $('#edit_genre_selector').val(slug);
+                $('#edit_genre_original_slug').val(slug);
+                $('#edit_genre_name').val($option.data('name') || slug);
+                $('#edit_genre_slug').val(slug);
+                $('#edit_genre_color').val($option.data('color') || '#2563eb');
+                $('#edit_genre_badge').val($option.data('badge') || '');
+            });
+
+            $('#edit_genre_selector').on('change', function(){
+                var slug = $(this).val();
+                var $option = $(this).find('option:selected');
+                if (!slug) {
+                    $('#edit_genre_original_slug').val('');
+                    $('#edit_genre_name').val('');
+                    $('#edit_genre_slug').val('');
+                    $('#edit_genre_color').val('#2563eb');
+                    $('#edit_genre_badge').val('');
+                    return;
+                }
+                $('#edit_genre_original_slug').val(slug);
+                $('#edit_genre_name').val($option.data('name') || slug);
+                $('#edit_genre_slug').val(slug);
+                $('#edit_genre_color').val($option.data('color') || '#2563eb');
+                $('#edit_genre_badge').val($option.data('badge') || '');
+            });
+
+            $('button[name="jlg_genre_action_delete"]').on('click', function(event){
+                event.preventDefault();
+                var slug = $(this).val();
+                if (!slug) {
+                    return;
+                }
+                if (!confirm('<?php echo esc_js(__('Confirmer la suppression de ce genre ?', 'notation-jlg')); ?>')) {
+                    return;
+                }
+                var $form = $('<form>', { method: 'POST', action: '' });
+                $form.append($('<input>', { type: 'hidden', name: 'jlg_genre_action', value: 'delete' }));
+                $form.append($('<input>', { type: 'hidden', name: 'genre_slug', value: slug }));
+                $form.append($('<input>', { type: 'hidden', name: 'jlg_genre_nonce', value: '<?php echo wp_create_nonce('jlg_genre_action'); ?>' }));
+                $('body').append($form);
+                $form.trigger('submit');
+            });
+        })(jQuery);
+        </script>
+        <?php
+    }
+
+    public function maybe_display_migration_notice() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $unmapped = get_option('jlg_genres_migration_unmapped', []);
+        if (empty($unmapped) || !is_array($unmapped)) {
+            return;
+        }
+
+        if (get_user_meta(get_current_user_id(), 'jlg_genres_notice_dismissed', true)) {
+            return;
+        }
+
+        $dismiss_url = wp_nonce_url(add_query_arg('jlg-dismiss-genre-notice', '1'), 'jlg_dismiss_genre_notice');
+        echo '<div class="notice notice-warning is-dismissible">';
+        echo '<p><strong>' . esc_html__('Notation JLG – Migration des genres', 'notation-jlg') . '</strong></p>';
+        echo '<p>' . esc_html__('Certaines valeurs historiques de genres n\'ont pas pu être converties automatiquement. Merci de les mapper manuellement dans l\'onglet "Types de jeu".', 'notation-jlg') . '</p>';
+        echo '<p>' . esc_html__('Valeurs détectées :', 'notation-jlg') . ' <code>' . esc_html(implode(', ', array_slice($unmapped, 0, 5))) . '</code></p>';
+        echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=notation_jlg_settings&tab=genres')) . '">' . esc_html__('Ouvrir la gestion des genres', 'notation-jlg') . '</a> ';
+        echo '<a class="button button-link" href="' . esc_url($dismiss_url) . '">' . esc_html__('Ignorer cette notification', 'notation-jlg') . '</a></p>';
+        echo '</div>';
+    }
+
+    public function handle_notice_dismissal() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        if (!isset($_GET['jlg-dismiss-genre-notice'])) {
+            return;
+        }
+
+        if (!isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'jlg_dismiss_genre_notice')) {
+            return;
+        }
+
+        update_user_meta(get_current_user_id(), 'jlg_genres_notice_dismissed', 1);
+        delete_option('jlg_genres_migration_unmapped');
+
+        wp_safe_redirect(remove_query_arg(['jlg-dismiss-genre-notice', '_wpnonce']));
+        exit;
+    }
+}

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -53,6 +53,7 @@ class JLG_Admin_Menu {
             'reglages' => __('⚙️ Réglages', 'notation-jlg'),
             'articles_notes' => __('📊 Articles Notés', 'notation-jlg'),
             'plateformes' => __('🎮 Plateformes', 'notation-jlg'),
+            'genres' => __('🎭 Types de jeu', 'notation-jlg'),
             'shortcodes' => __('📝 Shortcodes', 'notation-jlg'),
             'tutoriels' => __('📚 Tutoriels', 'notation-jlg'),
         ];
@@ -72,6 +73,8 @@ class JLG_Admin_Menu {
                 return $this->get_posts_list_tab_content();
             case 'plateformes':
                 return $this->get_platforms_tab_content();
+            case 'genres':
+                return $this->get_genres_tab_content();
             case 'shortcodes':
                 return $this->get_shortcodes_tab_content();
             case 'tutoriels':
@@ -242,6 +245,33 @@ class JLG_Admin_Menu {
         }
 
         return $results;
+    }
+
+    private function get_genres_tab_content() {
+        ob_start();
+        echo '<h2 class=\"title\">' . esc_html__('🎭 Gestion des Types de jeu', 'notation-jlg') . '</h2>';
+        $this->render_genres_tab();
+        return ob_get_clean();
+    }
+
+    private function render_genres_tab() {
+        if (class_exists('JLG_Admin_Genres')) {
+            $genres_manager = JLG_Admin_Genres::get_instance();
+            $genres_manager->render_genres_page();
+            return;
+        }
+
+        $path = JLG_NOTATION_PLUGIN_DIR . 'includes/admin/class-jlg-admin-genres.php';
+        if (file_exists($path)) {
+            require_once $path;
+            if (class_exists('JLG_Admin_Genres')) {
+                $genres_manager = JLG_Admin_Genres::get_instance();
+                $genres_manager->render_genres_page();
+                return;
+            }
+        }
+
+        echo '<div class=\"notice notice-error\"><p>' . esc_html__('Impossible de charger la gestion des genres.', 'notation-jlg') . '</p></div>';
     }
 
     private function get_platforms_tab_content() {

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -758,6 +758,7 @@ class JLG_Frontend {
             'order'      => isset($_POST['order']) ? sanitize_text_field(wp_unslash($_POST['order'])) : 'DESC',
             'cat_filter' => isset($_POST['cat_filter']) ? intval($_POST['cat_filter']) : 0,
             'paged'      => isset($_POST['paged']) ? intval($_POST['paged']) : 1,
+            'genre_filter' => isset($_POST['genre_filter']) ? sanitize_title(wp_unslash($_POST['genre_filter'])) : '',
         ];
 
         $current_url = isset($_POST['current_url']) ? esc_url_raw(wp_unslash($_POST['current_url'])) : '';
@@ -781,6 +782,7 @@ class JLG_Frontend {
             'order'      => $context['order'] ?? 'DESC',
             'paged'      => $context['paged'] ?? 1,
             'cat_filter' => $context['cat_filter'] ?? 0,
+            'genre_filter' => $context['genre_filter'] ?? '',
             'total_pages' => 0,
         ];
 
@@ -939,6 +941,8 @@ class JLG_Frontend {
                 'colonnes_disponibles' => [],
                 'error_message'      => '',
                 'cat_filter'         => 0,
+                'genre_filter'       => '',
+                'genre_options'      => [],
                 'table_id'           => '',
                 'widget_args'        => [],
                 'title'              => '',

--- a/plugin-notation-jeux_V4/includes/class-jlg-widget.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-widget.php
@@ -14,6 +14,12 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
     public function widget($args, $instance) {
         $title = apply_filters('widget_title', $instance['title'] ?? __('Derniers Tests', 'notation-jlg'));
         $number = (!empty($instance['number'])) ? absint($instance['number']) : 5;
+        $genre_slug = !empty($instance['genre']) ? sanitize_title($instance['genre']) : '';
+
+        $genre_options = class_exists('JLG_Helpers') ? JLG_Helpers::get_registered_genres() : [];
+        if ($genre_slug !== '' && !isset($genre_options[$genre_slug])) {
+            $genre_slug = '';
+        }
 
         $rated_post_ids = JLG_Helpers::get_rated_post_ids();
 
@@ -35,6 +41,16 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
             'order' => 'DESC',
             'ignore_sticky_posts' => 1
         ];
+
+        if ($genre_slug !== '') {
+            $query_args['meta_query'] = [
+                [
+                    'key'     => '_jlg_genres',
+                    'value'   => '"' . $genre_slug . '"',
+                    'compare' => 'LIKE',
+                ],
+            ];
+        }
         
         $latest_reviews = new WP_Query($query_args);
 
@@ -42,13 +58,36 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
         echo JLG_Frontend::get_template_html('widget-latest-reviews', [
             'widget_args' => $args,
             'title' => $title,
-            'latest_reviews' => $latest_reviews
+            'latest_reviews' => $latest_reviews,
+            'selected_genre' => $genre_slug,
         ]);
     }
 
     public function form($instance) {
         $title = !empty($instance['title']) ? $instance['title'] : __('Derniers Tests', 'notation-jlg');
         $number = isset($instance['number']) ? absint($instance['number']) : 5;
+        $selected_genre = isset($instance['genre']) ? sanitize_title($instance['genre']) : '';
+
+        $genre_choices = [];
+        if (class_exists('JLG_Helpers')) {
+            foreach (JLG_Helpers::get_registered_genres() as $slug => $genre) {
+                if (!is_array($genre)) {
+                    continue;
+                }
+
+                $label = isset($genre['name']) ? $genre['name'] : $slug;
+                $label = sanitize_text_field($label);
+                if ($label === '') {
+                    continue;
+                }
+
+                $genre_choices[$slug] = $label;
+            }
+        }
+
+        if ($selected_genre !== '' && !isset($genre_choices[$selected_genre])) {
+            $selected_genre = '';
+        }
         ?>
         <p>
             <label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php echo esc_html__('Titre :', 'notation-jlg'); ?></label>
@@ -62,6 +101,19 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
                    name="<?php echo esc_attr($this->get_field_name('number')); ?>"
                    type="number" step="1" min="1" value="<?php echo esc_attr($number); ?>" size="3">
         </p>
+        <?php if (!empty($genre_choices)) : ?>
+            <p>
+                <label for="<?php echo esc_attr($this->get_field_id('genre')); ?>"><?php echo esc_html__('Filtrer par genre :', 'notation-jlg'); ?></label>
+                <select class="widefat"
+                        id="<?php echo esc_attr($this->get_field_id('genre')); ?>"
+                        name="<?php echo esc_attr($this->get_field_name('genre')); ?>">
+                    <option value="" <?php selected($selected_genre, ''); ?>><?php echo esc_html__('Tous les genres', 'notation-jlg'); ?></option>
+                    <?php foreach ($genre_choices as $slug => $label) : ?>
+                        <option value="<?php echo esc_attr($slug); ?>" <?php selected($selected_genre, $slug); ?>><?php echo esc_html($label); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </p>
+        <?php endif; ?>
         <?php
     }
 
@@ -69,6 +121,20 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
         $instance = [];
         $instance['title'] = (!empty($new_instance['title'])) ? strip_tags($new_instance['title']) : '';
         $instance['number'] = (!empty($new_instance['number'])) ? absint($new_instance['number']) : 5;
+        $instance['genre'] = '';
+
+        if (!empty($new_instance['genre'])) {
+            $genre_slug = sanitize_title($new_instance['genre']);
+
+            if ($genre_slug !== '' && class_exists('JLG_Helpers')) {
+                $registered_genres = JLG_Helpers::get_registered_genres();
+                if (!isset($registered_genres[$genre_slug])) {
+                    $genre_slug = '';
+                }
+            }
+
+            $instance['genre'] = $genre_slug;
+        }
         return $instance;
     }
 }

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
@@ -80,6 +80,56 @@ class JLG_Validator {
         return array_values(array_intersect($sanitized, $allowed_platforms));
     }
 
+    public static function sanitize_genres($genres, $primary = '') {
+        $registered = class_exists('JLG_Helpers') ? JLG_Helpers::get_registered_genres() : [];
+
+        if (empty($registered) || !is_array($registered)) {
+            return [];
+        }
+
+        if (!is_array($genres)) {
+            if (is_string($genres)) {
+                $genres = preg_split('/[,;|]/', $genres);
+            } else {
+                $genres = [];
+            }
+        }
+
+        $allowed_slugs = array_keys($registered);
+        $selected = [];
+
+        foreach ($genres as $value) {
+            if (is_array($value)) {
+                $value = implode(' ', $value);
+            }
+
+            $slug = sanitize_title($value);
+
+            if ($slug === '' || !in_array($slug, $allowed_slugs, true)) {
+                continue;
+            }
+
+            if (!in_array($slug, $selected, true)) {
+                $selected[] = $slug;
+            }
+        }
+
+        if (empty($selected)) {
+            return [];
+        }
+
+        $primary_slug = sanitize_title($primary);
+
+        if ($primary_slug === '' || !in_array($primary_slug, $selected, true)) {
+            $primary_slug = $selected[0];
+        }
+
+        return [
+            'selected' => $selected,
+            'primary' => $primary_slug,
+        ];
+    }
+
     public static function validate_date($date, $allow_empty = true) {
         if ($date === '' || $date === null) {
             return $allow_empty;

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -137,6 +137,12 @@ final class JLG_Plugin_De_Notation_Main {
             add_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
         }
 
+        if (!get_option('jlg_genres_list')) {
+            add_option('jlg_genres_list', JLG_Helpers::get_default_genres_storage());
+        }
+
+        JLG_Helpers::migrate_legacy_genre_meta();
+
         update_option('jlg_notation_version', JLG_NOTATION_VERSION);
         flush_rewrite_rules();
     }

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -20,6 +20,9 @@ $current_orderby = !empty($orderby) ? $orderby : 'date';
 $current_order = !empty($order) ? $order : 'DESC';
 $show_filters = ($atts['layout'] === 'table' && empty($atts['categorie']));
 $current_cat_filter = ($show_filters && isset($cat_filter)) ? intval($cat_filter) : 0;
+$genre_options = is_array($genre_options) ? $genre_options : [];
+$resolved_genre_filter = isset($genre_filter) ? sanitize_title($genre_filter) : '';
+$current_genre_filter = ($show_filters && empty($atts['genre'])) ? $resolved_genre_filter : '';
 $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $columns)) : '';
 ?>
 
@@ -34,8 +37,9 @@ $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $colum
     data-order="<?php echo esc_attr($current_order); ?>"
     data-paged="<?php echo esc_attr(intval($paged)); ?>"
     data-cat-filter="<?php echo esc_attr($current_cat_filter); ?>"
+    data-genre-filter="<?php echo esc_attr($resolved_genre_filter); ?>"
 >
-    
+
     <?php if ($show_filters) : ?>
         <!-- Filtres -->
         <div class="jlg-summary-filters">
@@ -53,6 +57,14 @@ $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $colum
                     'hierarchical' => true
                 ]);
                 ?>
+                <?php if (empty($atts['genre']) && !empty($genre_options)) : ?>
+                    <select name="genre_filter" id="jlg_genre_filter">
+                        <option value=""><?php echo esc_html__('Tous les genres', 'notation-jlg'); ?></option>
+                        <?php foreach ($genre_options as $slug => $label) : ?>
+                            <option value="<?php echo esc_attr($slug); ?>" <?php selected($current_genre_filter, $slug); ?>><?php echo esc_html($label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
                 <input type="submit" value="<?php echo esc_attr__('Filtrer', 'notation-jlg'); ?>">
             </form>
         </div>
@@ -70,6 +82,8 @@ $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $colum
             'colonnes_disponibles' => $available_columns,
             'error_message'        => isset($error_message) ? $error_message : '',
             'cat_filter'           => $current_cat_filter,
+            'genre_filter'         => $resolved_genre_filter,
+            'genre_options'        => $genre_options,
             'table_id'             => $table_id,
         ]);
         ?>

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -17,6 +17,8 @@ $layout = isset($atts['layout']) ? $atts['layout'] : 'table';
 $current_orderby = !empty($orderby) ? $orderby : 'date';
 $current_order = !empty($order) ? strtoupper($order) : 'DESC';
 $current_cat_filter = isset($cat_filter) ? intval($cat_filter) : 0;
+$resolved_genre_filter = isset($genre_filter) ? sanitize_title($genre_filter) : '';
+$genre_options = is_array($genre_options) ? $genre_options : [];
 $default_empty_message = '<p>' . esc_html__('Aucun article trouvé pour cette sélection.', 'notation-jlg') . '</p>';
 $empty_message = !empty($error_message) ? $error_message : $default_empty_message;
 $columns_count = count($columns);
@@ -105,6 +107,14 @@ if ($layout === 'grid') :
                     <div class="jlg-game-card-title">
                         <span><?php echo esc_html($game_title); ?></span>
                     </div>
+                    <?php
+                    $genre_markup = class_exists('JLG_Helpers') ? JLG_Helpers::get_genre_badges_markup($post_id) : '';
+                    if (!empty($genre_markup)) :
+                    ?>
+                        <div class="jlg-game-card-genres" style="margin-top:8px;display:flex;flex-wrap:wrap;gap:6px;">
+                            <?php echo wp_kses_post($genre_markup); ?>
+                        </div>
+                    <?php endif; ?>
                 </a>
             <?php endwhile;
         else :
@@ -171,6 +181,9 @@ else :
                                         $publisher = get_post_meta($post_id, '_jlg_editeur', true) ?: __('-', 'notation-jlg');
                                         echo esc_html($publisher);
                                         break;
+                                    case 'genres':
+                                        echo wp_kses_post(class_exists('JLG_Helpers') ? JLG_Helpers::get_genre_badges_markup($post_id) : '');
+                                        break;
                                 }
                                 echo '</td>';
                             }
@@ -215,6 +228,10 @@ if ($total_pages > 1) {
 
     if ($current_cat_filter > 0) {
         $pagination_args['add_args']['cat_filter'] = $current_cat_filter;
+    }
+
+    if ($resolved_genre_filter !== '') {
+        $pagination_args['add_args']['genre_filter'] = $resolved_genre_filter;
     }
 
     $pagination_links = paginate_links($pagination_args);

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -13,7 +13,13 @@ if ($latest_reviews->have_posts()) {
         $latest_reviews->the_post();
         $post_id = get_the_ID();
         $game_title = JLG_Helpers::get_game_title($post_id);
-        echo '<li><a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a></li>';
+        echo '<li>';
+        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a>';
+        $genre_markup = class_exists('JLG_Helpers') ? JLG_Helpers::get_genre_badges_markup($post_id, false) : '';
+        if (!empty($genre_markup)) {
+            echo '<div class="jlg-widget-genre-badges" style="margin-top:4px;display:flex;flex-wrap:wrap;gap:4px;">' . wp_kses_post($genre_markup) . '</div>';
+        }
+        echo '</li>';
     }
     echo '</ul>';
 } else {

--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -22,6 +22,8 @@ if ($delete_data) {
     delete_option('jlg_notation_version');
     delete_option('jlg_migration_v5_completed');
     delete_option('jlg_platforms_list');
+    delete_option('jlg_genres_list');
+    delete_option('jlg_genres_migration_unmapped');
     delete_option('jlg_notation_delete_data_on_uninstall');
     
     // Supprimer toutes les métadonnées des posts
@@ -33,6 +35,7 @@ if ($delete_data) {
         '_jlg_points_forts', '_jlg_points_faibles',
         '_jlg_developpeur', '_jlg_editeur',
         '_jlg_date_sortie', '_jlg_plateformes',
+        '_jlg_genres',
         '_jlg_cover_image_url', '_jlg_version',
         '_jlg_pegi', '_jlg_temps_de_jeu',
         '_jlg_user_ratings', '_jlg_user_rating_avg',
@@ -46,4 +49,6 @@ if ($delete_data) {
     // Nettoyer les transients éventuels
     $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_jlg_%'");
     $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_jlg_%'");
+
+    delete_metadata('user', 0, 'jlg_genres_notice_dismissed', '', true);
 }


### PR DESCRIPTION
## Summary
- add a dedicated admin manager for genres, including CRUD/order UI and migration notice hooks wired into the settings screen
- surface genre data across helpers, metaboxes, widgets, templates, and AJAX endpoints so games can be tagged and filtered by type
- update activation/uninstall routines and client scripts to persist, display, and clean up genre selections consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2e2344910832eb6d3919a5aa9d2f6