### PR TITLE
Load shared logic for all-in-one shortcode

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
@@ -1,0 +1,115 @@
+(function() {
+    if (window.jlgAllInOneInit) {
+        return;
+    }
+
+    let observer = null;
+    let blocksInitialized = false;
+
+    const observeBlock = (block) => {
+        const animationsEnabled = block.dataset.animationsEnabled === 'true' || block.classList.contains('animate-in');
+
+        if (!animationsEnabled) {
+            return;
+        }
+
+        if ('IntersectionObserver' in window) {
+            if (!observer) {
+                observer = new IntersectionObserver((entries) => {
+                    entries.forEach((entry) => {
+                        if (entry.isIntersecting) {
+                            entry.target.classList.add('is-visible');
+                            observer.unobserve(entry.target);
+                        }
+                    });
+                }, {
+                    threshold: 0.2
+                });
+            }
+
+            observer.observe(block);
+        } else {
+            block.classList.add('is-visible');
+        }
+    };
+
+    const bindFlagToggle = (block) => {
+        const hasMultipleTaglines = block.dataset.hasMultipleTaglines === 'true';
+        if (!hasMultipleTaglines) {
+            return;
+        }
+
+        const flags = block.querySelectorAll('.jlg-aio-flag');
+        const taglines = block.querySelectorAll('.jlg-aio-tagline');
+
+        if (!flags.length || !taglines.length) {
+            return;
+        }
+
+        flags.forEach((flag) => {
+            flag.addEventListener('click', () => {
+                const selectedLang = flag.dataset.lang;
+
+                flags.forEach((innerFlag) => {
+                    innerFlag.classList.toggle('active', innerFlag === flag);
+                });
+
+                taglines.forEach((tagline) => {
+                    if (tagline.dataset.lang === selectedLang) {
+                        tagline.style.display = 'block';
+                    } else {
+                        tagline.style.display = 'none';
+                    }
+                });
+            });
+        });
+    };
+
+    const initBlocks = () => {
+        const blocks = document.querySelectorAll('.jlg-all-in-one-block');
+
+        if (!blocks.length) {
+            return;
+        }
+
+        blocks.forEach((block) => {
+            if (block.dataset.jlgAioInitialized === 'true') {
+                return;
+            }
+
+            block.dataset.jlgAioInitialized = 'true';
+
+            bindFlagToggle(block);
+            observeBlock(block);
+        });
+
+        blocksInitialized = true;
+    };
+
+    const onReadyStateChange = () => {
+        if (!blocksInitialized) {
+            initBlocks();
+        }
+    };
+
+    const onDOMContentLoaded = () => {
+        initBlocks();
+        document.removeEventListener('DOMContentLoaded', onDOMContentLoaded);
+    };
+
+    const onWindowLoad = () => {
+        initBlocks();
+        window.removeEventListener('load', onWindowLoad);
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
+    } else {
+        initBlocks();
+    }
+
+    window.addEventListener('load', onWindowLoad);
+    document.addEventListener('readystatechange', onReadyStateChange);
+
+    window.jlgAllInOneInit = initBlocks;
+})();

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -36,6 +36,16 @@ class JLG_Shortcode_All_In_One {
                 JLG_NOTATION_VERSION
             );
         }
+
+        if (!wp_script_is('jlg-all-in-one', 'registered')) {
+            wp_register_script(
+                'jlg-all-in-one',
+                JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-all-in-one.js',
+                [],
+                JLG_NOTATION_VERSION,
+                true
+            );
+        }
     }
 
     public function render($atts, $content = '', $shortcode_tag = '') {
@@ -139,10 +149,11 @@ class JLG_Shortcode_All_In_One {
         $cons_list = !empty($cons) ? array_filter(array_map('trim', explode("\n", $cons))) : [];
 
         // Enregistrer/charger la feuille de style
-        if (!wp_style_is($this->style_handle, 'registered')) {
+        if (!wp_style_is($this->style_handle, 'registered') || !wp_script_is('jlg-all-in-one', 'registered')) {
             $this->register_assets();
         }
         wp_enqueue_style($this->style_handle);
+        wp_enqueue_script('jlg-all-in-one');
 
         $tagline_font_size = isset($options['tagline_font_size']) ? absint($options['tagline_font_size']) : 16;
         if ($tagline_font_size <= 0) {

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -10,9 +10,14 @@ $has_tagline = ($atts['afficher_tagline'] === 'oui' && (!empty($tagline_fr) || !
 $has_dual_tagline = (!empty($tagline_fr) && !empty($tagline_en));
 $show_rating = ($atts['afficher_notation'] === 'oui' && $average_score !== null);
 $show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !empty($cons_list)));
+$data_attributes = sprintf(
+    ' data-animations-enabled="%s" data-has-multiple-taglines="%s"',
+    esc_attr($animations_enabled ? 'true' : 'false'),
+    esc_attr($has_dual_tagline ? 'true' : 'false')
+);
 ?>
 
-<div class="<?php echo esc_attr($block_classes); ?>"<?php echo $style_attribute; ?>>
+<div class="<?php echo esc_attr($block_classes); ?>"<?php echo $style_attribute; ?><?php echo $data_attributes; ?>>
     <?php if ($has_tagline): ?>
     <div class="jlg-aio-header">
         <?php if ($has_dual_tagline): ?>
@@ -106,52 +111,3 @@ $show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !em
     </div>
     <?php endif; ?>
 </div>
-
-<?php if (!empty($tagline_fr) && !empty($tagline_en)): ?>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const allFlags = document.querySelectorAll('.jlg-aio-flag');
-
-    allFlags.forEach(flag => {
-        const block = flag.closest('.jlg-all-in-one-block');
-        if (!block) {
-            return;
-        }
-
-        const blockFlags = block.querySelectorAll('.jlg-aio-flag');
-        const blockTaglines = block.querySelectorAll('.jlg-aio-tagline');
-
-        flag.addEventListener('click', function() {
-            const selectedLang = this.dataset.lang;
-
-            blockFlags.forEach(f => f.classList.remove('active'));
-            this.classList.add('active');
-
-            blockTaglines.forEach(t => {
-                if (t.dataset.lang === selectedLang) {
-                    t.style.display = 'block';
-                } else {
-                    t.style.display = 'none';
-                }
-            });
-        });
-    });
-
-    <?php if ($animations_enabled): ?>
-    const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                entry.target.classList.add('is-visible');
-                observer.unobserve(entry.target);
-            }
-        });
-    }, {
-        threshold: 0.2
-    });
-
-    const animatedBlocks = document.querySelectorAll('.jlg-all-in-one-block.animate-in');
-    animatedBlocks.forEach(block => observer.observe(block));
-    <?php endif; ?>
-});
-</script>
-<?php endif; ?>


### PR DESCRIPTION
## Summary
- add a dedicated frontend script that initializes all-in-one blocks once and reuses a shared IntersectionObserver
- register and enqueue the script alongside the shortcode assets so it only loads when needed, exposing animation flags via data attributes
- remove the inline JavaScript from the shortcode template in favor of the centralized script

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b359d7f4832e9a6b206c34dc02aa