### PR TITLE
Improve migration scheduling and harden rating storage

### DIFF
--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -11,6 +11,13 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
     exit;
 }
 
+if (function_exists('wp_clear_scheduled_hook')) {
+    wp_clear_scheduled_hook('jlg_process_v5_migration');
+}
+
+delete_option('jlg_migration_v5_queue');
+delete_option('jlg_migration_v5_completed');
+
 // Option pour vérifier si l'utilisateur veut supprimer les données
 $delete_data = get_option('jlg_notation_delete_data_on_uninstall', false);
 


### PR DESCRIPTION
## Summary
- clear the migration cron schedule on deactivation/uninstall and accept async rebuild requests for pending posts
- limit synchronous average refreshes in the summary shortcode while capping expensive `post__in` usage
- optimize rated post discovery and prune stored user votes/IP logs to keep postmeta lean

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d42f0f0fb0832e98aacd2a3946221d