### PR TITLE
Handle custom ports in frontend URL sanitization

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1274,6 +1274,7 @@ class JLG_Frontend {
         $site_url = wp_parse_url($canonical_home);
         $site_host = is_array($site_url) && isset($site_url['host']) ? strtolower($site_url['host']) : '';
         $site_scheme = is_array($site_url) && isset($site_url['scheme']) ? $site_url['scheme'] : '';
+        $site_port = is_array($site_url) && isset($site_url['port']) ? intval($site_url['port']) : null;
 
         $normalize_host = static function ($host) {
             $host = strtolower((string) $host);
@@ -1319,8 +1320,15 @@ class JLG_Frontend {
 
         $normalized_url .= $site_host;
 
-        if (!empty($parsed_url['port'])) {
-            $normalized_url .= ':' . intval($parsed_url['port']);
+        $target_port = null;
+        if (isset($parsed_url['port'])) {
+            $target_port = intval($parsed_url['port']);
+        } elseif ($site_port !== null) {
+            $target_port = $site_port;
+        }
+
+        if ($target_port !== null) {
+            $normalized_url .= ':' . $target_port;
         }
 
         $normalized_url .= $path;

--- a/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
@@ -109,4 +109,28 @@ class FrontendSummaryBaseUrlTest extends TestCase
             'Base URL should collapse benign host aliases to the canonical home URL.'
         );
     }
+
+    public function test_home_url_with_custom_port_is_preserved()
+    {
+        $frontend = new JLG_Frontend();
+
+        $reflection = new ReflectionClass(JLG_Frontend::class);
+        $method = $reflection->getMethod('sanitize_internal_url');
+        $method->setAccessible(true);
+
+        $previous_base = $GLOBALS['wp_test_home_url_base'];
+        $GLOBALS['wp_test_home_url_base'] = 'https://public.example:8443';
+
+        try {
+            $base_url = $method->invoke($frontend, 'https://public.example:8443/custom/path');
+        } finally {
+            $GLOBALS['wp_test_home_url_base'] = $previous_base;
+        }
+
+        $this->assertSame(
+            'https://public.example:8443/custom/path',
+            $base_url,
+            'Base URL should keep the custom port defined in the home URL.'
+        );
+    }
 }

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -524,10 +524,12 @@ if (!function_exists('esc_url')) {
 }
 
 if (!function_exists('home_url')) {
+    $GLOBALS['wp_test_home_url_base'] = $GLOBALS['wp_test_home_url_base'] ?? 'https://public.example';
+
     function home_url($path = '', $scheme = null) {
         unset($scheme);
 
-        $base = 'https://public.example';
+        $base = isset($GLOBALS['wp_test_home_url_base']) ? (string) $GLOBALS['wp_test_home_url_base'] : 'https://public.example';
 
         if (!is_string($path)) {
             $path = '';


### PR DESCRIPTION
## Summary
- ensure sanitize_internal_url falls back to the home URL port when none is provided in the parsed URL
- allow tests to override the simulated home URL base and add coverage for custom ports

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: missing WordPress helper functions in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68d86c257838832e9fe436cd555b0773