### PR TITLE
Ensure rating averages refresh and harden vote hashing

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -13,6 +13,21 @@ class JLG_Helpers {
     private static $options_cache = null;
     private static $default_settings_cache = null;
 
+    private static function get_rating_meta_keys() {
+        static $meta_keys = null;
+
+        if ($meta_keys === null) {
+            $meta_keys = array_map(
+                static function ($key) {
+                    return '_note_' . $key;
+                },
+                self::$category_keys
+            );
+        }
+
+        return $meta_keys;
+    }
+
     private static function get_theme_defaults() {
         return [
             'light' => [
@@ -282,6 +297,33 @@ class JLG_Helpers {
             'value' => null,
             'formatted' => null,
         ];
+    }
+
+    /**
+     * Clear the cached average score when one of the rating metas is changed.
+     */
+    public static function maybe_handle_rating_meta_change($meta_id, $post_id, $meta_key) {
+        unset($meta_id);
+
+        if (!is_string($meta_key) || !in_array($meta_key, self::get_rating_meta_keys(), true)) {
+            return;
+        }
+
+        self::invalidate_average_score_cache($post_id);
+    }
+
+    /**
+     * Delete the stored average and queue a rebuild for the provided post.
+     */
+    public static function invalidate_average_score_cache($post_id) {
+        $post_id = (int) $post_id;
+
+        if ($post_id <= 0) {
+            return;
+        }
+
+        delete_post_meta($post_id, '_jlg_average_score');
+        self::queue_average_score_rebuild($post_id);
     }
 
     public static function get_rating_categories() {

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -77,6 +77,9 @@ final class JLG_Plugin_De_Notation_Main {
         add_action('update_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
         add_action('add_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
         add_action('delete_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
+        add_action('added_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
+        add_action('updated_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
+        add_action('deleted_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
 
         // Frontend (toujours)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-dynamic-css.php';

--- a/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendUserRatingTest.php
@@ -75,7 +75,7 @@ class FrontendUserRatingTest extends TestCase
             $this->assertNull($exception->status);
         }
 
-        $ip_hash = wp_hash('198.51.100.42');
+        $ip_hash = hash('sha256', '198.51.100.42|https://example.com');
         $this->assertArrayHasKey($post_id, $GLOBALS['jlg_test_meta']);
         $this->assertArrayHasKey('_jlg_user_rating_ips', $GLOBALS['jlg_test_meta'][$post_id]);
         $this->assertArrayHasKey($ip_hash, $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_ips']);

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -85,6 +85,16 @@ if (!function_exists('apply_filters')) {
     }
 }
 
+if (!function_exists('do_action')) {
+    function do_action($hook, ...$args) {
+        if (!isset($GLOBALS['jlg_test_actions'])) {
+            $GLOBALS['jlg_test_actions'] = [];
+        }
+
+        $GLOBALS['jlg_test_actions'][] = [$hook, $args];
+    }
+}
+
 if (!function_exists('register_setting')) {
     function register_setting($option_group, $option_name, $args = []) {
         // No-op stub used during tests.
@@ -174,6 +184,12 @@ if (!function_exists('__')) {
 if (!function_exists('esc_html')) {
     function esc_html($text) {
         return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($data) {
+        return (string) $data;
     }
 }
 
@@ -414,6 +430,14 @@ if (!function_exists('check_ajax_referer')) {
     }
 }
 
+if (!function_exists('site_url')) {
+    function site_url($path = '', $scheme = null) {
+        unset($path, $scheme);
+
+        return 'https://example.com';
+    }
+}
+
 if (!function_exists('wp_hash')) {
     function wp_hash($data) {
         return md5((string) $data);
@@ -489,6 +513,18 @@ if (!function_exists('update_post_meta')) {
         ];
 
         $GLOBALS['jlg_test_meta'][$post_id][$key] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_post_meta')) {
+    function delete_post_meta($post_id, $key, $value = '') {
+        unset($value);
+
+        if (isset($GLOBALS['jlg_test_meta'][$post_id][$key])) {
+            unset($GLOBALS['jlg_test_meta'][$post_id][$key]);
+        }
 
         return true;
     }


### PR DESCRIPTION
## Summary
- flush cached average scores whenever rating metas change and queue their rebuild
- allow shortcode error notices to render inline code safely for administrators
- replace wp_hash-based vote keys with stable sha256 hashes and adjust unit tests/stubs accordingly

## Testing
- ./vendor/bin/phpunit
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d44bf254f8832ea74884eb061979e8