### PR TITLE
Ensure validator fallback uses helper platform defaults

### DIFF
--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
@@ -69,11 +69,26 @@ class JLG_Validator {
             }
         }
 
+        if (empty($allowed_platforms) && class_exists('JLG_Helpers') && method_exists('JLG_Helpers', 'get_registered_platform_labels')) {
+            $default_definitions = JLG_Helpers::get_registered_platform_labels();
+
+            if (is_array($default_definitions)) {
+                $allowed_platforms = array_filter(
+                    array_map('sanitize_text_field', array_column($default_definitions, 'name')),
+                    static function ($name) {
+                        return $name !== '';
+                    }
+                );
+
+                $allowed_platforms = array_values(array_unique($allowed_platforms));
+            }
+        }
+
         if (empty($allowed_platforms)) {
-            $allowed_platforms = [
-                'PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch 2',
-                'Nintendo Switch', 'PlayStation 4', 'Xbox One'
-            ];
+            $allowed_platforms = array_map('sanitize_text_field', [
+                'PC', 'PlayStation 5', 'Xbox Series S/X', 'Nintendo Switch',
+                'PlayStation 4', 'Xbox One', 'Steam Deck'
+            ]);
         }
 
         $sanitized = array_map('sanitize_text_field', $platforms);

--- a/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
@@ -138,4 +138,24 @@ class AdminPlatformsTest extends TestCase
         $this->assertArrayHasKey('mega-drive', $platforms);
         $this->assertFalse($platforms['mega-drive']['custom']);
     }
+
+    public function test_sanitize_platforms_falls_back_to_helper_defaults_when_singleton_missing(): void
+    {
+        $instanceProperty = new ReflectionProperty(JLG_Admin_Platforms::class, 'instance');
+        $instanceProperty->setAccessible(true);
+        $originalInstance = $instanceProperty->getValue();
+
+        try {
+            $instanceProperty->setValue(null, false);
+
+            $sanitized = JLG_Validator::sanitize_platforms([
+                'Steam Deck',
+                'Invalid Console',
+            ]);
+        } finally {
+            $instanceProperty->setValue(null, $originalInstance);
+        }
+
+        $this->assertSame(['Steam Deck'], $sanitized);
+    }
 }


### PR DESCRIPTION
## Summary
- fall back to helper-provided platform definitions when admin singleton is unavailable and refresh the static defaults
- add a regression test to confirm Steam Deck persists through platform sanitization while invalid labels are removed

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d66f8b6a2c832e9681469c8bc833e0