### PR TITLE
Localize admin platform confirmations and nonces

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-platforms-order.js
@@ -16,6 +16,35 @@
         };
     }
 
+    function getL10n() {
+        var defaults = {
+            confirmReset: 'Are you sure you want to reset all platforms?',
+            confirmDelete: 'Are you sure you want to delete the "%s" platform?',
+            nonce: '',
+            nonceField: 'jlg_platform_nonce',
+            actionField: 'jlg_platform_action',
+            deleteAction: 'delete'
+        };
+
+        if (window.jlgPlatformsOrderL10n && typeof window.jlgPlatformsOrderL10n === 'object') {
+            return $.extend({}, defaults, window.jlgPlatformsOrderL10n);
+        }
+
+        return defaults;
+    }
+
+    function formatConfirmationMessage(template, replacement) {
+        if (typeof template !== 'string') {
+            return '';
+        }
+
+        if (typeof replacement === 'undefined') {
+            return template;
+        }
+
+        return template.replace('%s', replacement);
+    }
+
     function ensurePlaceholderStyle(className) {
         if (!className) {
             return;
@@ -75,6 +104,7 @@
 
     $(function () {
         var settings = getSettings();
+        var l10n = getL10n();
         var $list = $(settings.listSelector);
 
         if (!$list.length || typeof $list.sortable !== 'function') {
@@ -121,5 +151,61 @@
         }
 
         syncOrder($list, settings);
+
+        $('.jlg-reset-platforms-form').on('submit', function (event) {
+            var message = l10n.confirmReset || '';
+
+            if (message && !window.confirm(message)) {
+                event.preventDefault();
+            }
+        });
+
+        $('.delete-platform').on('click', function (event) {
+            event.preventDefault();
+
+            var $button = $(this);
+            var key = $button.data('key');
+            var name = $button.data('name');
+            var messageTemplate = l10n.confirmDelete || '';
+            var message = formatConfirmationMessage(messageTemplate, name);
+
+            if (!message) {
+                message = 'Are you sure you want to delete this platform?';
+            }
+
+            if (!window.confirm(message)) {
+                return;
+            }
+
+            if (!key) {
+                return;
+            }
+
+            var form = $('<form>', {
+                method: 'POST',
+                action: ''
+            });
+
+            form.append($('<input>', {
+                type: 'hidden',
+                name: l10n.actionField,
+                value: l10n.deleteAction
+            }));
+
+            form.append($('<input>', {
+                type: 'hidden',
+                name: 'platform_key',
+                value: key
+            }));
+
+            form.append($('<input>', {
+                type: 'hidden',
+                name: l10n.nonceField,
+                value: l10n.nonce
+            }));
+
+            $('body').append(form);
+            form.submit();
+        });
     });
 })(jQuery);

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -682,7 +682,7 @@ class JLG_Admin_Platforms {
                 <div style="background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
                     <h3>⚙️ Actions</h3>
 
-                    <form method="post" action="" onsubmit="return confirm('Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?');">
+                    <form method="post" action="" class="jlg-reset-platforms-form">
                         <?php wp_nonce_field('jlg_platform_action', 'jlg_platform_nonce'); ?>
                         <input type="hidden" name="jlg_platform_action" value="reset">
 
@@ -709,43 +709,6 @@ class JLG_Admin_Platforms {
             </div>
         </div>
 
-        <!-- JavaScript pour la suppression -->
-        <script>
-        jQuery(document).ready(function($) {
-            $('.delete-platform').on('click', function() {
-                var key = $(this).data('key');
-                var name = $(this).data('name');
-                
-                if (confirm('Êtes-vous sûr de vouloir supprimer la plateforme "' + name + '" ?')) {
-                    var form = $('<form>', {
-                        method: 'POST',
-                        action: ''
-                    });
-                    
-                    form.append($('<input>', {
-                        type: 'hidden',
-                        name: 'jlg_platform_action',
-                        value: 'delete'
-                    }));
-                    
-                    form.append($('<input>', {
-                        type: 'hidden',
-                        name: 'platform_key',
-                        value: key
-                    }));
-                    
-                    form.append($('<input>', {
-                        type: 'hidden',
-                        name: 'jlg_platform_nonce',
-                        value: '<?php echo wp_create_nonce('jlg_platform_action'); ?>'
-                    }));
-                    
-                    $('body').append(form);
-                    form.submit();
-                }
-            });
-        });
-        </script>
         <?php
     }
 

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -52,6 +52,15 @@ class JLG_Assets {
             'placeholderClass' => 'jlg-sortable-placeholder',
         ]);
 
+        wp_localize_script($handle, 'jlgPlatformsOrderL10n', [
+            'confirmReset'  => esc_html__('Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?', 'notation-jlg'),
+            'confirmDelete' => esc_html__('Êtes-vous sûr de vouloir supprimer la plateforme "%s" ?', 'notation-jlg'),
+            'nonce'         => wp_create_nonce('jlg_platform_action'),
+            'nonceField'    => 'jlg_platform_nonce',
+            'actionField'   => 'jlg_platform_action',
+            'deleteAction'  => 'delete',
+        ]);
+
         wp_enqueue_script($handle);
     }
 


### PR DESCRIPTION
## Summary
- remove inline confirmation strings and nonce creation from the platforms admin page and rely on the shared script
- expose confirmation messages and the delete nonce to jlg-platforms-order.js through wp_localize_script
- update the platforms ordering script to use localized strings, handle reset confirmation, and submit delete requests with the provided nonce

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
- php -l plugin-notation-jeux_V4/includes/class-jlg-assets.php

------
https://chatgpt.com/codex/tasks/task_e_68da5757e14c832eab4cc0592750f1eb