### PR TITLE
Refine all-in-one shortcode front-end initialization

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
@@ -3,34 +3,51 @@
         return;
     }
 
-    let observer = null;
-    let blocksInitialized = false;
+    const initializedBlocks = new WeakSet();
+    const observersByThreshold = new Map();
+
+    const ensureObserver = (threshold) => {
+        if (!('IntersectionObserver' in window)) {
+            return null;
+        }
+
+        const normalizedThreshold = Math.max(0, Math.min(1, threshold));
+        const key = normalizedThreshold.toFixed(2);
+
+        if (!observersByThreshold.has(key)) {
+            const io = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('is-visible');
+                        io.unobserve(entry.target);
+                    }
+                });
+            }, {
+                threshold: normalizedThreshold,
+            });
+
+            observersByThreshold.set(key, io);
+        }
+
+        return observersByThreshold.get(key) || null;
+    };
 
     const observeBlock = (block) => {
         const animationsEnabled = block.dataset.animationsEnabled === 'true' || block.classList.contains('animate-in');
-
         if (!animationsEnabled) {
+            block.classList.add('is-visible');
             return;
         }
 
-        if ('IntersectionObserver' in window) {
-            if (!observer) {
-                observer = new IntersectionObserver((entries) => {
-                    entries.forEach((entry) => {
-                        if (entry.isIntersecting) {
-                            entry.target.classList.add('is-visible');
-                            observer.unobserve(entry.target);
-                        }
-                    });
-                }, {
-                    threshold: 0.2
-                });
-            }
+        const threshold = Math.max(0, Math.min(1, parseFloat(block.dataset.animationThreshold || '0.2') || 0.2));
+        const io = ensureObserver(threshold);
 
-            observer.observe(block);
-        } else {
-            block.classList.add('is-visible');
+        if (io) {
+            io.observe(block);
+            return;
         }
+
+        block.classList.add('is-visible');
     };
 
     const bindFlagToggle = (block) => {
@@ -55,61 +72,47 @@
                 });
 
                 taglines.forEach((tagline) => {
-                    if (tagline.dataset.lang === selectedLang) {
-                        tagline.style.display = 'block';
-                    } else {
-                        tagline.style.display = 'none';
-                    }
+                    tagline.style.display = tagline.dataset.lang === selectedLang ? 'block' : 'none';
                 });
             });
         });
     };
 
+    const initBlock = (block) => {
+        if (initializedBlocks.has(block)) {
+            return;
+        }
+
+        initializedBlocks.add(block);
+        bindFlagToggle(block);
+        observeBlock(block);
+    };
+
     const initBlocks = () => {
         const blocks = document.querySelectorAll('.jlg-all-in-one-block');
-
         if (!blocks.length) {
             return;
         }
 
-        blocks.forEach((block) => {
-            if (block.dataset.jlgAioInitialized === 'true') {
-                return;
-            }
-
-            block.dataset.jlgAioInitialized = 'true';
-
-            bindFlagToggle(block);
-            observeBlock(block);
-        });
-
-        blocksInitialized = true;
+        blocks.forEach(initBlock);
     };
 
-    const onReadyStateChange = () => {
-        if (!blocksInitialized) {
-            initBlocks();
-        }
-    };
-
-    const onDOMContentLoaded = () => {
+    const handleReady = () => {
         initBlocks();
-        document.removeEventListener('DOMContentLoaded', onDOMContentLoaded);
-    };
-
-    const onWindowLoad = () => {
-        initBlocks();
-        window.removeEventListener('load', onWindowLoad);
     };
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
+        document.addEventListener('DOMContentLoaded', handleReady, { once: true });
     } else {
-        initBlocks();
+        handleReady();
     }
 
-    window.addEventListener('load', onWindowLoad);
-    document.addEventListener('readystatechange', onReadyStateChange);
+    window.addEventListener('load', initBlocks);
+    document.addEventListener('readystatechange', () => {
+        if (document.readyState === 'complete') {
+            initBlocks();
+        }
+    });
 
     window.jlgAllInOneInit = initBlocks;
 })();

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1455,6 +1455,7 @@ class JLG_Frontend {
                 'css_variables'      => '',
                 'score_layout'       => 'text',
                 'animations_enabled' => false,
+                'animation_threshold' => 0.2,
                 'paged'              => 1,
                 'orderby'            => '',
                 'order'              => '',

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -299,6 +299,12 @@ class JLG_Shortcode_All_In_One {
         $tag = $shortcode_tag !== '' ? $shortcode_tag : 'jlg_bloc_complet';
         JLG_Frontend::mark_shortcode_rendered($tag);
 
+        $animation_threshold = apply_filters('jlg_all_in_one_animation_threshold', 0.2);
+        if (!is_numeric($animation_threshold)) {
+            $animation_threshold = 0.2;
+        }
+        $animation_threshold = max(0.0, min(1.0, floatval($animation_threshold)));
+
         return JLG_Frontend::get_template_html('shortcode-all-in-one', [
             'options' => $options,
             'average_score' => $average_score,
@@ -313,6 +319,7 @@ class JLG_Shortcode_All_In_One {
             'css_variables' => $css_variables_string,
             'score_layout' => $score_layout,
             'animations_enabled' => !empty($options['enable_animations']),
+            'animation_threshold' => $animation_threshold,
         ]);
     }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -11,9 +11,10 @@ $has_dual_tagline = (!empty($tagline_fr) && !empty($tagline_en));
 $show_rating = ($atts['afficher_notation'] === 'oui' && $average_score !== null);
 $show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !empty($cons_list)));
 $data_attributes = sprintf(
-    ' data-animations-enabled="%s" data-has-multiple-taglines="%s"',
+    ' data-animations-enabled="%s" data-has-multiple-taglines="%s" data-animation-threshold="%s"',
     esc_attr($animations_enabled ? 'true' : 'false'),
-    esc_attr($has_dual_tagline ? 'true' : 'false')
+    esc_attr($has_dual_tagline ? 'true' : 'false'),
+    esc_attr($animation_threshold)
 );
 ?>
 


### PR DESCRIPTION
## Summary
- refactor the all-in-one shortcode script to initialize each block once, reuse IntersectionObservers per threshold, and expose a manual init hook
- surface the animation threshold via PHP so templates render the required data attributes without inline scripts
- extend the frontend template defaults to include the threshold metadata consumed by the script

## Testing
- php -l includes/shortcodes/class-jlg-shortcode-all-in-one.php

------
https://chatgpt.com/codex/tasks/task_e_68d707c2ccc8832ebd72cd28c8850368