### PR TITLE
Allow selecting posts in game info shortcode

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -52,7 +52,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 - `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 - `[bloc_notation_jeu]` - Bloc de notation principal
-- `[jlg_fiche_technique]` - Fiche technique du jeu
+- `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher, utilise l'article courant sinon), `champs` (liste de champs séparés par des virgules) et `titre`.
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 - `[jlg_points_forts_faibles]` - Points positifs et négatifs
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -49,7 +49,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 * `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 * `[bloc_notation_jeu]` - Bloc de notation principal
-* `[jlg_fiche_technique]` - Fiche technique du jeu
+* `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher ; sinon l'article courant est utilisé), `champs` (liste de champs séparés par des virgules) et `titre`.
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 * `[jlg_points_forts_faibles]` - Points positifs et négatifs
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -8,10 +8,6 @@ class JLG_Shortcode_Game_Info {
     }
 
     public function render($atts, $content = '', $shortcode_tag = '') {
-        if (!is_singular('post')) {
-            return '';
-        }
-
         // Définition de tous les champs possibles avec leur libellé
         $all_possible_fields = [
             'developpeur'  => 'Développeur',
@@ -28,21 +24,24 @@ class JLG_Shortcode_Game_Info {
         $atts = shortcode_atts([
             'titre'  => 'Fiche Technique',
             'champs' => $default_fields_order,
+            'post_id' => '',
         ], $atts, 'jlg_fiche_technique');
 
-        $post_id = get_the_ID();
-        
+        $post_id = $this->resolve_target_post_id($atts['post_id']);
+        if (!$post_id) {
+            return '';
+        }
+
         // On transforme la liste de l'attribut en tableau
         $requested_fields = array_map('trim', explode(',', $atts['champs']));
-        
+
         $data_to_display = [];
         foreach ($requested_fields as $field_key) {
             // On vérifie si le champ demandé est valide
             if (array_key_exists($field_key, $all_possible_fields)) {
-                $meta_value = get_post_meta($post_id, '_jlg_' . $field_key, true);
-                
-                // On n'ajoute le champ que s'il a une valeur
-                if (!empty($meta_value)) {
+                $meta_value = $this->sanitize_meta_value(get_post_meta($post_id, '_jlg_' . $field_key, true));
+
+                if ($this->has_displayable_value($meta_value)) {
                     $data_to_display[$field_key] = [
                         'label' => $all_possible_fields[$field_key],
                         'value' => $meta_value,
@@ -61,5 +60,76 @@ class JLG_Shortcode_Game_Info {
             'titre'             => sanitize_text_field($atts['titre']),
             'champs_a_afficher' => $data_to_display,
         ]);
+    }
+
+    private function resolve_target_post_id($post_id_attribute) {
+        $post_id = absint($post_id_attribute);
+        if ($post_id && $this->is_valid_target_post($post_id)) {
+            return $post_id;
+        }
+
+        if ($post_id_attribute !== '' && $post_id === 0) {
+            return 0;
+        }
+
+        $current_post_id = get_the_ID();
+        if (!$current_post_id) {
+            return 0;
+        }
+
+        if (function_exists('is_singular') && !is_singular('post')) {
+            return 0;
+        }
+
+        return $this->is_valid_target_post($current_post_id) ? $current_post_id : 0;
+    }
+
+    private function is_valid_target_post($post_id) {
+        $post = get_post($post_id);
+        if (!$post instanceof WP_Post) {
+            return false;
+        }
+
+        if (($post->post_type ?? '') !== 'post') {
+            return false;
+        }
+
+        if (($post->post_status ?? '') !== 'publish') {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function sanitize_meta_value($meta_value) {
+        if (is_array($meta_value)) {
+            $sanitized = array_filter(array_map(static function ($value) {
+                if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+                    $clean_value = sanitize_text_field((string) $value);
+
+                    return wp_strip_all_tags($clean_value);
+                }
+
+                return '';
+            }, $meta_value));
+
+            return array_values(array_filter($sanitized, static function ($value) {
+                return $value !== '';
+            }));
+        }
+
+        if (is_scalar($meta_value) || (is_object($meta_value) && method_exists($meta_value, '__toString'))) {
+            return wp_strip_all_tags(sanitize_text_field((string) $meta_value));
+        }
+
+        return '';
+    }
+
+    private function has_displayable_value($value) {
+        if (is_array($value)) {
+            return !empty($value);
+        }
+
+        return $value !== '';
     }
 }

--- a/plugin-notation-jeux_V4/templates/shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-info.php
@@ -9,20 +9,16 @@ if (!defined('ABSPATH')) exit;
             <dt><?php echo esc_html($data['label']); ?></dt>
             <dd>
                 <?php
-                // Traitement spécial pour les plateformes
-                if ($key === 'plateformes' && is_array($data['value'])) {
-                    echo '<div class="platforms-list">';
-                    foreach($data['value'] as $p) {
-                        echo '<span>' . esc_html($p) . '</span>';
+                if (is_array($data['value'])) {
+                    $wrapper_class = $key === 'plateformes' ? 'platforms-list' : 'jlg-game-info-list';
+                    echo '<div class="' . esc_attr($wrapper_class) . '">';
+                    foreach ($data['value'] as $item) {
+                        echo '<span>' . esc_html($item) . '</span>';
                     }
                     echo '</div>';
-                } 
-                // Traitement spécial pour la date
-                elseif ($key === 'date_sortie') {
+                } elseif ($key === 'date_sortie' && $data['value'] !== '') {
                     echo esc_html(date_i18n(get_option('date_format'), strtotime($data['value'])));
-                } 
-                // Affichage standard pour les autres champs
-                else {
+                } else {
                     echo esc_html($data['value']);
                 }
                 ?>

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameInfoTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameInfoTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-game-info.php';
+
+class ShortcodeGameInfoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_current_post_id'] = 0;
+    }
+
+    public function test_render_with_valid_post_id_returns_template(): void
+    {
+        $post_id = 321;
+        $this->register_post($post_id, 'publish');
+
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_jlg_developpeur' => 'Studio <b>X</b>',
+            '_jlg_plateformes' => ['PC', 'Switch ', '<script>'],
+        ];
+
+        $shortcode = new JLG_Shortcode_Game_Info();
+        $output = $shortcode->render([
+            'post_id' => (string) $post_id,
+            'champs'  => 'developpeur,plateformes',
+        ]);
+
+        $this->assertNotSame('', $output);
+        $this->assertStringContainsString('Studio X', $output);
+        $this->assertStringNotContainsString('<script>', $output);
+        $this->assertStringContainsString('<span>PC</span>', $output);
+        $this->assertStringContainsString('<span>Switch</span>', $output);
+    }
+
+    public function test_render_with_draft_post_returns_empty(): void
+    {
+        $post_id = 654;
+        $this->register_post($post_id, 'draft');
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_jlg_developpeur' => 'Studio Y',
+        ];
+
+        $shortcode = new JLG_Shortcode_Game_Info();
+        $output = $shortcode->render(['post_id' => $post_id]);
+
+        $this->assertSame('', $output);
+    }
+
+    public function test_render_uses_current_context_when_valid(): void
+    {
+        $post_id = 777;
+        $this->register_post($post_id, 'publish');
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_jlg_editeur' => 'Publisher Z',
+        ];
+
+        $GLOBALS['jlg_test_current_post_id'] = $post_id;
+
+        $shortcode = new JLG_Shortcode_Game_Info();
+        $output = $shortcode->render(['champs' => 'editeur']);
+
+        $this->assertNotSame('', $output);
+        $this->assertStringContainsString('Publisher Z', $output);
+        $this->assertStringContainsString('Éditeur', $output);
+    }
+
+    private function register_post(int $post_id, string $status): void
+    {
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'          => $post_id,
+            'post_type'   => 'post',
+            'post_status' => $status,
+        ]);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -12,6 +12,10 @@ if (!defined('JLG_NOTATION_PLUGIN_URL')) {
     define('JLG_NOTATION_PLUGIN_URL', 'https://example.com/plugin/');
 }
 
+if (!defined('JLG_NOTATION_PLUGIN_DIR')) {
+    define('JLG_NOTATION_PLUGIN_DIR', dirname(__DIR__) . '/');
+}
+
 if (!function_exists('add_action')) {
     function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
         // No-op stub for WordPress hook registration in tests.
@@ -36,7 +40,31 @@ if (!function_exists('shortcode_atts')) {
 
 if (!function_exists('get_the_ID')) {
     function get_the_ID() {
-        return 0;
+        return isset($GLOBALS['jlg_test_current_post_id']) ? (int) $GLOBALS['jlg_test_current_post_id'] : 0;
+    }
+}
+
+if (!function_exists('is_singular')) {
+    function is_singular($post_types = '') {
+        $post_id = get_the_ID();
+        if ($post_id <= 0) {
+            return false;
+        }
+
+        $post = get_post($post_id);
+        if (!$post instanceof WP_Post) {
+            return false;
+        }
+
+        if ($post_types === '') {
+            return true;
+        }
+
+        if (is_array($post_types)) {
+            return in_array($post->post_type ?? '', $post_types, true);
+        }
+
+        return ($post->post_type ?? '') === $post_types;
     }
 }
 
@@ -85,6 +113,14 @@ if (!function_exists('apply_filters')) {
     }
 }
 
+if (!function_exists('did_action')) {
+    function did_action($hook) {
+        unset($hook);
+
+        return 0;
+    }
+}
+
 if (!function_exists('do_action')) {
     function do_action($hook, ...$args) {
         if (!isset($GLOBALS['jlg_test_actions'])) {
@@ -106,6 +142,24 @@ if (!function_exists('get_option')) {
         $options = $GLOBALS['jlg_test_options'] ?? [];
 
         return $options[$option] ?? $default;
+    }
+}
+
+if (!function_exists('date_i18n')) {
+    function date_i18n($format, $timestamp) {
+        if (!is_int($timestamp)) {
+            $timestamp = is_numeric($timestamp) ? (int) $timestamp : strtotime((string) $timestamp);
+        }
+
+        if ($timestamp === false) {
+            return '';
+        }
+
+        if (!is_string($format) || $format === '') {
+            $format = 'F j, Y';
+        }
+
+        return date($format, $timestamp);
     }
 }
 
@@ -314,6 +368,16 @@ if (!function_exists('sanitize_text_field')) {
         $filtered = filter_var($str, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 
         return is_string($filtered) ? trim($filtered) : '';
+    }
+}
+
+if (!function_exists('absint')) {
+    function absint($maybeint) {
+        if (is_numeric($maybeint)) {
+            return (int) abs($maybeint);
+        }
+
+        return 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- add an optional `post_id` attribute to the game info shortcode with published post validation and context fallback
- normalise meta values for rendering, improve array handling in the template, and document the new shortcode attribute
- extend the test bootstrap and add a shortcode unit test covering the new behaviour

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d6512c9808832e9d7646859cb16f2d