### PR TITLE
Prevent TypeErrors from malformed shortcode query params

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -253,7 +253,7 @@ class JLG_Shortcode_Game_Explorer {
         $filters_enabled = self::normalize_filters($atts['filters']);
 
         $request = is_array($request) ? $request : [];
-        $orderby = isset($request['orderby']) ? sanitize_key($request['orderby']) : 'date';
+        $orderby = (isset($request['orderby']) && is_string($request['orderby'])) ? sanitize_key($request['orderby']) : 'date';
         $order = isset($request['order']) ? strtoupper(sanitize_text_field($request['order'])) : 'DESC';
         if (!in_array($order, ['ASC', 'DESC'], true)) {
             $order = 'DESC';
@@ -262,7 +262,7 @@ class JLG_Shortcode_Game_Explorer {
         $letter_filter = isset($request['letter']) ? self::normalize_letter($request['letter']) : '';
         $category_filter = isset($request['category']) ? sanitize_text_field($request['category']) : '';
         $platform_filter = isset($request['platform']) ? sanitize_text_field($request['platform']) : '';
-        $availability_filter = isset($request['availability']) ? sanitize_key($request['availability']) : '';
+        $availability_filter = (isset($request['availability']) && is_string($request['availability'])) ? sanitize_key($request['availability']) : '';
         $search_filter = isset($request['search']) ? sanitize_text_field($request['search']) : '';
         $paged = isset($request['paged']) ? max(1, (int) $request['paged']) : 1;
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -52,7 +52,7 @@ class JLG_Shortcode_Summary_Display {
 
         $request = is_array($request) ? $request : [];
 
-        $orderby = isset($request['orderby']) ? sanitize_key($request['orderby']) : 'date';
+        $orderby = (isset($request['orderby']) && is_string($request['orderby'])) ? sanitize_key($request['orderby']) : 'date';
         $order = isset($request['order']) && in_array(strtoupper($request['order']), ['ASC', 'DESC'], true)
             ? strtoupper($request['order'])
             : 'DESC';


### PR DESCRIPTION
## Summary
- guard shortcode request handling against non-string orderby values before calling sanitize_key
- ensure availability filter also verifies a string before sanitizing

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3a5cdca40832ea7f4c8c1cbb6f9ea