### PR TITLE
Align game explorer availability with site timezone

### DIFF
--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerAvailabilityTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerAvailabilityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-game-explorer.php';
+
+class ShortcodeGameExplorerAvailabilityTest extends TestCase
+{
+    public function test_same_day_release_is_available_in_custom_timezone(): void
+    {
+        $previous_timezone = get_option('timezone_string');
+        update_option('timezone_string', 'Europe/Paris');
+
+        try {
+            $timezone = wp_timezone();
+            $release_iso = (new DateTimeImmutable('now', $timezone))->format('Y-m-d');
+
+            $method = new ReflectionMethod(JLG_Shortcode_Game_Explorer::class, 'determine_availability');
+            $method->setAccessible(true);
+
+            $availability = $method->invoke(null, $release_iso);
+
+            $this->assertIsArray($availability, 'Availability response should be an array.');
+            $this->assertSame('available', $availability['status'] ?? null, 'Release on the current day should be available.');
+            $this->assertSame(
+                esc_html__('Disponible', 'notation-jlg'),
+                $availability['label'] ?? '',
+                'Availability label should match the available status.'
+            );
+        } finally {
+            if (is_string($previous_timezone) && $previous_timezone !== '') {
+                update_option('timezone_string', $previous_timezone);
+            } else {
+                delete_option('timezone_string');
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the game explorer availability check to compare release dates using the site's timezone and fall back gracefully when parsing fails
- expose wp_timezone helpers and adjust the current_time stub in the test bootstrap so tests honour custom timezones
- add a unit test that confirms a same-day release remains available when the site timezone is not UTC

## Testing
- vendor/bin/phpunit --filter ShortcodeGameExplorerAvailabilityTest


------
https://chatgpt.com/codex/tasks/task_e_68d7cfe70e48832e8cc02d2cf109db3f