### PR TITLE
Allow user rating via rendered shortcodes

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -851,7 +851,7 @@ class JLG_Frontend {
         $content = $post->post_content ?? '';
 
         foreach (['notation_utilisateurs_jlg', 'jlg_bloc_complet', 'bloc_notation_complet'] as $shortcode) {
-            if (has_shortcode($content, $shortcode)) {
+            if (has_shortcode($content, $shortcode) || self::has_rendered_shortcode($shortcode)) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- make `post_allows_user_rating()` honor shortcodes that were executed during the request even if they are not inside the post content
- cover the behavior with a regression test that marks the shortcode as rendered outside of the post body

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d31ebd53cc832ea6b41c600da40117