### PR TITLE
Honor custom rated post types in shortcodes

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -178,6 +178,27 @@ class JLG_Helpers {
         return self::$options_cache;
     }
 
+    /**
+     * Retrieve the post types allowed for ratings and shortcodes.
+     *
+     * @return string[] List of sanitized post type identifiers.
+     */
+    public static function get_allowed_post_types() {
+        $post_types = apply_filters('jlg_rated_post_types', ['post']);
+
+        if (!is_array($post_types)) {
+            $post_types = ['post'];
+        }
+
+        $post_types = array_values(array_filter(array_map('sanitize_key', $post_types)));
+
+        if (empty($post_types)) {
+            $post_types = ['post'];
+        }
+
+        return array_values(array_unique($post_types));
+    }
+
     public static function flush_plugin_options_cache() {
         self::$options_cache = null;
     }
@@ -372,11 +393,7 @@ class JLG_Helpers {
             return '_note_' . $key;
         }, self::$category_keys);
 
-        $post_types = apply_filters('jlg_rated_post_types', ['post']);
-        if (!is_array($post_types) || empty($post_types)) {
-            $post_types = ['post'];
-        }
-        $post_types = array_values(array_filter(array_map('sanitize_key', $post_types)));
+        $post_types = self::get_allowed_post_types();
 
         $post_statuses = apply_filters('jlg_rated_post_statuses', ['publish']);
         if (!is_array($post_statuses) || empty($post_statuses)) {

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -70,7 +70,9 @@ class JLG_Shortcode_All_In_One {
         }
 
         $post = get_post($post_id);
-        if (!$post instanceof WP_Post || ($post->post_type ?? '') !== 'post') {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        if (!$post instanceof WP_Post || !in_array($post->post_type ?? '', $allowed_types, true)) {
             return '';
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -605,10 +605,7 @@ class JLG_Shortcode_Game_Explorer {
             $paged = 1;
         }
 
-        $post_types = apply_filters('jlg_rated_post_types', ['post']);
-        if (!is_array($post_types) || empty($post_types)) {
-            $post_types = ['post'];
-        }
+        $post_types = JLG_Helpers::get_allowed_post_types();
         $post_statuses = apply_filters('jlg_rated_post_statuses', ['publish']);
         if (!is_array($post_statuses) || empty($post_statuses)) {
             $post_statuses = ['publish'];

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -64,7 +64,9 @@ class JLG_Shortcode_Game_Info {
 
     private function resolve_target_post_id($post_id_attribute) {
         $post_id = absint($post_id_attribute);
-        if ($post_id && $this->is_valid_target_post($post_id)) {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        if ($post_id && $this->is_valid_target_post($post_id, $allowed_types)) {
             return $post_id;
         }
 
@@ -77,20 +79,24 @@ class JLG_Shortcode_Game_Info {
             return 0;
         }
 
-        if (function_exists('is_singular') && !is_singular('post')) {
+        if (function_exists('is_singular') && !is_singular($allowed_types)) {
             return 0;
         }
 
-        return $this->is_valid_target_post($current_post_id) ? $current_post_id : 0;
+        return $this->is_valid_target_post($current_post_id, $allowed_types) ? $current_post_id : 0;
     }
 
-    private function is_valid_target_post($post_id) {
+    private function is_valid_target_post($post_id, ?array $allowed_types = null) {
+        if ($allowed_types === null) {
+            $allowed_types = JLG_Helpers::get_allowed_post_types();
+        }
+
         $post = get_post($post_id);
         if (!$post instanceof WP_Post) {
             return false;
         }
 
-        if (($post->post_type ?? '') !== 'post') {
+        if (!in_array($post->post_type ?? '', $allowed_types, true)) {
             return false;
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
@@ -8,8 +8,10 @@ class JLG_Shortcode_Pros_Cons {
     }
 
     public function render($atts = [], $content = '', $shortcode_tag = '') {
-        // Sécurité : ne s'exécute que sur les articles ('post') ou pages singulières
-        if (!is_singular('post')) {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        // Sécurité : ne s'exécute que sur les contenus autorisés
+        if (!is_singular($allowed_types)) {
             return '';
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
@@ -19,7 +19,9 @@ class JLG_Shortcode_Rating_Block {
         }
 
         $post = get_post($post_id);
-        if (!$post instanceof WP_Post || ($post->post_type ?? '') !== 'post') {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        if (!$post instanceof WP_Post || !in_array($post->post_type ?? '', $allowed_types, true)) {
             return '';
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
@@ -8,7 +8,9 @@ class JLG_Shortcode_Tagline {
     }
 
     public function render($atts = [], $content = '', $shortcode_tag = '') {
-        if (!is_singular('post')) {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        if (!is_singular($allowed_types)) {
             return '';
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -8,7 +8,9 @@ class JLG_Shortcode_User_Rating {
     }
 
     public function render($atts = [], $content = '', $shortcode_tag = '') {
-        if (!is_singular('post')) {
+        $allowed_types = JLG_Helpers::get_allowed_post_types();
+
+        if (!is_singular($allowed_types)) {
             return '';
         }
 

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllowedPostTypesTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllowedPostTypesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-jlg-helpers.php';
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-tagline.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-rating-block.php';
+
+class ShortcodeAllowedPostTypesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_options'] = [];
+        $GLOBALS['jlg_test_current_post_id'] = 0;
+        $GLOBALS['jlg_test_filters'] = [];
+
+        JLG_Helpers::flush_plugin_options_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset(
+            $GLOBALS['jlg_test_posts'],
+            $GLOBALS['jlg_test_meta'],
+            $GLOBALS['jlg_test_options'],
+            $GLOBALS['jlg_test_current_post_id'],
+            $GLOBALS['jlg_test_filters']
+        );
+    }
+
+    public function test_tagline_renders_for_custom_allowed_type(): void
+    {
+        add_filter('jlg_rated_post_types', static function ($types) {
+            $types[] = 'jlg_review';
+
+            return $types;
+        });
+
+        $post_id = 501;
+
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'          => $post_id,
+            'post_type'   => 'jlg_review',
+            'post_status' => 'publish',
+        ]);
+
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_jlg_tagline_fr' => 'Tagline personnalisée FR',
+            '_jlg_tagline_en' => 'Custom tagline EN',
+        ];
+
+        $defaults = JLG_Helpers::get_default_settings();
+        $GLOBALS['jlg_test_options']['notation_jlg_settings'] = array_merge($defaults, [
+            'tagline_enabled' => 1,
+        ]);
+        JLG_Helpers::flush_plugin_options_cache();
+
+        $GLOBALS['jlg_test_current_post_id'] = $post_id;
+
+        $shortcode = new JLG_Shortcode_Tagline();
+        $output = $shortcode->render();
+
+        $this->assertNotSame('', $output);
+        $this->assertStringContainsString('Tagline personnalisée FR', $output);
+        $this->assertStringContainsString('Custom tagline EN', $output);
+    }
+
+    public function test_rating_block_rejects_disallowed_type(): void
+    {
+        $post_id = 777;
+
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'          => $post_id,
+            'post_type'   => 'page',
+            'post_status' => 'publish',
+        ]);
+
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_note_cat1' => 8.0,
+        ];
+
+        $shortcode = new JLG_Shortcode_Rating_Block();
+        $output = $shortcode->render([
+            'post_id' => (string) $post_id,
+        ]);
+
+        $this->assertSame('', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add a helper to centralize sanitized allowed post types
- update rating-related shortcodes to respect filtered post types
- improve filter stubs in the test harness and add coverage for custom types

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6b32ba5bc832e9c71a7e6825b85a8