### PR TITLE
Handle note metadata when detecting frontend assets

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -214,7 +214,10 @@ class JLG_Frontend {
         }
 
         foreach ($meta as $meta_key => $values) {
-            if (strpos($meta_key, '_jlg_') !== 0) {
+            $is_plugin_meta = strpos($meta_key, '_jlg_') === 0
+                || strpos($meta_key, '_note_') === 0;
+
+            if (!$is_plugin_meta) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- detect both `_jlg_` and `_note_` metadata when checking if frontend assets should load
- keep ignoring empty metadata values via the existing helper

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2f73715d0832ea65661dcf1aab787