### PR TITLE
Refine front-end handling for all-in-one shortcode

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -45,6 +45,34 @@ class JLG_Shortcode_All_In_One {
                 JLG_NOTATION_VERSION,
                 true
             );
+
+            $script_settings = apply_filters('jlg_all_in_one_script_settings', [
+                'observerThreshold' => 0.2,
+                'visibleClass'      => 'is-visible',
+                'animationClass'    => 'animate-in',
+            ]);
+
+            $inline_settings  = 'window.jlgAllInOneSettings = window.jlgAllInOneSettings || {};' . "\n";
+
+            foreach ($script_settings as $key => $value) {
+                if (!is_string($key) || $key === '') {
+                    continue;
+                }
+
+                $js_key = preg_replace('/[^A-Za-z0-9_]/', '', $key);
+                if ($js_key === '') {
+                    continue;
+                }
+
+                $encoded_value = wp_json_encode($value);
+                $inline_settings .= sprintf(
+                    'if (typeof window.jlgAllInOneSettings.%1$s === "undefined") { window.jlgAllInOneSettings.%1$s = %2$s; }' . "\n",
+                    $js_key,
+                    $encoded_value
+                );
+            }
+
+            wp_add_inline_script('jlg-all-in-one', $inline_settings, 'before');
         }
     }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -40,7 +40,7 @@ $data_attributes = sprintf(
         <?php endif; ?>
 
         <?php if (!empty($tagline_en)): ?>
-        <div class="jlg-aio-tagline" data-lang="en"<?php echo $has_dual_tagline ? ' style="display:none;"' : ''; ?>>
+        <div class="jlg-aio-tagline" data-lang="en"<?php echo $has_dual_tagline ? ' style="display:none;" hidden' : ''; ?>>
             <?php echo wp_kses_post($tagline_en); ?>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- update the dedicated all-in-one frontend script to initialise flag toggles and animations once per block and honour runtime settings
- register the script with inline configuration that can be filtered and surface per-block options through data attributes
- ensure the shortcode template stays markup-only, marking inactive taglines as hidden for accessibility

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b5da3628832ea91b767a3bc443ef