### PR TITLE
Invalidate Game Explorer snapshot cache when metadata changes

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -73,6 +73,7 @@ final class JLG_Plugin_De_Notation_Main {
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-helpers.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-assets.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'functions.php';
+        require_once JLG_NOTATION_PLUGIN_DIR . 'includes/shortcodes/class-jlg-shortcode-game-explorer.php';
 
         add_action('update_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
         add_action('add_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
@@ -80,6 +81,18 @@ final class JLG_Plugin_De_Notation_Main {
         add_action('added_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
         add_action('updated_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
         add_action('deleted_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
+
+        if (class_exists('JLG_Shortcode_Game_Explorer')) {
+            add_action('added_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
+            add_action('updated_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
+            add_action('deleted_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
+            add_action('save_post', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_post'], 20, 3);
+            add_action('transition_post_status', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_status_change'], 20, 3);
+            add_action('set_object_terms', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_terms'], 20, 4);
+            add_action('created_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 3);
+            add_action('edited_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 3);
+            add_action('delete_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 4);
+        }
 
         // Frontend (toujours)
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-dynamic-css.php';

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -284,6 +284,25 @@ class FrontendGameExplorerAjaxTest extends TestCase
         }
     }
 
+    public function test_snapshot_cleared_after_relevant_meta_update(): void
+    {
+        $this->configureOptions();
+        $this->registerPost(777, 'Gamma Horizon', 'Content body', '2023-01-10 09:00:00');
+
+        $this->primeSnapshot($this->buildSnapshotWithPosts());
+        set_transient('jlg_game_explorer_snapshot_v1', ['cached' => true]);
+
+        JLG_Shortcode_Game_Explorer::maybe_clear_filters_snapshot_for_meta(0, 777, '_jlg_developpeur', 'Studio Gamma');
+
+        $this->assertFalse(get_transient('jlg_game_explorer_snapshot_v1'), 'Transient cache should be cleared after meta update.');
+
+        $reflection = new ReflectionClass(JLG_Shortcode_Game_Explorer::class);
+        $property = $reflection->getProperty('filters_snapshot');
+        $property->setAccessible(true);
+
+        $this->assertNull($property->getValue(), 'Static snapshot cache should be reset after meta update.');
+    }
+
     private function configureOptions(): void
     {
         $defaults = JLG_Helpers::get_default_settings();


### PR DESCRIPTION
## Summary
- add cache invalidation utilities to the Game Explorer shortcode to reset the transient snapshot and in-memory cache
- hook the new invalidation helper into post meta, post status, and taxonomy change events so the snapshot stays fresh when content changes
- extend the Game Explorer AJAX test suite with coverage that verifies the transient is cleared after a relevant meta update

## Testing
- ./vendor/bin/phpunit tests/FrontendGameExplorerAjaxTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d7cfe552dc832e86eb311abca0e410