### PR TITLE
Allow latest reviews widget to query allowed post types

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-widget.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-widget.php
@@ -28,7 +28,7 @@ class JLG_Latest_Reviews_Widget extends WP_Widget {
         }
 
         $query_args = [
-            'post_type' => 'post',
+            'post_type' => JLG_Helpers::get_allowed_post_types(),
             'posts_per_page' => $number,
             'post__in' => $rated_post_ids,
             'orderby' => 'date',


### PR DESCRIPTION
## Summary
- update the latest reviews widget to query all allowed post types via helper logic

## Testing
- not run (environment only includes source changes)

------
https://chatgpt.com/codex/tasks/task_e_68d83b287f18832eb58bb69db3956aff