### PR TITLE
Harden AJAX responses

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -5,7 +5,6 @@ class JLG_Admin_Ajax {
     
     public function __construct() {
         add_action('wp_ajax_jlg_search_rawg_games', [$this, 'handle_rawg_search']);
-        add_action('wp_ajax_nopriv_jlg_search_rawg_games', [$this, 'handle_rawg_search']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_ajax_assets']);
     }
 
@@ -39,13 +38,13 @@ class JLG_Admin_Ajax {
 
         // Sécurité basique
         if (!current_user_can('edit_posts')) {
-            wp_send_json_error('Permissions insuffisantes.');
+            wp_send_json_error('Permissions insuffisantes.', 403);
         }
 
         $search_term = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
         
         if (empty($search_term)) {
-            wp_send_json_error('Terme de recherche vide.');
+            wp_send_json_error('Terme de recherche vide.', 400);
         }
 
         // Simulation de réponse (remplacez par vraie API si vous avez une clé)

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -558,7 +558,7 @@ class JLG_Frontend {
         $post_id = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
 
         if (!$post_id) {
-            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')]);
+            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')], 400);
         }
 
         $post = get_post($post_id);
@@ -580,7 +580,7 @@ class JLG_Frontend {
         $rating = isset($_POST['rating']) ? intval($_POST['rating']) : 0;
 
         if ($rating < 1 || $rating > 5) {
-            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')]);
+            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')], 422);
         }
 
         $user_ip = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP);
@@ -607,7 +607,7 @@ class JLG_Frontend {
         $ratings = self::get_post_user_rating_tokens($post_id, $ratings_meta);
 
         if (isset($ratings[$token_hash])) {
-            wp_send_json_error(['message' => esc_html__('Vous avez déjà voté !', 'notation-jlg')]);
+            wp_send_json_error(['message' => esc_html__('Vous avez déjà voté !', 'notation-jlg')], 409);
         }
 
         $ratings[$token_hash] = $rating;


### PR DESCRIPTION
## Summary
- secure the RAWG admin search endpoint by limiting it to authenticated users and returning explicit status codes on errors
- add HTTP status codes to invalid input and duplicate vote responses in the frontend user rating handler

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3be067084832e8aa996189f960668