### PR TITLE
Align platform validator fallback with helper defaults

### DIFF
--- a/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
@@ -158,4 +158,25 @@ class AdminPlatformsTest extends TestCase
 
         $this->assertSame(['Steam Deck'], $sanitized);
     }
+
+    public function test_sanitize_platforms_filters_obsolete_defaults_when_manager_unavailable(): void
+    {
+        $instanceProperty = new ReflectionProperty(JLG_Admin_Platforms::class, 'instance');
+        $instanceProperty->setAccessible(true);
+        $originalInstance = $instanceProperty->getValue();
+
+        try {
+            $instanceProperty->setValue(null, false);
+
+            $sanitized = JLG_Validator::sanitize_platforms([
+                'Steam Deck',
+                'Nintendo Switch 2',
+                'Invalid Console',
+            ]);
+        } finally {
+            $instanceProperty->setValue(null, $originalInstance);
+        }
+
+        $this->assertSame(['Steam Deck'], $sanitized);
+    }
 }


### PR DESCRIPTION
## Summary
- derive the validator fallback platform names from the helper defaults when the admin manager is unavailable
- extend the admin platforms test suite to ensure Steam Deck persists while obsolete labels are filtered during sanitization

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d675be459c832e9a66364e54628d98