### PR TITLE
Normalize summary base URL handling and add coverage

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1257,21 +1257,49 @@ class JLG_Frontend {
             return '';
         }
 
-        if (empty($parsed_url['path'])) {
+        $site_url = wp_parse_url(home_url('/'));
+        $site_host = is_array($site_url) && isset($site_url['host']) ? strtolower($site_url['host']) : '';
+        $site_scheme = is_array($site_url) && isset($site_url['scheme']) ? $site_url['scheme'] : '';
+
+        $target_host = isset($parsed_url['host']) ? strtolower($parsed_url['host']) : '';
+
+        if ($target_host === '') {
+            return home_url('/');
+        }
+
+        if ($site_host !== '' && $target_host !== $site_host) {
             return '';
         }
 
-        $site_url = wp_parse_url(home_url('/'));
-        if (!empty($parsed_url['host'])) {
-            $site_host = isset($site_url['host']) ? strtolower($site_url['host']) : '';
-            $target_host = strtolower($parsed_url['host']);
-
-            if ($site_host !== '' && $target_host !== $site_host) {
-                return '';
-            }
+        $scheme = $parsed_url['scheme'] ?? $site_scheme;
+        $path = $parsed_url['path'] ?? '';
+        if ($path === '') {
+            $path = '/';
         }
 
-        return $sanitized_url;
+        $normalized_url = '';
+
+        if ($scheme !== '') {
+            $normalized_url .= $scheme . '://';
+        }
+
+        $normalized_url .= $parsed_url['host'];
+
+        if (!empty($parsed_url['port'])) {
+            $normalized_url .= ':' . intval($parsed_url['port']);
+        }
+
+        $normalized_url .= $path;
+
+        if (!empty($parsed_url['query'])) {
+            $normalized_url .= '?' . $parsed_url['query'];
+        }
+
+        if (!empty($parsed_url['fragment'])) {
+            $normalized_url .= '#' . $parsed_url['fragment'];
+        }
+
+        return $normalized_url;
     }
 
     /**

--- a/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+$colonnes = [];
+$colonnes_disponibles = [];
+$atts = [];
+$orderby = '';
+$order = '';
+$cat_filter = 0;
+$letter_filter = '';
+$genre_filter = '';
+$error_message = '';
+$base_url = '';
+
+ob_start();
+require_once __DIR__ . '/../templates/summary-table-fragment.php';
+ob_end_clean();
+
+use PHPUnit\Framework\TestCase;
+
+class FrontendSummaryBaseUrlTest extends TestCase
+{
+    public function test_root_url_without_trailing_slash_generates_front_link()
+    {
+        $frontend = new JLG_Frontend();
+
+        $reflection = new ReflectionClass(JLG_Frontend::class);
+        $method = $reflection->getMethod('sanitize_internal_url');
+        $method->setAccessible(true);
+
+        $base_url = $method->invoke($frontend, 'https://public.example');
+
+        $this->assertSame('https://public.example/', $base_url, 'Base URL should normalize to the public domain with a trailing slash.');
+
+        ob_start();
+        jlg_print_sortable_header(
+            'note',
+            [
+                'label'    => 'Note',
+                'sortable' => true,
+                'sort'     => [
+                    'key' => 'note',
+                ],
+            ],
+            'date',
+            'DESC',
+            'table-test',
+            [
+                'base_url' => $base_url,
+            ]
+        );
+        $output = ob_get_clean();
+
+        $this->assertNotFalse(
+            strpos($output, "href=\"https://public.example/?orderby=note&order=ASC#table-test\""),
+            'Sortable header should link to the front domain.'
+        );
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -199,6 +199,94 @@ if (!function_exists('esc_html__')) {
     }
 }
 
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($url) {
+        if (!is_string($url)) {
+            return '';
+        }
+
+        $sanitized = filter_var($url, FILTER_SANITIZE_URL);
+
+        return is_string($sanitized) ? $sanitized : '';
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        return esc_url_raw($url);
+    }
+}
+
+if (!function_exists('home_url')) {
+    function home_url($path = '', $scheme = null) {
+        unset($scheme);
+
+        $base = 'https://public.example';
+
+        if (!is_string($path)) {
+            $path = '';
+        }
+
+        if ($path === '' || $path === '/') {
+            return $base . '/';
+        }
+
+        if ($path[0] !== '/') {
+            $path = '/' . $path;
+        }
+
+        return $base . $path;
+    }
+}
+
+if (!function_exists('wp_parse_url')) {
+    function wp_parse_url($url) {
+        if (!is_string($url) || $url === '') {
+            return false;
+        }
+
+        return parse_url($url);
+    }
+}
+
+if (!function_exists('taxonomy_exists')) {
+    function taxonomy_exists($taxonomy) {
+        unset($taxonomy);
+
+        return false;
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) {
+        unset($thing);
+
+        return false;
+    }
+}
+
+if (!function_exists('get_category')) {
+    function get_category($id) {
+        unset($id);
+
+        return null;
+    }
+}
+
+if (!function_exists('get_term_by')) {
+    function get_term_by($field, $value, $taxonomy, $output = 'OBJECT', $filter = 'raw') {
+        unset($field, $value, $taxonomy, $output, $filter);
+
+        return false;
+    }
+}
+
 if (!function_exists('esc_html_e')) {
     function esc_html_e($text, $domain = 'default') {
         echo esc_html__($text, $domain);


### PR DESCRIPTION
## Summary
- normalize sanitize_internal_url() so internal roots default to /, relative URLs fall back to home_url('/') and external hosts stay rejected
- extend the PHPUnit bootstrap with URL/escaping and taxonomy stubs needed by the new test harness
- add a FrontendSummaryBaseUrlTest that checks the root URL normalization and sortable header link generation

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d5c02599fc832ea2799396d7b94d4c