### PR TITLE
Format game explorer counts with localized numbers

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -99,9 +99,11 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
             </div>
             <div class="jlg-ge-count">
                 <?php
+                $formatted_total_items = number_format_i18n($total_items);
+
                 printf(
-                    esc_html(_n('%d jeu', '%d jeux', $total_items, 'notation-jlg')),
-                    $total_items
+                    esc_html(_n('%s jeu', '%s jeux', $total_items, 'notation-jlg')),
+                    $formatted_total_items
                 );
                 ?>
             </div>

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerCountTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerCountTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512) {
+        return json_encode($data, $options, $depth);
+    }
+}
+
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain = 'default') {
+        unset($domain);
+
+        return (int) $number === 1 ? $single : $plural;
+    }
+}
+
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+
+class ShortcodeGameExplorerCountTest extends TestCase
+{
+    public function test_renders_singular_label_with_formatted_count(): void
+    {
+        $output = $this->renderTemplateWithTotal(1);
+
+        $this->assertMatchesRegularExpression(
+            '/<div class="jlg-ge-count">\s*1 jeu\s*<\/div>/',
+            $output,
+            'The singular label should be rendered when there is only one game.'
+        );
+    }
+
+    public function test_renders_plural_label_with_formatted_count(): void
+    {
+        $output = $this->renderTemplateWithTotal(2);
+
+        $this->assertMatchesRegularExpression(
+            '/<div class="jlg-ge-count">\s*2 jeux\s*<\/div>/',
+            $output,
+            'The plural label should be rendered when there are multiple games.'
+        );
+    }
+
+    public function test_uses_number_format_i18n_for_large_counts(): void
+    {
+        $output = $this->renderTemplateWithTotal(12345);
+
+        $this->assertStringContainsString(
+            '12,345 jeux',
+            $output,
+            'The game count should be formatted using number_format_i18n().' 
+        );
+    }
+
+    private function renderTemplateWithTotal(int $total): string
+    {
+        return JLG_Frontend::get_template_html('shortcode-game-explorer', [
+            'total_items' => $total,
+            'atts' => [
+                'posts_per_page' => 12,
+            ],
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- format the game explorer counter using number_format_i18n while keeping proper pluralization
- add PHPUnit coverage ensuring singular, plural, and large values render correctly

## Testing
- ./vendor/bin/phpunit --filter ShortcodeGameExplorerCountTest

------
https://chatgpt.com/codex/tasks/task_e_68d91e5edc28832e8459526c81979741