### PR TITLE
Fix SVG assets and tighten color sanitization

### DIFF
--- a/plugin-notation-jeux_V4/assets/flags/fr.svg
+++ b/plugin-notation-jeux_V4/assets/flags/fr.svg
@@ -1,19 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 -4 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_503_2485)">
-<rect x="0.25" y="0.25" width="27.5" height="19.5" rx="1.75" fill="white" stroke="#F5F5F5" stroke-width="0.5"/>
-<mask id="mask0_503_2485" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="28" height="20">
-<rect x="0.25" y="0.25" width="27.5" height="19.5" rx="1.75" fill="white" stroke="white" stroke-width="0.5"/>
-</mask>
-<g mask="url(#mask0_503_2485)">
-<rect x="18.6667" width="9.33333" height="20" fill="#F44653"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0 20H9.33333V0H0V20Z" fill="#1035BB"/>
-</g>
-</g>
-<defs>
-<clipPath id="clip0_503_2485">
-<rect width="28" height="20" rx="2" fill="white"/>
-</clipPath>
-</defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="1" height="2" fill="#0055A4"/>
+  <rect width="1" height="2" x="1" fill="#FFFFFF"/>
+  <rect width="1" height="2" x="2" fill="#EF4135"/>
+</svg>
 </svg>

--- a/plugin-notation-jeux_V4/assets/flags/gb.svg
+++ b/plugin-notation-jeux_V4/assets/flags/gb.svg
@@ -1,24 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 -4 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_503_2952)">
-<rect width="28" height="20" rx="2" fill="white"/>
-<mask id="mask0_503_2952" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="28" height="20">
-<rect width="28" height="20" rx="2" fill="white"/>
-</mask>
-<g mask="url(#mask0_503_2952)">
-<rect width="28" height="20" fill="#0A17A7"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M-1.28244 -1.91644L10.6667 6.14335V-1.33333H17.3334V6.14335L29.2825 -1.91644L30.7737 0.294324L21.3263 6.66667H28V13.3333H21.3263L30.7737 19.7057L29.2825 21.9165L17.3334 13.8567V21.3333H10.6667V13.8567L-1.28244 21.9165L-2.77362 19.7057L6.67377 13.3333H2.95639e-05V6.66667H6.67377L-2.77362 0.294324L-1.28244 -1.91644Z" fill="white"/>
-<path d="M18.668 6.33219L31.3333 -2" stroke="#DB1F35" stroke-width="0.666667" stroke-linecap="round"/>
-<path d="M20.0128 13.6975L31.3666 21.3503" stroke="#DB1F35" stroke-width="0.666667" stroke-linecap="round"/>
-<path d="M8.00555 6.31046L-3.83746 -1.67099" stroke="#DB1F35" stroke-width="0.666667" stroke-linecap="round"/>
-<path d="M9.29006 13.6049L-3.83746 22.3105" stroke="#DB1F35" stroke-width="0.666667" stroke-linecap="round"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12H12V20H16V12H28V8H16V0H12V8H0V12Z" fill="#E6273E"/>
-</g>
-</g>
-<defs>
-<clipPath id="clip0_503_2952">
-<rect width="28" height="20" rx="2" fill="white"/>
-</clipPath>
-</defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" width="1200" height="600">
+  <clipPath id="t">
+    <path d="M30,15 h30 v15 z v15 h-30 z h-30 v-15 z v-15 h30 z"/>
+  </clipPath>
+  <path d="M0,0 v30 h60 v-30 z" fill="#012169"/>
+  <path d="M0,0 L60,30 M60,0 L0,30" stroke="#FFFFFF" stroke-width="6"/>
+  <path d="M0,0 L60,30 M60,0 L0,30" clip-path="url(#t)" stroke="#C8102E" stroke-width="4"/>
+  <path d="M30,0 v30 M0,15 h60" stroke="#FFFFFF" stroke-width="10"/>
+  <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/>
+</svg>
 </svg>

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
@@ -87,12 +87,13 @@ class JLG_Admin_Settings {
                 'table_zebra_bg_color',
             ];
 
-            if (is_string($value) && in_array($key, $allow_transparent_fields, true)) {
-                $trimmed_value = strtolower(trim($value));
+            $trimmed_value = is_string($value) ? strtolower(trim($value)) : '';
 
-                if ($trimmed_value === 'transparent') {
-                    return 'transparent';
-                }
+            if (
+                $trimmed_value === 'transparent'
+                && in_array($key, $allow_transparent_fields, true)
+            ) {
+                return 'transparent';
             }
 
             $sanitized_color = sanitize_hex_color($value);
@@ -101,7 +102,18 @@ class JLG_Admin_Settings {
                 return $sanitized_color;
             }
 
-            return is_string($default_value) ? $default_value : '';
+            $default_trimmed = is_string($default_value) ? strtolower(trim($default_value)) : '';
+
+            if (
+                $default_trimmed === 'transparent'
+                && in_array($key, $allow_transparent_fields, true)
+            ) {
+                return 'transparent';
+            }
+
+            $sanitized_default = is_string($default_value) ? sanitize_hex_color($default_value) : '';
+
+            return $sanitized_default ? $sanitized_default : '';
         }
         
         // Nombres


### PR DESCRIPTION
## Summary
- replace the French and UK flag SVG assets with inline vector markup so the tagline shortcode renders valid images
- harden admin color option sanitization by normalizing "transparent" handling and falling back to sanitized defaults

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3e6594db0832eb016e3aefe1448c7