### PR TITLE
Secure AJAX sorting and cache plugin options

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -10,6 +10,7 @@ class JLG_Helpers {
 
     private static $option_name = 'notation_jlg_settings';
     private static $category_keys = ['cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6'];
+    private static $options_cache = null;
 
     private static function get_theme_defaults() {
         return [
@@ -140,10 +141,20 @@ class JLG_Helpers {
         ];
     }
 
-    public static function get_plugin_options() {
+    public static function get_plugin_options($force_refresh = false) {
+        if (!$force_refresh && is_array(self::$options_cache)) {
+            return self::$options_cache;
+        }
+
         $defaults = self::get_default_settings();
         $saved_options = get_option(self::$option_name, $defaults);
-        return wp_parse_args($saved_options, $defaults);
+        self::$options_cache = wp_parse_args($saved_options, $defaults);
+
+        return self::$options_cache;
+    }
+
+    public static function flush_plugin_options_cache() {
+        self::$options_cache = null;
     }
 
     /**

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -85,6 +85,19 @@ class JLG_Shortcode_Game_Explorer {
         ];
     }
 
+    public static function get_allowed_sort_keys() {
+        $options = self::get_sort_options();
+        $keys = [];
+
+        foreach ($options as $option) {
+            if (isset($option['orderby'])) {
+                $keys[] = sanitize_key($option['orderby']);
+            }
+        }
+
+        return array_values(array_unique(array_filter($keys)));
+    }
+
     protected static function normalize_filters($filters_string) {
         $allowed = ['letter', 'category', 'platform', 'availability', 'search'];
         $normalized = [];

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -374,6 +374,22 @@ class JLG_Shortcode_Summary_Display {
         return $options;
     }
 
+    public static function get_allowed_sort_keys() {
+        $options = self::get_sorting_options();
+        $allowed = [];
+
+        foreach ($options as $key => $option) {
+            $allowed[] = sanitize_key($key);
+            if (isset($option['key'])) {
+                $allowed[] = sanitize_key($option['key']);
+            }
+        }
+
+        $allowed[] = 'date';
+
+        return array_values(array_unique(array_filter($allowed)));
+    }
+
     protected static function prepare_columns($atts) {
         $requested = array_filter(array_map('trim', explode(',', $atts['colonnes'])));
         $available = self::get_available_columns();

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -14,6 +14,7 @@ if ($table_id === '' && isset($atts['id'])) {
     $table_id = sanitize_html_class($atts['id']);
 }
 $layout = isset($atts['layout']) ? $atts['layout'] : 'table';
+$base_url = isset($base_url) ? esc_url_raw($base_url) : '';
 $current_orderby = !empty($orderby) ? $orderby : 'date';
 $current_order = !empty($order) ? strtoupper($order) : 'DESC';
 $current_cat_filter = isset($cat_filter) ? intval($cat_filter) : 0;
@@ -84,6 +85,12 @@ if ($columns_count === 0) {
 
 if (!function_exists('jlg_print_sortable_header')) {
     function jlg_print_sortable_header($col, $col_info, $current_orderby, $current_order, $table_id, $extra_params = []) {
+        $base_url = '';
+        if (isset($extra_params['base_url'])) {
+            $base_url = esc_url_raw($extra_params['base_url']);
+            unset($extra_params['base_url']);
+        }
+
         if (!isset($col_info['sortable']) || !$col_info['sortable']) {
             echo '<th>' . esc_html($col_info['label']) . '</th>';
             return;
@@ -121,7 +128,11 @@ if (!function_exists('jlg_print_sortable_header')) {
             }
         }
 
-        $url = add_query_arg($args);
+        if ($base_url !== '') {
+            $url = add_query_arg($args, remove_query_arg('paged', $base_url));
+        } else {
+            $url = add_query_arg($args);
+        }
         $url = remove_query_arg('paged', $url);
 
         if (!empty($table_id)) {
@@ -237,6 +248,7 @@ else :
                         'cat_filter'    => $current_cat_filter,
                         'letter_filter' => $current_letter_filter,
                         'genre_filter'  => $current_genre_filter,
+                        'base_url'      => $base_url,
                     ];
                     ?>
                     <?php


### PR DESCRIPTION
## Summary
- enforce whitelists for sort keys and normalize sort order in AJAX handlers to block arbitrary queries
- stop rewriting `$_SERVER['REQUEST_URI']` by passing a sanitized base URL to the summary template for link generation
- cache plugin options in `JLG_Helpers` with an opt-in refresh helper and plumb the new base URL through the template helpers

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3da7e3f48832ebff51ece3ab78d05