### PR TITLE
Use allowed post types for summary shortcode queries

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -90,13 +90,21 @@ class JLG_Shortcode_Summary_Display {
         $orderby = $sorting['key'];
 
         $rated_post_ids = JLG_Helpers::get_rated_post_ids();
+        $allowed_post_types = JLG_Helpers::get_allowed_post_types();
+        $allowed_post_types = array_values(array_unique(array_filter($allowed_post_types, static function ($type) {
+            return is_string($type) && $type !== '';
+        })));
+
+        if (empty($allowed_post_types)) {
+            $allowed_post_types = ['post'];
+        }
 
         if (!empty($rated_post_ids) && isset($sorting['meta_key']) && $sorting['meta_key'] === '_jlg_average_score') {
             $max_sync = apply_filters('jlg_summary_max_sync_average_rebuilds', self::MAX_SYNC_AVERAGE_REBUILDS, $atts);
             $max_sync = max(0, intval($max_sync));
 
             $posts_missing_average = get_posts([
-                'post_type'      => 'post',
+                'post_type'      => $allowed_post_types,
                 'post__in'       => $rated_post_ids,
                 'fields'         => 'ids',
                 'posts_per_page' => $max_sync + 1,
@@ -151,7 +159,7 @@ class JLG_Shortcode_Summary_Display {
         }
 
         $args = [
-            'post_type'      => 'post',
+            'post_type'      => $allowed_post_types,
             'posts_per_page' => $posts_per_page,
             'paged'          => $paged,
             'order'          => $order,

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -137,4 +137,30 @@ class ShortcodeSummarySortingTest extends TestCase
         $this->assertSame('meta_value_num', $context['query']->args['orderby']);
         $this->assertSame('average_score', $context['orderby']);
     }
+
+    public function test_render_context_uses_filtered_post_types()
+    {
+        $previous_filters = $GLOBALS['jlg_test_filters'] ?? null;
+
+        add_filter('jlg_rated_post_types', function ($types) {
+            $types[] = 'game_review';
+            $types[] = 'post';
+            $types[] = 'game_review';
+
+            return $types;
+        });
+
+        try {
+            $context = JLG_Shortcode_Summary_Display::get_render_context([], []);
+        } finally {
+            if ($previous_filters === null) {
+                unset($GLOBALS['jlg_test_filters']);
+            } else {
+                $GLOBALS['jlg_test_filters'] = $previous_filters;
+            }
+        }
+
+        $this->assertInstanceOf(WP_Query::class, $context['query']);
+        $this->assertSame(['post', 'game_review'], $context['query']->args['post_type']);
+    }
 }


### PR DESCRIPTION
## Summary
- use the helper-provided list of allowed post types for the summary display shortcode queries
- normalise the post type arrays before passing them to get_posts and WP_Query
- extend the summary shortcode test to confirm the filtered post types are propagated to the query arguments

## Testing
- vendor/bin/phpunit --filter ShortcodeSummarySortingTest

------
https://chatgpt.com/codex/tasks/task_e_68d72004bf4c832eb4472bb3192eb76a