### PR TITLE
Handle missing migration scan completion flag

### DIFF
--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -333,7 +333,7 @@ final class JLG_Plugin_De_Notation_Main {
 
         return [
             'last_post_id' => isset($state['last_post_id']) ? (int) $state['last_post_id'] : 0,
-            'complete' => $has_complete_flag ? !empty($state['complete']) : true,
+            'complete' => $has_complete_flag ? !empty($state['complete']) : false,
         ];
     }
 

--- a/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
+++ b/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
@@ -75,6 +75,19 @@ class MigrationScheduleTest extends TestCase
         $this->assertHookScheduled('jlg_process_v5_migration');
     }
 
+    public function testEnsureMigrationScheduleQueuesEventWhenCompleteFlagMissing(): void
+    {
+        $plugin = $this->bootPlugin();
+
+        update_option('jlg_migration_v5_scan_state', [
+            'last_post_id' => 123,
+        ]);
+
+        $plugin->ensure_migration_schedule();
+
+        $this->assertHookScheduled('jlg_process_v5_migration');
+    }
+
     public function testEnsureMigrationScheduleQueuesEventWhenQueueHasEntries(): void
     {
         $plugin = $this->bootPlugin();


### PR DESCRIPTION
## Summary
- treat a missing `complete` flag in the migration scan state as incomplete work
- add test coverage to ensure the migration event is scheduled when the completion flag is absent

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: missing WordPress helper functions in shortcode tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d86c1d5df0832e8e6bf86bda3a1710