### PR TITLE
Clear rated cache when publish status changes

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -81,6 +81,7 @@ final class JLG_Plugin_De_Notation_Main {
         add_action('added_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
         add_action('updated_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
         add_action('deleted_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
+        add_action('transition_post_status', ['JLG_Helpers', 'maybe_clear_rated_post_ids_cache_for_status_change'], 20, 3);
 
         if (class_exists('JLG_Shortcode_Game_Explorer')) {
             add_action('added_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);

--- a/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
@@ -54,4 +54,23 @@ class HelpersRatingCacheTest extends TestCase
         $this->assertArrayHasKey('_jlg_average_score', $GLOBALS['jlg_test_meta'][$post_id] ?? []);
         $this->assertSame([88], get_transient('jlg_rated_post_ids_v1'));
     }
+
+    public function test_status_transition_from_publish_clears_rated_cache(): void
+    {
+        $post_id = 987;
+
+        $post = new WP_Post([
+            'ID' => $post_id,
+            'post_type' => 'post',
+        ]);
+
+        $GLOBALS['jlg_test_posts'][$post_id] = $post;
+        $GLOBALS['jlg_test_meta'][$post_id]['_note_cat1'] = '9.0';
+
+        set_transient('jlg_rated_post_ids_v1', [123, 456]);
+
+        JLG_Helpers::maybe_clear_rated_post_ids_cache_for_status_change('draft', 'publish', $post);
+
+        $this->assertFalse(get_transient('jlg_rated_post_ids_v1'));
+    }
 }


### PR DESCRIPTION
## Summary
- register a `transition_post_status` hook so publish transitions invalidate the rated post cache
- add a helper callback that filters publish status changes to rated posts before clearing cached IDs
- add a unit test covering cache clearing when a rated post moves from publish to draft

## Testing
- ./vendor/bin/phpunit *(fails: missing WordPress stubs for wp_json_encode and wp_kses in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d86c22a8a4832e88baed13f967cddb