### PR TITLE
Ensure sanitize_internal_url normalizes host aliases

### DIFF
--- a/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
@@ -92,4 +92,21 @@ class FrontendSummaryBaseUrlTest extends TestCase
             'Sortable header should keep links on the public domain.'
         );
     }
+
+    public function test_www_alias_is_canonicalized_to_home_url()
+    {
+        $frontend = new JLG_Frontend();
+
+        $reflection = new ReflectionClass(JLG_Frontend::class);
+        $method = $reflection->getMethod('sanitize_internal_url');
+        $method->setAccessible(true);
+
+        $base_url = $method->invoke($frontend, 'https://www.public.example/path/?foo=bar');
+
+        $this->assertSame(
+            'https://public.example/path/?foo=bar',
+            $base_url,
+            'Base URL should collapse benign host aliases to the canonical home URL.'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- normalize frontend URL sanitization to always return the canonical home URL, even when benign host aliases such as www-prefixed domains are supplied
- ensure external domains are rejected by falling back to the public home URL instead of leaving the value empty
- add a regression test covering the www alias scenario for sanitize_internal_url

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d69b09959c832e9300621dfd1fbe35