### PR TITLE
Improve migration queue handling and tagline color customization

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
@@ -419,6 +419,12 @@ class JLG_Admin_Settings {
             $tagline_font_size_args
         );
         $this->store_field_constraints($tagline_font_size_args);
+        add_settings_field('tagline_bg_color', 'Fond de la tagline', [$this, 'render_field'], 'notation_jlg_page', 'jlg_tagline_section',
+            ['id' => 'tagline_bg_color', 'type' => 'color']
+        );
+        add_settings_field('tagline_text_color', 'Texte de la tagline', [$this, 'render_field'], 'notation_jlg_page', 'jlg_tagline_section',
+            ['id' => 'tagline_text_color', 'type' => 'color']
+        );
 
         // Section 8: Modules - Notation Utilisateurs
         add_settings_section('jlg_user_rating_section', '8. ⭐ Module Notation Utilisateurs', null, 'notation_jlg_page');

--- a/plugin-notation-jeux_V4/tests/HelpersColorPaletteTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersColorPaletteTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersColorPaletteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        JLG_Helpers::flush_plugin_options_cache();
+        $GLOBALS['jlg_test_options'] = [];
+    }
+
+    public function test_uses_custom_tagline_colors_when_defined(): void
+    {
+        $defaults = JLG_Helpers::get_default_settings();
+        $options = $defaults;
+        $options['visual_theme'] = 'dark';
+        $options['tagline_bg_color'] = '#123456';
+        $options['tagline_text_color'] = '#abcdef';
+
+        update_option('notation_jlg_settings', $options);
+
+        $palette = JLG_Helpers::get_color_palette();
+
+        $this->assertSame('#123456', $palette['tagline_bg_color']);
+        $this->assertSame('#abcdef', $palette['tagline_text_color']);
+    }
+
+    public function test_falls_back_to_theme_defaults_when_tagline_colors_missing(): void
+    {
+        $defaults = JLG_Helpers::get_default_settings();
+        $options = $defaults;
+        $options['visual_theme'] = 'light';
+        $options['tagline_bg_color'] = '';
+        $options['tagline_text_color'] = '';
+
+        update_option('notation_jlg_settings', $options);
+
+        $palette = JLG_Helpers::get_color_palette();
+
+        $this->assertSame('#f3f4f6', $palette['tagline_bg_color']);
+        $this->assertSame('#4b5563', $palette['tagline_text_color']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -100,7 +100,7 @@ if (!function_exists('get_option')) {
 }
 
 if (!function_exists('update_option')) {
-    function update_option($option, $value) {
+    function update_option($option, $value, $autoload = null) {
         if (!isset($GLOBALS['jlg_test_options'])) {
             $GLOBALS['jlg_test_options'] = [];
         }

--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -16,6 +16,7 @@ if (function_exists('wp_clear_scheduled_hook')) {
 }
 
 delete_option('jlg_migration_v5_queue');
+delete_option('jlg_migration_v5_scan_state');
 delete_option('jlg_migration_v5_completed');
 
 // Option pour vérifier si l'utilisateur veut supprimer les données
@@ -28,6 +29,7 @@ if ($delete_data) {
     delete_option('notation_jlg_settings');
     delete_option('jlg_notation_version');
     delete_option('jlg_migration_v5_completed');
+    delete_option('jlg_migration_v5_scan_state');
     delete_option('jlg_platforms_list');
     delete_option('jlg_notation_delete_data_on_uninstall');
     


### PR DESCRIPTION
## Summary
- allow tagline background and text colors to be customized through stored options and expose pickers in the admin settings
- refactor the v5 migration queue to build batches asynchronously, cache scan state off the autoload list, and ensure cleanup on completion
- add coverage around the new tagline palette behaviour

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d4404ad104832e95ec7a67db94b25d