### PR TITLE
Add Gutenberg blocks mirroring JLG shortcodes

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -69,6 +69,27 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
   avec `[jlg_tableau_recap]`, puis affichez une page ou une archive : les assets `jlg-frontend` et `jlg-user-rating`
   sont maintenant chargés dès le rendu du bloc, garantissant le même affichage que dans le contenu principal.
 
+### Blocs Gutenberg
+
+Le plugin propose désormais une collection complète de blocs dynamiques pour l'éditeur moderne :
+
+- **Bloc de notation** (`notation-jlg/rating-block`) : sélectionnez un test publié ou laissez vide pour utiliser l'article
+  courant.
+- **Points forts / faibles** (`notation-jlg/pros-cons`) et **Tagline bilingue** (`notation-jlg/tagline`) : affichent
+  automatiquement les métadonnées du test.
+- **Fiche technique** (`notation-jlg/game-info`) : choisissez les champs à afficher, personnalisez le titre et ciblez un
+  autre article via le sélecteur de contenu.
+- **Notation utilisateurs** (`notation-jlg/user-rating`) : insère le module de vote interactif.
+- **Tableau récapitulatif** (`notation-jlg/summary-display`) : contrôlez le nombre d'éléments, la disposition (table ou
+  grille), les colonnes et les filtres par défaut.
+- **Bloc tout-en-un** (`notation-jlg/all-in-one`) : activez ou non chaque sous-section, choisissez le style et la couleur
+  d'accent pour un rendu cohérent.
+- **Game Explorer** (`notation-jlg/game-explorer`) : définissez le tri initial, les filtres disponibles et les paramètres de
+  préfiltrage (catégorie, plateforme, lettre).
+
+Chaque bloc repose sur le rendu PHP historique (shortcodes) et marque automatiquement l'exécution via
+`JLG_Frontend::mark_shortcode_rendered()` afin que les assets nécessaires soient chargés, y compris dans l'éditeur.
+
 ## Installation
 
 1. Téléchargez le plugin et décompressez l'archive

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -66,6 +66,27 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
   affichez une page ou une archive : les assets `jlg-frontend` et `jlg-user-rating` sont chargés automatiquement dès le
   rendu du widget, assurant la même mise en forme que dans un article.
 
+== Blocs Gutenberg ==
+
+Le plugin expose huit blocs dynamiques prêts à l'emploi :
+
+* **Bloc de notation** (`notation-jlg/rating-block`) — choisissez l'article ciblé ou laissez le champ vide pour utiliser le
+  contenu courant.
+* **Points forts / faibles** (`notation-jlg/pros-cons`) et **Tagline bilingue** (`notation-jlg/tagline`) — affichent
+  automatiquement les métadonnées saisies dans la fiche test.
+* **Fiche technique** (`notation-jlg/game-info`) — sélection des champs via cases à cocher, titre personnalisable et
+  ciblage d'un autre test.
+* **Notation utilisateurs** (`notation-jlg/user-rating`) — intègre le module de vote AJAX pour les lecteurs.
+* **Tableau récapitulatif** (`notation-jlg/summary-display`) — réglage du nombre d'entrées, du layout (table ou grille), des
+  colonnes visibles et des filtres par défaut.
+* **Bloc tout-en-un** (`notation-jlg/all-in-one`) — activez/désactivez chaque sous-bloc, modifiez le style et la couleur
+  d'accent ainsi que les titres.
+* **Game Explorer** (`notation-jlg/game-explorer`) — configurez le tri initial, les filtres proposés et les paramètres de
+  préfiltrage (catégorie, plateforme, lettre).
+
+Chaque bloc délègue le rendu à la logique PHP historique (shortcodes) tout en appelant `JLG_Frontend::mark_shortcode_rendered()`
+afin de charger automatiquement les scripts et feuilles de style requis dans l'éditeur.
+
 == Installation ==
 
 1. Téléchargez le plugin et décompressez l'archive

--- a/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/all-in-one",
+  "title": "Bloc tout-en-un",
+  "category": "widgets",
+  "icon": "feedback",
+  "description": "Combine notation, points forts/faibles et tagline dans un seul bloc.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "align": ["wide", "full"],
+    "html": false
+  },
+  "attributes": {
+    "postId": {
+      "type": "integer",
+      "default": 0
+    },
+    "showRating": {
+      "type": "boolean",
+      "default": true
+    },
+    "showProsCons": {
+      "type": "boolean",
+      "default": true
+    },
+    "showTagline": {
+      "type": "boolean",
+      "default": true
+    },
+    "style": {
+      "type": "string",
+      "default": "moderne"
+    },
+    "accentColor": {
+      "type": "string",
+      "default": ""
+    },
+    "prosTitle": {
+      "type": "string",
+      "default": "Points Forts"
+    },
+    "consTitle": {
+      "type": "string",
+      "default": "Points Faibles"
+    }
+  },
+  "editorScript": "notation-jlg-all-in-one-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/game-explorer/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/game-explorer/block.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/game-explorer",
+  "title": "Game Explorer",
+  "category": "widgets",
+  "icon": "grid-view",
+  "description": "Affiche le Game Explorer interactif avec filtres.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "align": ["wide", "full"],
+    "html": false
+  },
+  "attributes": {
+    "postsPerPage": {
+      "type": "integer",
+      "default": 12
+    },
+    "columns": {
+      "type": "integer",
+      "default": 3
+    },
+    "filters": {
+      "type": "array",
+      "default": ["letter", "category", "platform", "availability"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "category": {
+      "type": "string",
+      "default": ""
+    },
+    "platform": {
+      "type": "string",
+      "default": ""
+    },
+    "letter": {
+      "type": "string",
+      "default": ""
+    },
+    "sort": {
+      "type": "string",
+      "default": "date|DESC"
+    }
+  },
+  "editorScript": "notation-jlg-game-explorer-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/game-info/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/game-info/block.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/game-info",
+  "title": "Fiche technique",
+  "category": "widgets",
+  "icon": "portfolio",
+  "description": "Affiche la fiche technique personnalisable d'un test.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "postId": {
+      "type": "integer",
+      "default": 0
+    },
+    "title": {
+      "type": "string",
+      "default": "Fiche Technique"
+    },
+    "fields": {
+      "type": "array",
+      "default": [
+        "developpeur",
+        "editeur",
+        "date_sortie",
+        "version",
+        "pegi",
+        "temps_de_jeu",
+        "plateformes"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "editorScript": "notation-jlg-game-info-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/pros-cons/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/pros-cons/block.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/pros-cons",
+  "title": "Points forts / faibles",
+  "category": "widgets",
+  "icon": "list-view",
+  "description": "Affiche les points forts et points faibles du test courant.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "html": false
+  },
+  "attributes": {},
+  "editorScript": "notation-jlg-pros-cons-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/rating-block",
+  "title": "Bloc de notation",
+  "category": "widgets",
+  "icon": "star-filled",
+  "description": "Affiche le bloc de notation principal d'un test JLG.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "align": ["wide", "full"],
+    "html": false
+  },
+  "attributes": {
+    "postId": {
+      "type": "integer",
+      "default": 0
+    }
+  },
+  "editorScript": "notation-jlg-rating-block-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/summary-display/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/summary-display/block.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/summary-display",
+  "title": "Tableau récapitulatif",
+  "category": "widgets",
+  "icon": "table-col-after",
+  "description": "Affiche le tableau ou la grille récapitulant vos tests notés.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "align": ["wide", "full"],
+    "html": false
+  },
+  "attributes": {
+    "postsPerPage": {
+      "type": "integer",
+      "default": 12
+    },
+    "layout": {
+      "type": "string",
+      "default": "table"
+    },
+    "columns": {
+      "type": "array",
+      "default": ["titre", "date", "note"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "category": {
+      "type": "string",
+      "default": ""
+    },
+    "letterFilter": {
+      "type": "string",
+      "default": ""
+    },
+    "genreFilter": {
+      "type": "string",
+      "default": ""
+    }
+  },
+  "editorScript": "notation-jlg-summary-display-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/tagline/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/tagline/block.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/tagline",
+  "title": "Tagline bilingue",
+  "category": "widgets",
+  "icon": "format-status",
+  "description": "Affiche la tagline bilingue associée au test en cours.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "html": false
+  },
+  "attributes": {},
+  "editorScript": "notation-jlg-tagline-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/blocks/user-rating/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/user-rating/block.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/user-rating",
+  "title": "Notation utilisateurs",
+  "category": "widgets",
+  "icon": "thumbs-up",
+  "description": "Affiche le module de notation des lecteurs.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "html": false
+  },
+  "attributes": {},
+  "editorScript": "notation-jlg-user-rating-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/css/blocks-editor.css
+++ b/plugin-notation-jeux_V4/assets/css/blocks-editor.css
@@ -1,0 +1,14 @@
+.notation-jlg-post-picker .components-base-control + .components-base-control {
+    margin-top: 12px;
+}
+
+.notation-jlg-block-preview {
+    min-height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.notation-jlg-block-preview .components-placeholder {
+    width: 100%;
+}

--- a/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
@@ -1,0 +1,163 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var ToggleControl = wp.components.ToggleControl;
+    var SelectControl = wp.components.SelectControl;
+    var TextControl = wp.components.TextControl;
+    var ColorPalette = (blockEditor && blockEditor.ColorPalette) || wp.components.ColorPalette;
+    var PanelColorSettings = blockEditor.PanelColorSettings || blockEditor.__experimentalPanelColorSettings;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var PostPicker = blocksHelpers.PostPicker;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    registerBlockType('notation-jlg/all-in-one', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-all-in-one-block' });
+
+            var colorControl = PanelColorSettings
+                ? createElement(PanelColorSettings, {
+                      title: __('Couleurs', 'notation-jlg'),
+                      colorSettings: [
+                          {
+                              value: attributes.accentColor || '',
+                              onChange: function (value) {
+                                  setAttributes({ accentColor: value || '' });
+                              },
+                              label: __('Couleur d\'accent', 'notation-jlg'),
+                          },
+                      ],
+                  })
+                : createElement(
+                      PanelBody,
+                      { title: __('Couleur d\'accent', 'notation-jlg'), initialOpen: false },
+                      ColorPalette
+                          ? createElement(ColorPalette, {
+                                value: attributes.accentColor || '',
+                                onChange: function (value) {
+                                    setAttributes({ accentColor: value || '' });
+                                },
+                            })
+                          : null
+                  );
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Source et affichage', 'notation-jlg'), initialOpen: true },
+                        createElement(PostPicker, {
+                            value: attributes.postId || 0,
+                            onChange: function (value) {
+                                setAttributes({ postId: value || 0 });
+                            },
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Style visuel', 'notation-jlg'),
+                            value: attributes.style || 'moderne',
+                            options: [
+                                { value: 'moderne', label: __('Moderne', 'notation-jlg') },
+                                { value: 'classique', label: __('Classique', 'notation-jlg') },
+                                { value: 'compact', label: __('Compact', 'notation-jlg') },
+                            ],
+                            onChange: function (value) {
+                                setAttributes({ style: value || 'moderne' });
+                            },
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher la notation', 'notation-jlg'),
+                            checked: typeof attributes.showRating === 'boolean' ? attributes.showRating : true,
+                            onChange: function (value) {
+                                setAttributes({ showRating: !!value });
+                            },
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher les points forts/faibles', 'notation-jlg'),
+                            checked: typeof attributes.showProsCons === 'boolean' ? attributes.showProsCons : true,
+                            onChange: function (value) {
+                                setAttributes({ showProsCons: !!value });
+                            },
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher la tagline', 'notation-jlg'),
+                            checked: typeof attributes.showTagline === 'boolean' ? attributes.showTagline : true,
+                            onChange: function (value) {
+                                setAttributes({ showTagline: !!value });
+                            },
+                        })
+                    ),
+                    colorControl,
+                    createElement(
+                        PanelBody,
+                        { title: __('Titres personnalisés', 'notation-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('Titre Points forts', 'notation-jlg'),
+                            value: attributes.prosTitle || '',
+                            onChange: function (value) {
+                                setAttributes({ prosTitle: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Titre Points faibles', 'notation-jlg'),
+                            value: attributes.consTitle || '',
+                            onChange: function (value) {
+                                setAttributes({ consTitle: value || '' });
+                            },
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/all-in-one',
+                        attributes: {
+                            postId: attributes.postId || 0,
+                            showRating: typeof attributes.showRating === 'boolean' ? attributes.showRating : true,
+                            showProsCons: typeof attributes.showProsCons === 'boolean' ? attributes.showProsCons : true,
+                            showTagline: typeof attributes.showTagline === 'boolean' ? attributes.showTagline : true,
+                            style: attributes.style || 'moderne',
+                            accentColor: attributes.accentColor || '',
+                            prosTitle: attributes.prosTitle || '',
+                            consTitle: attributes.consTitle || '',
+                        },
+                        label: __('Bloc tout-en-un', 'notation-jlg'),
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/game-explorer.js
@@ -1,0 +1,185 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var RangeControl = wp.components.RangeControl;
+    var SelectControl = wp.components.SelectControl;
+    var CheckboxControl = wp.components.CheckboxControl;
+    var TextControl = wp.components.TextControl;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    var filterOptions = [
+        { value: 'letter', label: __('Filtre lettre', 'notation-jlg') },
+        { value: 'category', label: __('Filtre catégorie', 'notation-jlg') },
+        { value: 'platform', label: __('Filtre plateforme', 'notation-jlg') },
+        { value: 'availability', label: __('Disponibilité', 'notation-jlg') },
+    ];
+
+    var sortOptions = [
+        { value: 'date|DESC', label: __('Plus récents', 'notation-jlg') },
+        { value: 'date|ASC', label: __('Plus anciens', 'notation-jlg') },
+        { value: 'score|DESC', label: __('Meilleures notes', 'notation-jlg') },
+        { value: 'score|ASC', label: __('Notes les plus basses', 'notation-jlg') },
+        { value: 'title|ASC', label: __('Titre (A-Z)', 'notation-jlg') },
+        { value: 'title|DESC', label: __('Titre (Z-A)', 'notation-jlg') },
+    ];
+
+    registerBlockType('notation-jlg/game-explorer', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var filters = Array.isArray(attributes.filters) ? attributes.filters.slice() : ['letter', 'category', 'platform', 'availability'];
+            var blockProps = useBlockProps({ className: 'notation-jlg-game-explorer-block' });
+
+            var toggleFilter = function (value, isChecked) {
+                var current = Array.isArray(attributes.filters) ? attributes.filters.slice() : filters.slice();
+                var next;
+
+                if (isChecked) {
+                    if (current.indexOf(value) === -1) {
+                        current.push(value);
+                    }
+                    next = current;
+                } else {
+                    next = current.filter(function (item) {
+                        return item !== value;
+                    });
+                }
+
+                setAttributes({ filters: next });
+            };
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Configuration du listing', 'notation-jlg'), initialOpen: true },
+                        createElement(RangeControl, {
+                            label: __('Nombre d\'éléments par page', 'notation-jlg'),
+                            value: attributes.postsPerPage || 12,
+                            min: 1,
+                            max: 50,
+                            onChange: function (value) {
+                                var parsed = parseInt(value, 10);
+                                if (isNaN(parsed) || parsed < 1) {
+                                    parsed = 12;
+                                }
+                                setAttributes({ postsPerPage: parsed });
+                            },
+                        }),
+                        createElement(RangeControl, {
+                            label: __('Colonnes', 'notation-jlg'),
+                            value: attributes.columns || 3,
+                            min: 1,
+                            max: 4,
+                            onChange: function (value) {
+                                var parsed = parseInt(value, 10);
+                                if (isNaN(parsed) || parsed < 1) {
+                                    parsed = 3;
+                                }
+                                setAttributes({ columns: parsed });
+                            },
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Tri par défaut', 'notation-jlg'),
+                            value: attributes.sort || 'date|DESC',
+                            options: sortOptions,
+                            onChange: function (value) {
+                                setAttributes({ sort: value || 'date|DESC' });
+                            },
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Filtres disponibles', 'notation-jlg'), initialOpen: false },
+                        filterOptions.map(function (option) {
+                            var checked = filters.indexOf(option.value) !== -1;
+                            return createElement(CheckboxControl, {
+                                key: option.value,
+                                label: option.label,
+                                checked: checked,
+                                onChange: function (isChecked) {
+                                    toggleFilter(option.value, isChecked);
+                                },
+                            });
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Pré-filtrage', 'notation-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('Catégorie (slug)', 'notation-jlg'),
+                            value: attributes.category || '',
+                            onChange: function (value) {
+                                setAttributes({ category: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Plateforme (slug)', 'notation-jlg'),
+                            value: attributes.platform || '',
+                            onChange: function (value) {
+                                setAttributes({ platform: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Lettre', 'notation-jlg'),
+                            value: attributes.letter || '',
+                            onChange: function (value) {
+                                setAttributes({ letter: value || '' });
+                            },
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/game-explorer',
+                        attributes: {
+                            postsPerPage: attributes.postsPerPage || 12,
+                            columns: attributes.columns || 3,
+                            filters: attributes.filters || filters,
+                            category: attributes.category || '',
+                            platform: attributes.platform || '',
+                            letter: attributes.letter || '',
+                            sort: attributes.sort || 'date|DESC',
+                        },
+                        label: __('Game Explorer', 'notation-jlg'),
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/game-info.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/game-info.js
@@ -1,0 +1,145 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var TextControl = wp.components.TextControl;
+    var CheckboxControl = wp.components.CheckboxControl;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var PostPicker = blocksHelpers.PostPicker;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    var fieldOptions = [
+        { value: 'developpeur', label: __('Développeur', 'notation-jlg') },
+        { value: 'editeur', label: __('Éditeur', 'notation-jlg') },
+        { value: 'date_sortie', label: __('Date de sortie', 'notation-jlg') },
+        { value: 'version', label: __('Version', 'notation-jlg') },
+        { value: 'pegi', label: __('PEGI', 'notation-jlg') },
+        { value: 'temps_de_jeu', label: __('Temps de jeu', 'notation-jlg') },
+        { value: 'plateformes', label: __('Plateformes', 'notation-jlg') },
+    ];
+
+    registerBlockType('notation-jlg/game-info', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var fields = Array.isArray(attributes.fields) ? attributes.fields.slice() : [];
+            if (!fields.length) {
+                fields = fieldOptions.map(function (option) {
+                    return option.value;
+                });
+            }
+
+            var blockProps = useBlockProps({ className: 'notation-jlg-game-info-block' });
+
+            var toggleField = function (value, isChecked) {
+                var current = Array.isArray(attributes.fields) ? attributes.fields.slice() : fieldOptions.map(function (option) {
+                    return option.value;
+                });
+                var next;
+
+                if (isChecked) {
+                    if (current.indexOf(value) === -1) {
+                        current.push(value);
+                    }
+                    next = current;
+                } else {
+                    next = current.filter(function (item) {
+                        return item !== value;
+                    });
+
+                    if (!next.length) {
+                        return;
+                    }
+                }
+
+                setAttributes({ fields: next });
+            };
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Source des données', 'notation-jlg'), initialOpen: true },
+                        createElement(PostPicker, {
+                            value: attributes.postId || 0,
+                            onChange: function (value) {
+                                setAttributes({ postId: value || 0 });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Titre personnalisé', 'notation-jlg'),
+                            value: attributes.title || '',
+                            onChange: function (value) {
+                                setAttributes({ title: value || '' });
+                            },
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Champs affichés', 'notation-jlg'), initialOpen: false },
+                        fieldOptions.map(function (option) {
+                            var checked = fields.indexOf(option.value) !== -1;
+                            return createElement(CheckboxControl, {
+                                key: option.value,
+                                label: option.label,
+                                checked: checked,
+                                onChange: function (isChecked) {
+                                    toggleField(option.value, isChecked);
+                                },
+                            });
+                        }),
+                        createElement(
+                            'p',
+                            { className: 'description' },
+                            __('Décochez les éléments que vous ne souhaitez pas afficher.', 'notation-jlg')
+                        )
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/game-info',
+                        attributes: {
+                            postId: attributes.postId || 0,
+                            title: attributes.title || '',
+                            fields: attributes.fields || fields,
+                        },
+                        label: __('Fiche technique', 'notation-jlg'),
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/pros-cons.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/pros-cons.js
@@ -1,0 +1,46 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var createElement = wp.element.createElement;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    registerBlockType('notation-jlg/pros-cons', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-pros-cons-block' });
+
+            return createElement(
+                'div',
+                blockProps,
+                createElement(BlockPreview, {
+                    block: 'notation-jlg/pros-cons',
+                    attributes: attributes,
+                    label: __('Points forts / faibles', 'notation-jlg'),
+                })
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
@@ -1,0 +1,71 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var PanelBody = wp.components.PanelBody;
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var PostPicker = blocksHelpers.PostPicker;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    registerBlockType('notation-jlg/rating-block', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-rating-block-editor' });
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Source des données', 'notation-jlg'), initialOpen: true },
+                        createElement(PostPicker, {
+                            value: attributes.postId || 0,
+                            onChange: function (value) {
+                                setAttributes({ postId: value || 0 });
+                            },
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/rating-block',
+                        attributes: attributes,
+                        label: __('Bloc de notation', 'notation-jlg'),
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/shared.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/shared.js
@@ -1,0 +1,174 @@
+(function (wp) {
+    if (!wp || !wp.element || !wp.components || !wp.data || !wp.i18n) {
+        return;
+    }
+
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var useState = wp.element.useState;
+    var useMemo = wp.element.useMemo;
+    var useSelect = wp.data.useSelect;
+    var __ = wp.i18n.__;
+    var ComboboxControl = wp.components.ComboboxControl;
+    var SelectControl = wp.components.SelectControl;
+    var Placeholder = wp.components.Placeholder;
+    var Spinner = wp.components.Spinner;
+    var ServerSideRender = wp.serverSideRender;
+    var decodeEntities = wp.htmlEntities && wp.htmlEntities.decodeEntities ? wp.htmlEntities.decodeEntities : function (value) {
+        return value;
+    };
+
+    var settings = window.jlgBlockEditorSettings || {};
+    var allowedTypes = Array.isArray(settings.allowedPostTypes) ? settings.allowedPostTypes : [];
+    if (!allowedTypes.length) {
+        allowedTypes = [
+            {
+                slug: 'post',
+                label: __('Articles', 'notation-jlg'),
+            },
+        ];
+    }
+
+    var defaultPostType = allowedTypes[0] ? allowedTypes[0].slug : 'post';
+    var defaultPerPage = settings.postsQueryPerPage || 20;
+
+    var PostPicker = function PostPicker(props) {
+        var value = props.value || 0;
+        var onChange = typeof props.onChange === 'function' ? props.onChange : function () {};
+        var label = props.label || __('Article cible', 'notation-jlg');
+        var hasMultipleTypes = allowedTypes.length > 1;
+        var _useState = useState(defaultPostType);
+        var postType = _useState[0];
+        var setPostType = _useState[1];
+        var _useState2 = useState('');
+        var search = _useState2[0];
+        var setSearch = _useState2[1];
+
+        var queryArgs = useMemo(function () {
+            return {
+                per_page: defaultPerPage,
+                orderby: 'date',
+                order: 'desc',
+                status: 'publish',
+                search: search,
+            };
+        }, [search]);
+
+        var data = useSelect(
+            function (select) {
+                var core = select('core');
+                var records = core && core.getEntityRecords ? core.getEntityRecords('postType', postType, queryArgs) : [];
+                var isResolving = false;
+
+                if (select('core/data') && select('core/data').isResolving) {
+                    isResolving = select('core/data').isResolving('core', 'getEntityRecords', ['postType', postType, queryArgs]);
+                }
+
+                return {
+                    records: records,
+                    isResolving: isResolving,
+                };
+            },
+            [postType, queryArgs]
+        );
+
+        var records = data.records || [];
+        var isResolving = data.isResolving && (!records || !records.length);
+
+        var options = useMemo(
+            function () {
+                if (!records || !records.length) {
+                    return [];
+                }
+
+                return records.map(function (post) {
+                    var labelText = post && post.title && post.title.rendered ? post.title.rendered : '';
+                    if (!labelText && post && post.slug) {
+                        labelText = post.slug;
+                    }
+                    if (!labelText && post && post.id) {
+                        labelText = '#' + post.id;
+                    }
+                    return {
+                        value: String(post.id),
+                        label: decodeEntities(labelText),
+                    };
+                });
+            },
+            [records]
+        );
+
+        var helpText = '';
+        if (isResolving) {
+            helpText = __('Chargement…', 'notation-jlg');
+        } else if (!options.length) {
+            helpText = __('Aucun élément trouvé.', 'notation-jlg');
+        }
+
+        return createElement(
+            'div',
+            { className: 'notation-jlg-post-picker' },
+            hasMultipleTypes &&
+                createElement(SelectControl, {
+                    label: __('Type de contenu', 'notation-jlg'),
+                    value: postType,
+                    options: allowedTypes.map(function (type) {
+                        return {
+                            value: type.slug,
+                            label: type.label,
+                        };
+                    }),
+                    onChange: function (nextType) {
+                        setPostType(nextType);
+                    },
+                }),
+            createElement(
+                Fragment,
+                null,
+                createElement(ComboboxControl, {
+                    label: label,
+                    value: value ? String(value) : '',
+                    options: options,
+                    onFilterValueChange: function (nextSearch) {
+                        setSearch(nextSearch || '');
+                    },
+                    onChange: function (newValue) {
+                        var parsed = parseInt(newValue, 10);
+                        if (!newValue || isNaN(parsed)) {
+                            onChange(0);
+                            return;
+                        }
+                        onChange(parsed);
+                    },
+                    allowReset: true,
+                    help: helpText,
+                }),
+                isResolving && createElement(Spinner, null)
+            )
+        );
+    };
+
+    var BlockPreview = function BlockPreview(props) {
+        var blockName = props.block;
+        var attributes = props.attributes || {};
+        var label = props.label || __('Prévisualisation du bloc', 'notation-jlg');
+
+        if (!ServerSideRender) {
+            return createElement(
+                Placeholder,
+                { label: label },
+                __('La prévisualisation n\'est pas disponible dans cet environnement.', 'notation-jlg')
+            );
+        }
+
+        return createElement(
+            'div',
+            { className: 'notation-jlg-block-preview' },
+            createElement(ServerSideRender, { block: blockName, attributes: attributes })
+        );
+    };
+
+    window.jlgBlocks = window.jlgBlocks || {};
+    window.jlgBlocks.PostPicker = PostPicker;
+    window.jlgBlocks.BlockPreview = BlockPreview;
+})(window.wp);

--- a/plugin-notation-jeux_V4/assets/js/blocks/summary-display.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/summary-display.js
@@ -1,0 +1,172 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var RangeControl = wp.components.RangeControl;
+    var SelectControl = wp.components.SelectControl;
+    var CheckboxControl = wp.components.CheckboxControl;
+    var TextControl = wp.components.TextControl;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    var columnOptions = [
+        { value: 'titre', label: __('Titre du jeu', 'notation-jlg') },
+        { value: 'date', label: __('Date', 'notation-jlg') },
+        { value: 'note', label: __('Note moyenne', 'notation-jlg') },
+        { value: 'developpeur', label: __('Développeur', 'notation-jlg') },
+        { value: 'editeur', label: __('Éditeur', 'notation-jlg') },
+    ];
+
+    registerBlockType('notation-jlg/summary-display', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var columns = Array.isArray(attributes.columns) && attributes.columns.length
+                ? attributes.columns
+                : ['titre', 'date', 'note'];
+            var blockProps = useBlockProps({ className: 'notation-jlg-summary-display-block' });
+
+            var toggleColumn = function (value, isChecked) {
+                var current = Array.isArray(attributes.columns) ? attributes.columns.slice() : columns.slice();
+                var next;
+
+                if (isChecked) {
+                    if (current.indexOf(value) === -1) {
+                        current.push(value);
+                    }
+                    next = current;
+                } else {
+                    next = current.filter(function (item) {
+                        return item !== value;
+                    });
+                    if (!next.length) {
+                        return;
+                    }
+                }
+
+                setAttributes({ columns: next });
+            };
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Pagination et mise en page', 'notation-jlg'), initialOpen: true },
+                        createElement(RangeControl, {
+                            label: __('Nombre d\'éléments par page', 'notation-jlg'),
+                            value: attributes.postsPerPage || 12,
+                            min: 1,
+                            max: 50,
+                            onChange: function (value) {
+                                var parsed = parseInt(value, 10);
+                                if (isNaN(parsed) || parsed < 1) {
+                                    parsed = 12;
+                                }
+                                setAttributes({ postsPerPage: parsed });
+                            },
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Disposition', 'notation-jlg'),
+                            value: attributes.layout || 'table',
+                            options: [
+                                { value: 'table', label: __('Tableau', 'notation-jlg') },
+                                { value: 'grid', label: __('Grille', 'notation-jlg') },
+                            ],
+                            onChange: function (value) {
+                                setAttributes({ layout: value });
+                            },
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Colonnes affichées', 'notation-jlg'), initialOpen: false },
+                        columnOptions.map(function (option) {
+                            var checked = columns.indexOf(option.value) !== -1;
+                            return createElement(CheckboxControl, {
+                                key: option.value,
+                                label: option.label,
+                                checked: checked,
+                                onChange: function (isChecked) {
+                                    toggleColumn(option.value, isChecked);
+                                },
+                            });
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Filtres initiaux', 'notation-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('Catégorie (slug)', 'notation-jlg'),
+                            value: attributes.category || '',
+                            onChange: function (value) {
+                                setAttributes({ category: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Filtre lettre', 'notation-jlg'),
+                            value: attributes.letterFilter || '',
+                            onChange: function (value) {
+                                setAttributes({ letterFilter: value || '' });
+                            },
+                            help: __('Utilisez une lettre ou le symbole # pour regrouper chiffres et symboles.', 'notation-jlg'),
+                        }),
+                        createElement(TextControl, {
+                            label: __('Filtre genre', 'notation-jlg'),
+                            value: attributes.genreFilter || '',
+                            onChange: function (value) {
+                                setAttributes({ genreFilter: value || '' });
+                            },
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/summary-display',
+                        attributes: {
+                            postsPerPage: attributes.postsPerPage || 12,
+                            layout: attributes.layout || 'table',
+                            columns: attributes.columns || columns,
+                            category: attributes.category || '',
+                            letterFilter: attributes.letterFilter || '',
+                            genreFilter: attributes.genreFilter || '',
+                        },
+                        label: __('Tableau récapitulatif', 'notation-jlg'),
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/tagline.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/tagline.js
@@ -1,0 +1,46 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var createElement = wp.element.createElement;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    registerBlockType('notation-jlg/tagline', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-tagline-block' });
+
+            return createElement(
+                'div',
+                blockProps,
+                createElement(BlockPreview, {
+                    block: 'notation-jlg/tagline',
+                    attributes: attributes,
+                    label: __('Tagline bilingue', 'notation-jlg'),
+                })
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/assets/js/blocks/user-rating.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/user-rating.js
@@ -1,0 +1,46 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var createElement = wp.element.createElement;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    registerBlockType('notation-jlg/user-rating', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-user-rating-block' });
+
+            return createElement(
+                'div',
+                blockProps,
+                createElement(BlockPreview, {
+                    block: 'notation-jlg/user-rating',
+                    attributes: attributes,
+                    label: __('Notation utilisateurs', 'notation-jlg'),
+                })
+            );
+        },
+        save: function () {
+            return null;
+        },
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/includes/class-jlg-blocks.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-blocks.php
@@ -1,0 +1,491 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class JLG_Blocks {
+    /**
+     * Handle used for the shared utilities script.
+     *
+     * @var string
+     */
+    private $shared_script_handle = 'notation-jlg-blocks-shared';
+
+    /**
+     * Handle used for the editor stylesheet shared by blocks.
+     *
+     * @var string
+     */
+    private $editor_style_handle = 'notation-jlg-block-editor';
+
+    /**
+     * Path to the languages directory.
+     *
+     * @var string
+     */
+    private $languages_path;
+
+    /**
+     * List of dynamic blocks managed by the plugin.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private $blocks = [
+        'rating-block' => [
+            'name'            => 'notation-jlg/rating-block',
+            'shortcode'       => 'bloc_notation_jeu',
+            'script'          => 'notation-jlg-rating-block-editor',
+            'callback'        => 'render_rating_block',
+        ],
+        'pros-cons' => [
+            'name'            => 'notation-jlg/pros-cons',
+            'shortcode'       => 'jlg_points_forts_faibles',
+            'script'          => 'notation-jlg-pros-cons-editor',
+            'callback'        => 'render_pros_cons_block',
+        ],
+        'tagline' => [
+            'name'            => 'notation-jlg/tagline',
+            'shortcode'       => 'tagline_notation_jlg',
+            'script'          => 'notation-jlg-tagline-editor',
+            'callback'        => 'render_tagline_block',
+        ],
+        'game-info' => [
+            'name'            => 'notation-jlg/game-info',
+            'shortcode'       => 'jlg_fiche_technique',
+            'script'          => 'notation-jlg-game-info-editor',
+            'callback'        => 'render_game_info_block',
+        ],
+        'user-rating' => [
+            'name'            => 'notation-jlg/user-rating',
+            'shortcode'       => 'notation_utilisateurs_jlg',
+            'script'          => 'notation-jlg-user-rating-editor',
+            'callback'        => 'render_user_rating_block',
+        ],
+        'summary-display' => [
+            'name'            => 'notation-jlg/summary-display',
+            'shortcode'       => 'jlg_tableau_recap',
+            'script'          => 'notation-jlg-summary-display-editor',
+            'callback'        => 'render_summary_display_block',
+        ],
+        'all-in-one' => [
+            'name'            => 'notation-jlg/all-in-one',
+            'shortcode'       => 'jlg_bloc_complet',
+            'script'          => 'notation-jlg-all-in-one-editor',
+            'callback'        => 'render_all_in_one_block',
+        ],
+        'game-explorer' => [
+            'name'            => 'notation-jlg/game-explorer',
+            'shortcode'       => 'jlg_game_explorer',
+            'script'          => 'notation-jlg-game-explorer-editor',
+            'callback'        => 'render_game_explorer_block',
+        ],
+    ];
+
+    public function __construct() {
+        $this->languages_path = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'languages';
+
+        add_action('init', [$this, 'register_block_editor_assets']);
+        add_action('init', [$this, 'register_blocks']);
+    }
+
+    public function register_block_editor_assets() {
+        $scripts_dir = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/js/blocks/';
+        $scripts_url = trailingslashit(JLG_NOTATION_PLUGIN_URL) . 'assets/js/blocks/';
+        $style_path  = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/css/blocks-editor.css';
+        $style_url   = trailingslashit(JLG_NOTATION_PLUGIN_URL) . 'assets/css/blocks-editor.css';
+
+        if (file_exists($style_path)) {
+            wp_register_style(
+                $this->editor_style_handle,
+                $style_url,
+                ['wp-edit-blocks'],
+                $this->get_file_version($style_path)
+            );
+        }
+
+        $shared_script_path = $scripts_dir . 'shared.js';
+        if (file_exists($shared_script_path)) {
+            $shared_deps = [
+                'wp-blocks',
+                'wp-components',
+                'wp-element',
+                'wp-i18n',
+                'wp-block-editor',
+                'wp-data',
+                'wp-html-entities',
+                'wp-server-side-render',
+                'wp-compose',
+            ];
+
+            wp_register_script(
+                $this->shared_script_handle,
+                $scripts_url . 'shared.js',
+                $shared_deps,
+                $this->get_file_version($shared_script_path),
+                true
+            );
+
+            $settings = [
+                'allowedPostTypes' => $this->get_allowed_post_types_for_editor(),
+                'postsQueryPerPage' => 20,
+            ];
+
+            wp_localize_script($this->shared_script_handle, 'jlgBlockEditorSettings', $settings);
+            $this->set_script_translations($this->shared_script_handle);
+        }
+
+        foreach ($this->blocks as $slug => $config) {
+            $script_handle = isset($config['script']) ? $config['script'] : '';
+            $script_file   = $scripts_dir . $slug . '.js';
+
+            if ($script_handle === '' || !file_exists($script_file)) {
+                continue;
+            }
+
+            $deps = [$this->shared_script_handle];
+            wp_register_script(
+                $script_handle,
+                $scripts_url . $slug . '.js',
+                $deps,
+                $this->get_file_version($script_file),
+                true
+            );
+
+            $this->set_script_translations($script_handle);
+        }
+    }
+
+    public function register_blocks() {
+        if (!function_exists('register_block_type_from_metadata')) {
+            return;
+        }
+
+        foreach ($this->blocks as $slug => $config) {
+            $metadata_path = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/blocks/' . $slug;
+            $callback      = isset($config['callback']) ? $config['callback'] : '';
+
+            if (!is_dir($metadata_path) || !file_exists(trailingslashit($metadata_path) . 'block.json')) {
+                continue;
+            }
+
+            $args = [];
+            if ($callback !== '' && method_exists($this, $callback)) {
+                $args['render_callback'] = [$this, $callback];
+            }
+
+            register_block_type_from_metadata($metadata_path, $args);
+        }
+    }
+
+    private function get_allowed_post_types_for_editor() {
+        if (!class_exists('JLG_Helpers')) {
+            return [];
+        }
+
+        $types = JLG_Helpers::get_allowed_post_types();
+        if (!is_array($types)) {
+            $types = [];
+        }
+
+        $types = array_map('sanitize_key', array_filter($types));
+        $types = array_values(array_unique($types));
+        $result = [];
+
+        foreach ($types as $type) {
+            $object = get_post_type_object($type);
+            $label = $object && !empty($object->labels->singular_name)
+                ? $object->labels->singular_name
+                : ucwords(str_replace(['-', '_'], ' ', $type));
+
+            $result[] = [
+                'slug'  => $type,
+                'label' => $label,
+            ];
+        }
+
+        if (empty($result)) {
+            $result[] = [
+                'slug'  => 'post',
+                'label' => __('Articles', 'notation-jlg'),
+            ];
+        }
+
+        return $result;
+    }
+
+    private function set_script_translations($handle) {
+        if (!function_exists('wp_set_script_translations')) {
+            return;
+        }
+
+        if (!wp_script_is($handle, 'registered')) {
+            return;
+        }
+
+        if (!is_dir($this->languages_path)) {
+            return;
+        }
+
+        wp_set_script_translations($handle, 'notation-jlg', $this->languages_path);
+    }
+
+    private function get_file_version($path) {
+        $mtime = file_exists($path) ? filemtime($path) : false;
+
+        if ($mtime) {
+            return (string) $mtime;
+        }
+
+        return defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : '1.0.0';
+    }
+
+    private function render_shortcode($shortcode, array $atts = []) {
+        if (!shortcode_exists($shortcode)) {
+            return '';
+        }
+
+        if (class_exists('JLG_Frontend')) {
+            JLG_Frontend::mark_shortcode_rendered($shortcode);
+        }
+
+        $attributes_string = '';
+
+        foreach ($atts as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_bool($value)) {
+                $value = $value ? 'oui' : 'non';
+            } elseif (is_array($value)) {
+                $value = implode(',', array_filter(array_map('strval', $value)));
+            }
+
+            if ($value === '') {
+                continue;
+            }
+
+            $attributes_string .= sprintf(' %s="%s"', sanitize_key($key), esc_attr($value));
+        }
+
+        return do_shortcode(sprintf('[%s%s]', sanitize_key($shortcode), $attributes_string));
+    }
+
+    public function render_rating_block($attributes) {
+        $post_id = isset($attributes['postId']) ? absint($attributes['postId']) : 0;
+        $atts = [];
+
+        if ($post_id > 0) {
+            $atts['post_id'] = $post_id;
+        }
+
+        return $this->render_shortcode('bloc_notation_jeu', $atts);
+    }
+
+    public function render_pros_cons_block($attributes) {
+        unset($attributes);
+
+        return $this->render_shortcode('jlg_points_forts_faibles');
+    }
+
+    public function render_tagline_block($attributes) {
+        unset($attributes);
+
+        return $this->render_shortcode('tagline_notation_jlg');
+    }
+
+    public function render_game_info_block($attributes) {
+        $atts = [];
+
+        if (isset($attributes['postId'])) {
+            $post_id = absint($attributes['postId']);
+            if ($post_id > 0) {
+                $atts['post_id'] = $post_id;
+            }
+        }
+
+        if (!empty($attributes['fields']) && is_array($attributes['fields'])) {
+            $fields = array_map('sanitize_key', array_filter($attributes['fields']));
+            if (!empty($fields)) {
+                $atts['champs'] = implode(',', $fields);
+            }
+        }
+
+        if (!empty($attributes['title']) && is_string($attributes['title'])) {
+            $atts['titre'] = sanitize_text_field($attributes['title']);
+        }
+
+        return $this->render_shortcode('jlg_fiche_technique', $atts);
+    }
+
+    public function render_user_rating_block($attributes) {
+        unset($attributes);
+
+        return $this->render_shortcode('notation_utilisateurs_jlg');
+    }
+
+    public function render_summary_display_block($attributes) {
+        $atts = [];
+
+        if (isset($attributes['postsPerPage'])) {
+            $posts_per_page = max(1, absint($attributes['postsPerPage']));
+            $atts['posts_per_page'] = $posts_per_page;
+        }
+
+        if (!empty($attributes['layout']) && is_string($attributes['layout'])) {
+            $layout = sanitize_key($attributes['layout']);
+            if (in_array($layout, ['table', 'grid'], true)) {
+                $atts['layout'] = $layout;
+            }
+        }
+
+        if (!empty($attributes['columns']) && is_array($attributes['columns'])) {
+            $columns = array_map('sanitize_key', array_filter($attributes['columns']));
+            if (!empty($columns)) {
+                $atts['colonnes'] = implode(',', $columns);
+            }
+        }
+
+        if (!empty($attributes['category']) && is_string($attributes['category'])) {
+            $atts['categorie'] = sanitize_text_field($attributes['category']);
+        }
+
+        if (!empty($attributes['letterFilter']) && is_string($attributes['letterFilter'])) {
+            $atts['letter_filter'] = sanitize_text_field($attributes['letterFilter']);
+        }
+
+        if (!empty($attributes['genreFilter']) && is_string($attributes['genreFilter'])) {
+            $atts['genre_filter'] = sanitize_text_field($attributes['genreFilter']);
+        }
+
+        return $this->render_shortcode('jlg_tableau_recap', $atts);
+    }
+
+    public function render_all_in_one_block($attributes) {
+        $atts = [];
+
+        if (isset($attributes['postId'])) {
+            $post_id = absint($attributes['postId']);
+            if ($post_id > 0) {
+                $atts['post_id'] = $post_id;
+            }
+        }
+
+        $bool_attributes = [
+            'showRating' => 'afficher_notation',
+            'showProsCons' => 'afficher_points',
+            'showTagline' => 'afficher_tagline',
+        ];
+
+        foreach ($bool_attributes as $attr_key => $shortcode_key) {
+            if (isset($attributes[$attr_key])) {
+                $atts[$shortcode_key] = (bool) $attributes[$attr_key];
+            }
+        }
+
+        if (!empty($attributes['style']) && is_string($attributes['style'])) {
+            $style = sanitize_key($attributes['style']);
+            if (in_array($style, ['moderne', 'classique', 'compact'], true)) {
+                $atts['style'] = $style;
+            }
+        }
+
+        if (!empty($attributes['accentColor']) && is_string($attributes['accentColor'])) {
+            $color = sanitize_hex_color($attributes['accentColor']);
+            if (!empty($color)) {
+                $atts['couleur_accent'] = $color;
+            }
+        }
+
+        if (!empty($attributes['prosTitle']) && is_string($attributes['prosTitle'])) {
+            $atts['titre_points_forts'] = sanitize_text_field($attributes['prosTitle']);
+        }
+
+        if (!empty($attributes['consTitle']) && is_string($attributes['consTitle'])) {
+            $atts['titre_points_faibles'] = sanitize_text_field($attributes['consTitle']);
+        }
+
+        return $this->render_shortcode('jlg_bloc_complet', $atts);
+    }
+
+    public function render_game_explorer_block($attributes) {
+        $atts = [];
+
+        if (isset($attributes['postsPerPage'])) {
+            $posts_per_page = max(1, absint($attributes['postsPerPage']));
+            $atts['posts_per_page'] = $posts_per_page;
+        }
+
+        if (isset($attributes['columns'])) {
+            $columns = max(1, absint($attributes['columns']));
+            $atts['columns'] = $columns;
+        }
+
+        if (!empty($attributes['filters']) && is_array($attributes['filters'])) {
+            $filters = array_map('sanitize_key', array_filter($attributes['filters']));
+            if (!empty($filters)) {
+                $atts['filters'] = implode(',', $filters);
+            }
+        }
+
+        if (!empty($attributes['category']) && is_string($attributes['category'])) {
+            $atts['categorie'] = sanitize_text_field($attributes['category']);
+        }
+
+        if (!empty($attributes['platform']) && is_string($attributes['platform'])) {
+            $atts['plateforme'] = sanitize_text_field($attributes['platform']);
+        }
+
+        if (!empty($attributes['letter']) && is_string($attributes['letter'])) {
+            $atts['lettre'] = sanitize_text_field($attributes['letter']);
+        }
+
+        $sort_override = null;
+        if (!empty($attributes['sort']) && is_string($attributes['sort'])) {
+            $sort = sanitize_text_field($attributes['sort']);
+            $parts = explode('|', $sort);
+            $orderby = isset($parts[0]) ? sanitize_key($parts[0]) : '';
+            $order = isset($parts[1]) ? strtoupper(sanitize_key($parts[1])) : '';
+
+            if (in_array($orderby, ['date', 'score', 'title'], true)) {
+                if (!in_array($order, ['ASC', 'DESC'], true)) {
+                    $order = 'DESC';
+                }
+
+                $sort_override = [
+                    'orderby' => $orderby,
+                    'order'   => $order,
+                ];
+            }
+        }
+
+        $previous_orderby = null;
+        $previous_order = null;
+
+        if ($sort_override !== null) {
+            $previous_orderby = isset($_GET['orderby']) ? $_GET['orderby'] : null;
+            $previous_order = isset($_GET['order']) ? $_GET['order'] : null;
+
+            $_GET['orderby'] = $sort_override['orderby'];
+            $_GET['order'] = $sort_override['order'];
+        }
+
+        $output = $this->render_shortcode('jlg_game_explorer', $atts);
+
+        if ($sort_override !== null) {
+            if ($previous_orderby === null) {
+                unset($_GET['orderby']);
+            } else {
+                $_GET['orderby'] = $previous_orderby;
+            }
+
+            if ($previous_order === null) {
+                unset($_GET['order']);
+            } else {
+                $_GET['order'] = $previous_order;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -48,6 +48,7 @@ final class JLG_Plugin_De_Notation_Main {
     private $admin = null;
     private $assets = null;
     private $frontend = null;
+    private $blocks = null;
     private const MIGRATION_BATCH_SIZE = 50;
     private const MIGRATION_SCAN_BATCH_SIZE = 200;
 
@@ -99,6 +100,7 @@ final class JLG_Plugin_De_Notation_Main {
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-dynamic-css.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-frontend.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-widget.php';
+        require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-blocks.php';
         
         // Admin seulement si nécessaire
         if (is_admin()) {
@@ -144,6 +146,11 @@ final class JLG_Plugin_De_Notation_Main {
             add_action('widgets_init', function() {
                 register_widget('JLG_Latest_Reviews_Widget');
             });
+        }
+
+        // Blocks
+        if (class_exists('JLG_Blocks')) {
+            $this->blocks = new JLG_Blocks();
         }
 
         // Admin


### PR DESCRIPTION
## Summary
- add a dedicated blocks manager to register editor assets and dynamic renders for each existing shortcode
- define block metadata plus React editors for rating, pros/cons, tagline, game info, user rating, summary, all-in-one, and game explorer blocks
- document the new Gutenberg blocks in the plugin readmes

## Testing
- php -l plugin-notation-jeux_V4/includes/class-jlg-blocks.php
- php -l plugin-notation-jeux_V4/plugin-notation-jeux.php

------
https://chatgpt.com/codex/tasks/task_e_68dbffbfcee4832eb82f0007d2dfb3c4