### PR TITLE
Limit frontend JS loading to active shortcodes

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -38,7 +38,7 @@ class JLG_Shortcode_All_In_One {
         }
     }
 
-    public function render($atts) {
+    public function render($atts, $content = '', $shortcode_tag = '') {
         // Attributs du shortcode
         $atts = shortcode_atts([
             'post_id' => get_the_ID(),
@@ -283,7 +283,8 @@ class JLG_Shortcode_All_In_One {
 
         $css_variables_string = $this->format_css_variables($css_variables);
 
-        JLG_Frontend::mark_shortcode_rendered();
+        $tag = $shortcode_tag !== '' ? $shortcode_tag : 'jlg_bloc_complet';
+        JLG_Frontend::mark_shortcode_rendered($tag);
 
         return JLG_Frontend::get_template_html('shortcode-all-in-one', [
             'options' => $options,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -7,14 +7,14 @@ class JLG_Shortcode_Game_Explorer {
         add_shortcode('jlg_game_explorer', [$this, 'render']);
     }
 
-    public function render($atts) {
+    public function render($atts, $content = '', $shortcode_tag = '') {
         $context = self::get_render_context($atts, $_GET);
 
         if (!empty($context['error']) && !empty($context['message'])) {
             return $context['message'];
         }
 
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_game_explorer');
 
         return JLG_Frontend::get_template_html('shortcode-game-explorer', $context);
     }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -7,7 +7,7 @@ class JLG_Shortcode_Game_Info {
         add_shortcode('jlg_fiche_technique', [$this, 'render']);
     }
 
-    public function render($atts) {
+    public function render($atts, $content = '', $shortcode_tag = '') {
         if (!is_singular('post')) {
             return '';
         }
@@ -55,7 +55,7 @@ class JLG_Shortcode_Game_Info {
             return '';
         }
         
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_fiche_technique');
 
         return JLG_Frontend::get_template_html('shortcode-game-info', [
             'titre'             => sanitize_text_field($atts['titre']),

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
@@ -7,7 +7,7 @@ class JLG_Shortcode_Pros_Cons {
         add_shortcode('jlg_points_forts_faibles', [$this, 'render']);
     }
 
-    public function render() {
+    public function render($atts = [], $content = '', $shortcode_tag = '') {
         // Sécurité : ne s'exécute que sur les articles ('post') ou pages singulières
         if (!is_singular('post')) {
             return '';
@@ -21,7 +21,7 @@ class JLG_Shortcode_Pros_Cons {
             return '';
         }
         
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_points_forts_faibles');
 
         return JLG_Frontend::get_template_html('shortcode-pros-cons', [
             'pros_list' => !empty($pros) ? array_filter(explode("\n", $pros)) : [],

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
@@ -7,7 +7,7 @@ class JLG_Shortcode_Rating_Block {
         add_shortcode('bloc_notation_jeu', [$this, 'render']);
     }
 
-    public function render($atts) {
+    public function render($atts, $content = '', $shortcode_tag = '') {
         $atts = shortcode_atts([
             'post_id' => get_the_ID()
         ], $atts, 'bloc_notation_jeu');
@@ -43,7 +43,7 @@ class JLG_Shortcode_Rating_Block {
             }
         }
         
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'bloc_notation_jeu');
 
         return JLG_Frontend::get_template_html('shortcode-rating-block', [
             'options'       => JLG_Helpers::get_plugin_options(),

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -14,14 +14,14 @@ class JLG_Shortcode_Summary_Display {
         add_shortcode('jlg_tableau_recap', [$this, 'render']);
     }
 
-    public function render($atts) {
+    public function render($atts, $content = '', $shortcode_tag = '') {
         $context = self::get_render_context($atts, $_GET, true);
 
         if (!empty($context['error']) && !empty($context['message'])) {
             return $context['message'];
         }
 
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_tableau_recap');
 
         return JLG_Frontend::get_template_html('shortcode-summary-display', $context);
     }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
@@ -7,7 +7,7 @@ class JLG_Shortcode_Tagline {
         add_shortcode('tagline_notation_jlg', [$this, 'render']);
     }
 
-    public function render() {
+    public function render($atts = [], $content = '', $shortcode_tag = '') {
         if (!is_singular('post')) {
             return '';
         }
@@ -24,7 +24,7 @@ class JLG_Shortcode_Tagline {
             return '';
         }
         
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'tagline_notation_jlg');
 
         return JLG_Frontend::get_template_html('shortcode-tagline', [
             'options' => $options,

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -7,7 +7,7 @@ class JLG_Shortcode_User_Rating {
         add_shortcode('notation_utilisateurs_jlg', [$this, 'render']);
     }
 
-    public function render() {
+    public function render($atts = [], $content = '', $shortcode_tag = '') {
         if (!is_singular('post')) {
             return '';
         }
@@ -20,7 +20,7 @@ class JLG_Shortcode_User_Rating {
         $post_id = get_the_ID();
         list($has_voted, $user_vote) = JLG_Frontend::get_user_vote_for_post($post_id);
 
-        JLG_Frontend::mark_shortcode_rendered();
+        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'notation_utilisateurs_jlg');
 
         return JLG_Frontend::get_template_html('shortcode-user-rating', [
             'options' => $options,


### PR DESCRIPTION
## Summary
- add tracking of executed shortcodes in the frontend to know which components are rendered and gate the summary table / game explorer scripts accordingly, including AJAX fallbacks
- update each shortcode renderer to pass its tag to the tracking helper so usage is recorded precisely

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2f72afde0832e8a2cb2d162c69f5b