### PR TITLE
Conditionally enqueue Game Explorer styles

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -360,16 +360,13 @@ class JLG_Frontend {
 
         wp_add_inline_style('jlg-frontend', $inline_css);
 
-        wp_enqueue_style(
-            'jlg-game-explorer',
-            JLG_NOTATION_PLUGIN_URL . 'assets/css/game-explorer.css',
-            ['jlg-frontend'],
-            JLG_NOTATION_VERSION
-        );
-
-        $game_explorer_css = $this->build_game_explorer_css($options, $palette);
-        if (!empty($game_explorer_css)) {
-            wp_add_inline_style('jlg-game-explorer', $game_explorer_css);
+        if (!wp_style_is('jlg-game-explorer', 'registered')) {
+            wp_register_style(
+                'jlg-game-explorer',
+                JLG_NOTATION_PLUGIN_URL . 'assets/css/game-explorer.css',
+                ['jlg-frontend'],
+                JLG_NOTATION_VERSION
+            );
         }
 
         $queried_object = isset($queried_object) ? $queried_object : get_queried_object();
@@ -391,6 +388,19 @@ class JLG_Frontend {
 
         $should_enqueue_summary_script = $summary_shortcode_used || $summary_ajax;
         $should_enqueue_game_explorer_script = $game_explorer_shortcode_used || $game_explorer_ajax;
+        $should_enqueue_game_explorer_assets = $should_enqueue_game_explorer_script || $game_explorer_ajax;
+
+        if ($should_enqueue_game_explorer_assets) {
+            wp_enqueue_style('jlg-game-explorer');
+
+            if (wp_style_is('jlg-game-explorer', 'enqueued')) {
+                $game_explorer_css = $this->build_game_explorer_css($options, $palette);
+
+                if (!empty($game_explorer_css)) {
+                    wp_add_inline_style('jlg-game-explorer', $game_explorer_css);
+                }
+            }
+        }
 
         // Script pour la notation utilisateur
         if (!empty($options['user_rating_enabled'])) {

--- a/plugin-notation-jeux_V4/tests/FrontendAssetsEnqueueTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendAssetsEnqueueTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FrontendAssetsEnqueueTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetEnvironment();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetEnvironment();
+        parent::tearDown();
+    }
+
+    public function test_game_explorer_assets_skipped_when_not_needed(): void
+    {
+        $this->configurePluginOptions();
+        $post_id = 101;
+        $this->registerPost($post_id, '[jlg_tableau_recap]');
+
+        $frontend = new JLG_Frontend();
+        $frontend->enqueue_jlg_scripts();
+
+        $styles = $GLOBALS['jlg_test_styles']['enqueued'] ?? [];
+        $inline_styles = $GLOBALS['jlg_test_inline_styles'] ?? [];
+
+        $this->assertArrayHasKey('jlg-frontend', $styles, 'Main frontend stylesheet should always load when other assets are needed.');
+        $this->assertArrayNotHasKey('jlg-game-explorer', $styles, 'Game Explorer stylesheet should be skipped when unused.');
+        $this->assertArrayNotHasKey('jlg-game-explorer', $inline_styles, 'Inline Game Explorer styles should not be generated when the stylesheet is not enqueued.');
+    }
+
+    public function test_game_explorer_assets_load_when_shortcode_present(): void
+    {
+        $this->configurePluginOptions();
+        $post_id = 202;
+        $this->registerPost($post_id, '[jlg_game_explorer]');
+
+        $frontend = new JLG_Frontend();
+        $frontend->enqueue_jlg_scripts();
+
+        $styles = $GLOBALS['jlg_test_styles']['enqueued'] ?? [];
+        $inline_styles = $GLOBALS['jlg_test_inline_styles'] ?? [];
+
+        $this->assertArrayHasKey('jlg-game-explorer', $styles, 'Game Explorer stylesheet should load when the shortcode is present.');
+        $this->assertArrayHasKey('jlg-game-explorer', $inline_styles, 'Inline styles should accompany the Game Explorer stylesheet when it is enqueued.');
+        $this->assertNotEmpty($inline_styles['jlg-game-explorer'][0] ?? '', 'Generated Game Explorer CSS should not be empty.');
+    }
+
+    private function registerPost(int $post_id, string $content): void
+    {
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'           => $post_id,
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+            'post_content' => $content,
+        ]);
+
+        $GLOBALS['jlg_test_current_post_id'] = $post_id;
+    }
+
+    private function configurePluginOptions(): void
+    {
+        $GLOBALS['jlg_test_options']['notation_jlg_settings'] = [
+            'user_rating_enabled' => 0,
+            'tagline_enabled'     => 0,
+            'enable_animations'   => 0,
+        ];
+
+        JLG_Helpers::flush_plugin_options_cache();
+    }
+
+    private function resetEnvironment(): void
+    {
+        $GLOBALS['jlg_test_styles'] = [
+            'registered' => [],
+            'enqueued'   => [],
+        ];
+        $GLOBALS['jlg_test_inline_styles'] = [];
+        $GLOBALS['jlg_test_scripts'] = [
+            'registered' => [],
+            'enqueued'   => [],
+            'localized'  => [],
+        ];
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_options'] = [];
+        $GLOBALS['jlg_test_current_post_id'] = 0;
+        $GLOBALS['jlg_test_doing_ajax'] = false;
+        $_REQUEST = [];
+
+        $this->resetFrontendStatics();
+        JLG_Helpers::flush_plugin_options_cache();
+    }
+
+    private function resetFrontendStatics(): void
+    {
+        $reflection = new ReflectionClass(JLG_Frontend::class);
+        $properties = [
+            'shortcode_errors'     => [],
+            'instance'             => null,
+            'shortcode_rendered'   => false,
+            'assets_enqueued'      => false,
+            'deferred_styles_hooked' => false,
+            'rendered_shortcodes'  => [],
+        ];
+
+        foreach ($properties as $property => $value) {
+            if ($reflection->hasProperty($property)) {
+                $property_reflection = $reflection->getProperty($property);
+                $property_reflection->setAccessible(true);
+                $property_reflection->setValue(null, $value);
+            }
+        }
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -131,6 +131,12 @@ if (!function_exists('do_action')) {
     }
 }
 
+if (!function_exists('wp_doing_ajax')) {
+    function wp_doing_ajax() {
+        return !empty($GLOBALS['jlg_test_doing_ajax']);
+    }
+}
+
 if (!function_exists('register_setting')) {
     function register_setting($option_group, $option_name, $args = []) {
         // No-op stub used during tests.
@@ -579,6 +585,99 @@ if (!function_exists('wp_enqueue_style')) {
     }
 }
 
+if (!function_exists('wp_add_inline_style')) {
+    function wp_add_inline_style($handle, $data) {
+        if (!isset($GLOBALS['jlg_test_inline_styles'])) {
+            $GLOBALS['jlg_test_inline_styles'] = [];
+        }
+
+        if (!isset($GLOBALS['jlg_test_inline_styles'][$handle])) {
+            $GLOBALS['jlg_test_inline_styles'][$handle] = [];
+        }
+
+        $GLOBALS['jlg_test_inline_styles'][$handle][] = $data;
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_register_script')) {
+    function wp_register_script($handle, $src = '', $deps = [], $ver = false, $in_footer = false) {
+        if (!isset($GLOBALS['jlg_test_scripts'])) {
+            $GLOBALS['jlg_test_scripts'] = [
+                'registered' => [],
+                'enqueued'   => [],
+                'localized'  => [],
+            ];
+        }
+
+        $GLOBALS['jlg_test_scripts']['registered'][$handle] = [
+            'src'       => $src,
+            'deps'      => $deps,
+            'ver'       => $ver,
+            'in_footer' => $in_footer,
+        ];
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_script_is')) {
+    function wp_script_is($handle, $list = 'enqueued') {
+        $scripts = $GLOBALS['jlg_test_scripts'] ?? [
+            'registered' => [],
+            'enqueued'   => [],
+            'localized'  => [],
+        ];
+
+        if ($list === 'registered') {
+            return array_key_exists($handle, $scripts['registered']);
+        }
+
+        if ($list === 'enqueued') {
+            return array_key_exists($handle, $scripts['enqueued']);
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script($handle) {
+        if (!isset($GLOBALS['jlg_test_scripts'])) {
+            $GLOBALS['jlg_test_scripts'] = [
+                'registered' => [],
+                'enqueued'   => [],
+                'localized'  => [],
+            ];
+        }
+
+        $GLOBALS['jlg_test_scripts']['enqueued'][$handle] = true;
+
+        return true;
+    }
+}
+
+if (!function_exists('wp_localize_script')) {
+    function wp_localize_script($handle, $object_name, $l10n) {
+        if (!isset($GLOBALS['jlg_test_scripts'])) {
+            $GLOBALS['jlg_test_scripts'] = [
+                'registered' => [],
+                'enqueued'   => [],
+                'localized'  => [],
+            ];
+        }
+
+        if (!isset($GLOBALS['jlg_test_scripts']['localized'][$handle])) {
+            $GLOBALS['jlg_test_scripts']['localized'][$handle] = [];
+        }
+
+        $GLOBALS['jlg_test_scripts']['localized'][$handle][$object_name] = $l10n;
+
+        return true;
+    }
+}
+
 if (!function_exists('sanitize_hex_color')) {
     function sanitize_hex_color($color) {
         if (!is_string($color)) {
@@ -615,9 +714,29 @@ if (!function_exists('site_url')) {
     }
 }
 
+if (!function_exists('is_ssl')) {
+    function is_ssl() {
+        return false;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = '') {
+        $path = ltrim((string) $path, '/');
+
+        return 'https://example.com/wp-admin/' . $path;
+    }
+}
+
 if (!function_exists('wp_hash')) {
     function wp_hash($data) {
         return md5((string) $data);
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action = -1) {
+        return 'nonce-' . (string) $action;
     }
 }
 
@@ -650,6 +769,23 @@ if (!function_exists('get_post')) {
         $posts = $GLOBALS['jlg_test_posts'] ?? [];
 
         return $posts[$post_id] ?? null;
+    }
+}
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object()
+    {
+        $post_id = isset($GLOBALS['jlg_test_current_post_id']) ? (int) $GLOBALS['jlg_test_current_post_id'] : 0;
+        $posts = $GLOBALS['jlg_test_posts'] ?? [];
+
+        return ($post_id > 0 && isset($posts[$post_id])) ? $posts[$post_id] : null;
+    }
+}
+
+if (!function_exists('get_queried_object_id')) {
+    function get_queried_object_id()
+    {
+        return isset($GLOBALS['jlg_test_current_post_id']) ? (int) $GLOBALS['jlg_test_current_post_id'] : 0;
     }
 }
 
@@ -737,6 +873,7 @@ if (!function_exists('wp_send_json_success')) {
 }
 
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
+require_once __DIR__ . '/../includes/class-jlg-dynamic-css.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-settings.php';
 require_once __DIR__ . '/../includes/admin/class-jlg-admin-platforms.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';


### PR DESCRIPTION
## Summary
- register the Game Explorer stylesheet and attach inline styles only when the shortcode or AJAX context requires it
- extend the test bootstrap with asset, AJAX, and helper stubs needed for asset assertions
- add PHPUnit coverage ensuring Game Explorer assets are skipped when unused and enqueued when triggered

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d65d498528832eb3969fe328dbe2be