### PR TITLE
Allow shortcode game info preview for authorized users

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -100,11 +100,13 @@ class JLG_Shortcode_Game_Info {
             return false;
         }
 
-        if (($post->post_status ?? '') !== 'publish') {
-            return false;
+        $status = $post->post_status ?? '';
+
+        if ($status === 'publish') {
+            return true;
         }
 
-        return true;
+        return current_user_can('read_post', $post_id);
     }
 
     private function sanitize_meta_value($meta_value) {


### PR DESCRIPTION
## Summary
- allow the game info shortcode to render non-published posts when the viewer can read the post
- default test capability checks to deny access and add coverage for draft rendering when authorized

## Testing
- ./vendor/bin/phpunit *(fails: missing WordPress helper stubs such as wp_json_encode and wp_kses)*

------
https://chatgpt.com/codex/tasks/task_e_68d86c293674832e922abcba08209eea