### PR TITLE
Support custom rated post types in admin list

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -89,7 +89,7 @@ class JLG_Admin_Menu {
     }
 
     private function get_posts_list_tab_content() {
-        $rated_posts = JLG_Helpers::get_rated_post_ids();
+        $rated_posts = array_values(array_unique(array_filter(array_map('intval', JLG_Helpers::get_rated_post_ids()))));
         $empty_state = [
             'create_post_url' => admin_url('post-new.php'),
         ];
@@ -107,7 +107,7 @@ class JLG_Admin_Menu {
         $order = isset($_GET['order']) && in_array(strtoupper($_GET['order']), ['ASC', 'DESC'], true) ? strtoupper($_GET['order']) : 'DESC';
 
         $args = [
-            'post_type' => 'post',
+            'post_type' => JLG_Helpers::get_allowed_post_types(),
             'post__in' => $rated_posts,
             'posts_per_page' => $per_page,
             'paged' => $current_page,


### PR DESCRIPTION
## Summary
- allow the admin "Articles Notés" list to query all allowed rated post types instead of only posts
- sanitize the rated post ID list to keep pagination, sorting, and display limited to the intended entries

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68d8368296bc832e99f34b02deefbf8c