### PR TITLE
Handle letter normalization when mbstring is missing

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -294,8 +294,22 @@ class JLG_Shortcode_Game_Explorer {
         }
 
         $value = remove_accents($value);
-        $first = mb_substr($value, 0, 1, 'UTF-8');
-        $first_upper = mb_strtoupper($first, 'UTF-8');
+
+        if (function_exists('mb_substr')) {
+            $first = mb_substr($value, 0, 1, 'UTF-8');
+        } elseif (function_exists('iconv_substr')) {
+            $first = iconv_substr($value, 0, 1, 'UTF-8');
+        } else {
+            $first = substr($value, 0, 1);
+        }
+
+        if (function_exists('mb_strtoupper')) {
+            $first_upper = mb_strtoupper($first, 'UTF-8');
+        } elseif (function_exists('wp_strtoupper')) {
+            $first_upper = wp_strtoupper($first);
+        } else {
+            $first_upper = strtoupper($first);
+        }
 
         if (preg_match('/[A-Z]/u', $first_upper)) {
             return $first_upper;

--- a/plugin-notation-jeux_V4/tests/manual/test-normalize-letter.php
+++ b/plugin-notation-jeux_V4/tests/manual/test-normalize-letter.php
@@ -1,0 +1,49 @@
+<?php
+// Manual test script for normalize_letter compatibility.
+
+define('ABSPATH', __DIR__);
+
+if (!function_exists('remove_accents')) {
+    function remove_accents($string) {
+        if (!is_string($string)) {
+            return '';
+        }
+
+        $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $string);
+        if ($transliterated === false) {
+            return $string;
+        }
+
+        return $transliterated;
+    }
+}
+
+if (!function_exists('wp_strtoupper')) {
+    function wp_strtoupper($string) {
+        if (function_exists('mb_strtoupper')) {
+            return mb_strtoupper($string, 'UTF-8');
+        }
+
+        return strtoupper($string);
+    }
+}
+
+require_once dirname(__DIR__, 2) . '/includes/shortcodes/class-jlg-shortcode-game-explorer.php';
+
+class JLG_Shortcode_Game_Explorer_Test extends JLG_Shortcode_Game_Explorer {
+    public static function normalize($value) {
+        return self::normalize_letter($value);
+    }
+}
+
+$inputs = [
+    'Éclair',
+    ' 42Beta',
+    '中華',
+    'game',
+    '',
+];
+
+foreach ($inputs as $input) {
+    echo json_encode(['input' => $input, 'normalized' => JLG_Shortcode_Game_Explorer_Test::normalize($input)], JSON_UNESCAPED_UNICODE) . PHP_EOL;
+}


### PR DESCRIPTION
## Summary
- guard the game explorer letter normalization helper with fallbacks when mbstring functions are unavailable
- add a manual test script to exercise the shortcode normalization logic and support environments without mbstring

## Testing
- `php plugin-notation-jeux_V4/tests/manual/test-normalize-letter.php`
- `php -d disable_functions=mb_substr,mb_strtoupper plugin-notation-jeux_V4/tests/manual/test-normalize-letter.php`


------
https://chatgpt.com/codex/tasks/task_e_68dbe8e97b50832e8d1f523b240a3dcc