### PR TITLE
Normalize sanitized internal URLs

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1340,6 +1340,9 @@ class JLG_Frontend {
         $path = $parsed_url['path'] ?? '';
         if ($path === '') {
             $path = '/';
+        } else {
+            $path = '/' . ltrim($path, '/');
+            $path = preg_replace('#/+#', '/', $path);
         }
 
         $normalized_url = '';

--- a/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendSummaryBaseUrlTest.php
@@ -133,4 +133,21 @@ class FrontendSummaryBaseUrlTest extends TestCase
             'Base URL should keep the custom port defined in the home URL.'
         );
     }
+
+    public function test_relative_paths_are_normalized_with_leading_slash()
+    {
+        $frontend = new JLG_Frontend();
+
+        $reflection = new ReflectionClass(JLG_Frontend::class);
+        $method = $reflection->getMethod('sanitize_internal_url');
+        $method->setAccessible(true);
+
+        $base_url = $method->invoke($frontend, 'games/');
+
+        $this->assertSame(
+            'https://public.example/games/',
+            $base_url,
+            'Relative paths should be normalized against the public home URL.'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- normalize sanitized frontend URLs to ensure a single leading slash and collapse duplicate separators
- cover relative-path normalization with an additional FrontendSummaryBaseUrlTest case

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc06ccd884832e905c27e0737d5340