### PR TITLE
Add migration queue scheduling coverage

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -298,6 +298,8 @@ final class JLG_Plugin_De_Notation_Main {
             return $post_id > 0;
         }));
 
+        sort($queue);
+
         if (empty($queue)) {
             delete_option('jlg_migration_v5_queue');
 

--- a/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
+++ b/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
@@ -104,6 +104,19 @@ class MigrationScheduleTest extends TestCase
         $this->assertHookNotScheduled('jlg_process_v5_migration');
     }
 
+    public function testQueueAdditionalPostsForMigrationMergesAndSchedules(): void
+    {
+        $plugin = $this->bootPlugin();
+
+        update_option('jlg_migration_v5_queue', [300, 150]);
+
+        $plugin->queue_additional_posts_for_migration([150, 450, 275]);
+
+        $this->assertSame([150, 275, 300, 450], get_option('jlg_migration_v5_queue'));
+
+        $this->assertHookScheduled('jlg_process_v5_migration');
+    }
+
     public function testProcessMigrationBatchConsumesQueueAndFinalizes(): void
     {
         $plugin = $this->bootPlugin();


### PR DESCRIPTION
## Summary
- add a regression test covering queue_additional_posts_for_migration behaviour
- normalize stored migration queue values to be sorted when persisting

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d69f202504832e9ba706503af6b048