### PR TITLE
Harden dynamic CSS and admin AJAX handling

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -64,6 +64,39 @@ class JLG_Admin_Ajax {
         ];
 
         $normalized_games = array_map(function($game) {
+            $sanitize_scalar = static function($value) {
+                if (is_scalar($value)) {
+                    return sanitize_text_field((string) $value);
+                }
+
+                return '';
+            };
+
+            $game['name'] = isset($game['name']) ? $sanitize_scalar($game['name']) : '';
+
+            foreach (['developers', 'publishers'] as $field) {
+                if (!isset($game[$field])) {
+                    $game[$field] = '';
+                    continue;
+                }
+
+                if (is_array($game[$field])) {
+                    $game[$field] = array_values(array_filter(array_map($sanitize_scalar, $game[$field]), 'strlen'));
+                } else {
+                    $game[$field] = $sanitize_scalar($game[$field]);
+                }
+            }
+
+            if (isset($game['platforms'])) {
+                if (is_array($game['platforms'])) {
+                    $game['platforms'] = array_values(array_filter(array_map($sanitize_scalar, $game['platforms']), 'strlen'));
+                } else {
+                    $game['platforms'] = $sanitize_scalar($game['platforms']);
+                }
+            } else {
+                $game['platforms'] = [];
+            }
+
             if (!empty($game['release_date'])) {
                 $sanitized_date = JLG_Validator::sanitize_date($game['release_date']);
                 $game['release_date'] = $sanitized_date !== null ? $sanitized_date : '';

--- a/plugin-notation-jeux_V4/includes/class-jlg-dynamic-css.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-dynamic-css.php
@@ -250,12 +250,24 @@ class JLG_Dynamic_CSS {
             return '';
         }
 
+        $zebra_base_color = $this->sanitize_color_value($table_zebra_bg_color, true);
+
+        if ($zebra_base_color === '') {
+            return '';
+        }
+
         $css = '.jlg-summary-table tbody tr:nth-child(even){background-color:var(--jlg-table-zebra-bg-color);}';
 
-        if ($table_zebra_bg_color === 'transparent' || $table_zebra_bg_color === '') {
-            $zebra_hover_color = $table_zebra_bg_color;
-        } else {
-            $zebra_hover_color = $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($table_zebra_bg_color, 5));
+        if ($zebra_base_color === 'transparent') {
+            return $css;
+        }
+
+        $zebra_hover_color = $this->sanitize_color_value(
+            JLG_Helpers::adjust_hex_brightness($zebra_base_color, 5)
+        );
+
+        if ($zebra_hover_color === '') {
+            return $css;
         }
 
         return $css . '.jlg-summary-table tbody tr:nth-child(even):hover{background-color:' . $zebra_hover_color . ';}';
@@ -271,12 +283,17 @@ class JLG_Dynamic_CSS {
     private function build_table_border_css(array $options, $border_color) {
         $border_style = $options['table_border_style'] ?? '';
         $border_width = intval($options['table_border_width'] ?? 0);
+        $sanitized_border_color = $this->sanitize_color_value($border_color, true);
+
+        if ($sanitized_border_color === '') {
+            return '';
+        }
 
         switch ($border_style) {
             case 'horizontal':
-                return '.jlg-summary-table th,.jlg-summary-table td{border-bottom:' . $border_width . 'px solid ' . $border_color . ';}';
+                return '.jlg-summary-table th,.jlg-summary-table td{border-bottom:' . $border_width . 'px solid ' . $sanitized_border_color . ';}';
             case 'full':
-                return '.jlg-summary-table th,.jlg-summary-table td{border:' . $border_width . 'px solid ' . $border_color . ';}';
+                return '.jlg-summary-table th,.jlg-summary-table td{border:' . $border_width . 'px solid ' . $sanitized_border_color . ';}';
             default:
                 return '';
         }


### PR DESCRIPTION
## Summary
- guard dynamic table CSS generation against invalid colors before outputting zebra striping or borders
- sanitize RAWG mock API payloads so returned strings and arrays are safe for rendering
- gate platform admin debug logging and persistence behind the debug flag with reusable helpers

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-dynamic-css.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php

------
https://chatgpt.com/codex/tasks/task_e_68d537dc352c832ea2acee9b367f19dc