### PR TITLE
Allow user ratings on custom post types

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1042,7 +1042,9 @@ class JLG_Frontend {
             return false;
         }
 
-        if ($post->post_type !== 'post') {
+        $allowed_post_types = JLG_Helpers::get_allowed_post_types();
+
+        if (!in_array($post->post_type, $allowed_post_types, true)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- update the frontend user rating eligibility check to rely on the helper-defined list of post types
- add a unit test covering successful ratings on a custom post type registered through the jlg_rated_post_types filter

## Testing
- composer test *(fails: phpunit binary not available in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d71fc7c6cc832eab84889c1adf5e0a