### PR TITLE
Handle platform label arrays in validator

### DIFF
--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-validator.php
@@ -57,6 +57,28 @@ class JLG_Validator {
             return [];
         }
 
+        $extract_labels = static function ($definitions) {
+            if (!is_array($definitions)) {
+                return [];
+            }
+
+            $labels = [];
+
+            foreach ($definitions as $definition) {
+                if (is_string($definition)) {
+                    $labels[] = sanitize_text_field($definition);
+                } elseif (is_array($definition) && isset($definition['name']) && is_string($definition['name'])) {
+                    $labels[] = sanitize_text_field($definition['name']);
+                }
+            }
+
+            $labels = array_filter($labels, static function ($label) {
+                return $label !== '';
+            });
+
+            return array_values(array_unique($labels));
+        };
+
         $allowed_platforms = [];
 
         if (class_exists('JLG_Admin_Platforms')) {
@@ -72,16 +94,7 @@ class JLG_Validator {
         if (empty($allowed_platforms) && class_exists('JLG_Helpers') && method_exists('JLG_Helpers', 'get_registered_platform_labels')) {
             $default_definitions = JLG_Helpers::get_registered_platform_labels();
 
-            if (is_array($default_definitions)) {
-                $allowed_platforms = array_filter(
-                    array_map('sanitize_text_field', array_column($default_definitions, 'name')),
-                    static function ($name) {
-                        return $name !== '';
-                    }
-                );
-
-                $allowed_platforms = array_values(array_unique($allowed_platforms));
-            }
+            $allowed_platforms = $extract_labels($default_definitions);
         }
 
         if (empty($allowed_platforms) && class_exists('JLG_Helpers') && method_exists('JLG_Helpers', 'get_default_platform_definitions')) {
@@ -103,16 +116,7 @@ class JLG_Validator {
                 }
             }
 
-            if (is_array($default_definitions)) {
-                $allowed_platforms = array_filter(
-                    array_map('sanitize_text_field', array_column($default_definitions, 'name')),
-                    static function ($name) {
-                        return $name !== '';
-                    }
-                );
-
-                $allowed_platforms = array_values(array_unique($allowed_platforms));
-            }
+            $allowed_platforms = $extract_labels($default_definitions);
         }
 
         if (empty($allowed_platforms)) {

--- a/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPlatformsTest.php
@@ -179,4 +179,24 @@ class AdminPlatformsTest extends TestCase
 
         $this->assertSame(['Steam Deck'], $sanitized);
     }
+
+    public function test_sanitize_platforms_preserves_custom_platforms(): void
+    {
+        $admin = JLG_Admin_Platforms::get_instance();
+
+        $_POST['new_platform_name'] = 'Amiga 600';
+        $_POST['new_platform_icon'] = '🕹️';
+
+        $storage = $this->invokePrivateMethod($admin, 'get_stored_platform_data');
+        $result = $this->invokePrivateMethod($admin, 'add_platform', [&$storage]);
+
+        $this->assertTrue($result['success']);
+
+        $sanitized = JLG_Validator::sanitize_platforms([
+            'Amiga 600',
+            'Imaginary Console',
+        ]);
+
+        $this->assertSame(['Amiga 600'], $sanitized);
+    }
 }


### PR DESCRIPTION
## Summary
- normalize platform definitions returned by helper methods to support associative arrays of labels
- reuse the same extraction logic for default platform definitions to accept both string and structured entries
- add a regression test confirming sanitize_platforms keeps custom platforms registered via the admin manager

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d80757e600832ebf450ec2ae0727cd