### PR TITLE
Sanitize dynamic classes in game explorer templates

### DIFF
--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -102,7 +102,7 @@ if ($total_pages > 1) :
                 $is_active = ($page === $current_page);
                 ?>
                 <li>
-                    <button type="button" data-page="<?php echo esc_attr($page); ?>" class="<?php echo $is_active ? 'is-active' : ''; ?>">
+                    <button type="button" data-page="<?php echo esc_attr($page); ?>" class="<?php echo esc_attr($is_active ? 'is-active' : ''); ?>">
                         <?php echo esc_html($page); ?>
                     </button>
                 </li>

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -49,11 +49,17 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
                 <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e('Filtrer par lettre', 'notation-jlg'); ?>">
                     <ul>
                         <li>
+                            <?php
+                            $all_letters_classes = [];
+                            if ($letter_active === '') {
+                                $all_letters_classes[] = 'is-active';
+                            }
+                            ?>
                             <button
                                 type="button"
-                                class="<?php echo $letter_active === '' ? 'is-active' : ''; ?>"
+                                class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $all_letters_classes))); ?>"
                                 data-letter=""
-                                aria-pressed="<?php echo $letter_active === '' ? 'true' : 'false'; ?>"
+                                aria-pressed="<?php echo esc_attr($letter_active === '' ? 'true' : 'false'); ?>"
                             >
                                 <?php esc_html_e('Tous', 'notation-jlg'); ?>
                             </button>
@@ -64,12 +70,18 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
                             $is_active = ($value !== '' && $value === $letter_active);
                             ?>
                             <li>
+                                <?php
+                                $letter_button_classes = [];
+                                if ($is_active) {
+                                    $letter_button_classes[] = 'is-active';
+                                }
+                                ?>
                                 <button
                                     type="button"
                                     data-letter="<?php echo esc_attr($value); ?>"
-                                    class="<?php echo $is_active ? 'is-active' : ''; ?>"
+                                    class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $letter_button_classes))); ?>"
                                     <?php disabled(!$enabled); ?>
-                                    aria-pressed="<?php echo $is_active ? 'true' : 'false'; ?>"
+                                    aria-pressed="<?php echo esc_attr($is_active ? 'true' : 'false'); ?>"
                                 >
                                     <?php echo esc_html($letter_item['label'] ?? $value); ?>
                                 </button>

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -62,15 +62,33 @@ $letters = range('A', 'Z');
         <!-- Filtres -->
         <div class="jlg-summary-filters">
             <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e('Filtrer par lettre', 'notation-jlg'); ?>">
-                <button type="button" class="<?php echo $current_letter_filter === '' ? 'is-active' : ''; ?>" data-letter="">
+                <?php
+                $all_letters_classes = [];
+                if ($current_letter_filter === '') {
+                    $all_letters_classes[] = 'is-active';
+                }
+                ?>
+                <button type="button" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $all_letters_classes))); ?>" data-letter="">
                     <?php esc_html_e('Tous', 'notation-jlg'); ?>
                 </button>
                 <?php foreach ($letters as $letter) : ?>
-                    <button type="button" data-letter="<?php echo esc_attr($letter); ?>" class="<?php echo ($current_letter_filter === $letter) ? 'is-active' : ''; ?>">
+                    <?php
+                    $letter_button_classes = [];
+                    if ($current_letter_filter === $letter) {
+                        $letter_button_classes[] = 'is-active';
+                    }
+                    ?>
+                    <button type="button" data-letter="<?php echo esc_attr($letter); ?>" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $letter_button_classes))); ?>">
                         <?php echo esc_html($letter); ?>
                     </button>
                 <?php endforeach; ?>
-                <button type="button" data-letter="#" class="<?php echo ($current_letter_filter === '#') ? 'is-active' : ''; ?>">
+                <?php
+                $numeric_button_classes = [];
+                if ($current_letter_filter === '#') {
+                    $numeric_button_classes[] = 'is-active';
+                }
+                ?>
+                <button type="button" data-letter="#" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $numeric_button_classes))); ?>">
                     <?php esc_html_e('0-9', 'notation-jlg'); ?>
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- sanitize letter filter button classes in the game explorer shortcode template
- sanitize summary shortcode filter button classes with array-based class assembly
- escape pagination active class output in the game explorer fragment

## Testing
- php -l plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
- php -l plugin-notation-jeux_V4/templates/shortcode-summary-display.php
- php -l plugin-notation-jeux_V4/templates/game-explorer-fragment.php

------
https://chatgpt.com/codex/tasks/task_e_68d91e5ad1f0832e8a8a5c95e8361615