### PR TITLE
Use RAWG API for admin search and cache results

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -51,68 +51,235 @@ class JLG_Admin_Ajax {
             ], 400);
         }
 
-        // Simulation de réponse (remplacez par vraie API si vous avez une clé)
-        $mock_games = [
-            [
-                'name' => $search_term . ' - Résultat simulé',
-                'release_date' => '2024-01-15',
-                'developers' => 'Studio Exemple',
-                'publishers' => 'Éditeur Exemple',
-                'platforms' => ['PC', 'PlayStation 5'],
-                'pegi' => 'PEGI 12',
-            ]
+        $page = isset($_POST['page']) ? max(1, absint(wp_unslash($_POST['page']))) : 1;
+
+        $options = JLG_Helpers::get_plugin_options();
+        $api_key = isset($options['rawg_api_key']) ? sanitize_text_field((string) $options['rawg_api_key']) : '';
+
+        if ($api_key === '') {
+            // Simulation de réponse si aucune clé n'est configurée.
+            $mock_games = [
+                [
+                    'name' => $search_term . ' - Résultat simulé',
+                    'release_date' => '2024-01-15',
+                    'developers' => 'Studio Exemple',
+                    'publishers' => 'Éditeur Exemple',
+                    'platforms' => ['PC', 'PlayStation 5'],
+                    'pegi' => 'PEGI 12',
+                ]
+            ];
+
+            $normalized_games = array_map([$this, 'normalize_game_fields'], $mock_games);
+
+            wp_send_json_success([
+                'games' => $normalized_games,
+                'message' => __('Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg'),
+            ]);
+        }
+
+        $cache_key = 'jlg_rawg_search_' . md5(wp_json_encode([$search_term, $page]));
+        $cached_payload = get_transient($cache_key);
+
+        if ($cached_payload !== false && is_array($cached_payload)) {
+            wp_send_json_success($cached_payload);
+        }
+
+        $endpoint = 'https://api.rawg.io/api/games';
+        $query_args = [
+            'search' => $search_term,
+            'page' => $page,
+            'page_size' => 20,
+            'key' => $api_key,
         ];
 
-        $normalized_games = array_map(function($game) {
-            $sanitize_scalar = static function($value) {
-                if (is_scalar($value)) {
-                    return sanitize_text_field((string) $value);
-                }
+        $request_args = apply_filters(
+            'jlg_rawg_http_request_args',
+            [
+                'timeout' => 10,
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+            ],
+            $search_term,
+            $page
+        );
 
-                return '';
-            };
+        $response = wp_remote_get(add_query_arg($query_args, $endpoint), $request_args);
 
-            $game['name'] = isset($game['name']) ? $sanitize_scalar($game['name']) : '';
+        if (function_exists('is_wp_error') && is_wp_error($response)) {
+            wp_send_json_error([
+                'message' => __('Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement.', 'notation-jlg'),
+            ], 502);
+        }
 
-            foreach (['developers', 'publishers'] as $field) {
-                if (!isset($game[$field])) {
-                    $game[$field] = '';
-                    continue;
-                }
+        $status_code = (int) wp_remote_retrieve_response_code($response);
 
-                if (is_array($game[$field])) {
-                    $game[$field] = array_values(array_filter(array_map($sanitize_scalar, $game[$field]), 'strlen'));
-                } else {
-                    $game[$field] = $sanitize_scalar($game[$field]);
-                }
-            }
+        if ($status_code < 200 || $status_code >= 300) {
+            wp_send_json_error([
+                'message' => sprintf(
+                    /* translators: %d: HTTP status code returned by RAWG.io */
+                    __('La requête RAWG.io a échoué avec le code HTTP %d.', 'notation-jlg'),
+                    $status_code
+                ),
+            ], $status_code ?: 500);
+        }
 
-            if (isset($game['platforms'])) {
-                if (is_array($game['platforms'])) {
-                    $game['platforms'] = array_values(array_filter(array_map($sanitize_scalar, $game['platforms']), 'strlen'));
-                } else {
-                    $game['platforms'] = $sanitize_scalar($game['platforms']);
-                }
-            } else {
-                $game['platforms'] = [];
-            }
+        $body = wp_remote_retrieve_body($response);
+        $decoded = json_decode($body, true);
 
-            if (!empty($game['release_date'])) {
-                $sanitized_date = JLG_Validator::sanitize_date($game['release_date']);
-                $game['release_date'] = $sanitized_date !== null ? $sanitized_date : '';
-            }
+        if (!is_array($decoded)) {
+            wp_send_json_error([
+                'message' => __('Réponse RAWG.io invalide : données JSON non valides.', 'notation-jlg'),
+            ], 502);
+        }
 
-            if (!empty($game['pegi'])) {
-                $sanitized_pegi = JLG_Validator::sanitize_pegi($game['pegi']);
-                $game['pegi'] = $sanitized_pegi !== null ? $sanitized_pegi : '';
-            }
+        $raw_results = [];
+        if (!empty($decoded['results']) && is_array($decoded['results'])) {
+            $raw_results = array_map([$this, 'transform_rawg_game'], $decoded['results']);
+        }
 
-            return $game;
-        }, $mock_games);
+        $normalized_games = array_map([$this, 'normalize_game_fields'], $raw_results);
 
-        wp_send_json_success([
+        $payload = [
             'games' => $normalized_games,
-            'message' => __('Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg'),
-        ]);
+            'pagination' => [
+                'current_page' => $page,
+                'next_page' => $this->extract_rawg_page($decoded['next'] ?? ''),
+                'prev_page' => $this->extract_rawg_page($decoded['previous'] ?? ''),
+                'total_results' => isset($decoded['count']) ? (int) $decoded['count'] : null,
+            ],
+            'message' => __('Résultats récupérés depuis RAWG.io.', 'notation-jlg'),
+        ];
+
+        set_transient($cache_key, $payload, 15 * MINUTE_IN_SECONDS);
+
+        wp_send_json_success($payload);
+    }
+
+    private function transform_rawg_game(array $raw_game) {
+        $developers = [];
+        if (!empty($raw_game['developers']) && is_array($raw_game['developers'])) {
+            foreach ($raw_game['developers'] as $developer) {
+                if (is_array($developer) && isset($developer['name'])) {
+                    $developers[] = $developer['name'];
+                } elseif (is_string($developer)) {
+                    $developers[] = $developer;
+                }
+            }
+        }
+
+        $publishers = [];
+        if (!empty($raw_game['publishers']) && is_array($raw_game['publishers'])) {
+            foreach ($raw_game['publishers'] as $publisher) {
+                if (is_array($publisher) && isset($publisher['name'])) {
+                    $publishers[] = $publisher['name'];
+                } elseif (is_string($publisher)) {
+                    $publishers[] = $publisher;
+                }
+            }
+        }
+
+        $platforms = [];
+        if (!empty($raw_game['platforms']) && is_array($raw_game['platforms'])) {
+            foreach ($raw_game['platforms'] as $platform) {
+                if (is_array($platform)) {
+                    if (isset($platform['platform']['name'])) {
+                        $platforms[] = $platform['platform']['name'];
+                    } elseif (isset($platform['name'])) {
+                        $platforms[] = $platform['name'];
+                    }
+                } elseif (is_string($platform)) {
+                    $platforms[] = $platform;
+                }
+            }
+        }
+
+        $pegi = '';
+        if (!empty($raw_game['age_rating']['name'])) {
+            $pegi = $raw_game['age_rating']['name'];
+        } elseif (!empty($raw_game['esrb_rating']['name'])) {
+            $pegi = $raw_game['esrb_rating']['name'];
+        }
+
+        return [
+            'name' => $raw_game['name'] ?? '',
+            'release_date' => $raw_game['released'] ?? '',
+            'developers' => $developers,
+            'publishers' => $publishers,
+            'platforms' => $platforms,
+            'pegi' => $pegi,
+        ];
+    }
+
+    private function normalize_game_fields(array $game) {
+        $defaults = [
+            'name' => '',
+            'release_date' => '',
+            'developers' => '',
+            'publishers' => '',
+            'platforms' => [],
+            'pegi' => '',
+        ];
+
+        $game = array_merge($defaults, $game);
+
+        $sanitize_scalar = static function($value) {
+            if (is_scalar($value)) {
+                return sanitize_text_field((string) $value);
+            }
+
+            return '';
+        };
+
+        $game['name'] = $sanitize_scalar($game['name']);
+
+        foreach (['developers', 'publishers'] as $field) {
+            if (is_array($game[$field])) {
+                $game[$field] = array_values(array_filter(array_map($sanitize_scalar, $game[$field]), 'strlen'));
+            } else {
+                $game[$field] = $sanitize_scalar($game[$field]);
+            }
+        }
+
+        if (is_array($game['platforms'])) {
+            $game['platforms'] = array_values(array_filter(array_map($sanitize_scalar, $game['platforms']), 'strlen'));
+        } else {
+            $game['platforms'] = $sanitize_scalar($game['platforms']);
+            $game['platforms'] = $game['platforms'] === '' ? [] : [$game['platforms']];
+        }
+
+        if ($game['release_date'] !== '') {
+            $sanitized_date = JLG_Validator::sanitize_date($game['release_date']);
+            $game['release_date'] = $sanitized_date !== null ? $sanitized_date : '';
+        }
+
+        if ($game['pegi'] !== '') {
+            $sanitized_pegi = JLG_Validator::sanitize_pegi($game['pegi']);
+            $game['pegi'] = $sanitized_pegi !== null ? $sanitized_pegi : '';
+        }
+
+        return $game;
+    }
+
+    private function extract_rawg_page($url) {
+        if (!is_string($url) || $url === '') {
+            return null;
+        }
+
+        $parts = wp_parse_url($url);
+
+        if (!is_array($parts) || empty($parts['query'])) {
+            return null;
+        }
+
+        parse_str($parts['query'], $query_args);
+
+        if (empty($query_args['page'])) {
+            return null;
+        }
+
+        $page = absint($query_args['page']);
+
+        return $page > 0 ? $page : null;
     }
 }

--- a/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
@@ -2,21 +2,152 @@
 
 use PHPUnit\Framework\TestCase;
 
+if (!function_exists('wp_remote_get')) {
+    function wp_remote_get($url, $args = []) {
+        $pre = apply_filters('pre_http_request', false, $args, $url);
+
+        if ($pre !== false) {
+            return $pre;
+        }
+
+        return [
+            'body' => '',
+            'response' => ['code' => 200],
+            'headers' => [],
+        ];
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    function wp_remote_retrieve_response_code($response) {
+        if (is_array($response) && isset($response['response']['code'])) {
+            return (int) $response['response']['code'];
+        }
+
+        return 0;
+    }
+}
+
+if (!function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($response) {
+        if (is_array($response) && isset($response['body'])) {
+            return (string) $response['body'];
+        }
+
+        return '';
+    }
+}
+
 class AdminAjaxSearchTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
         $_POST = [];
+        remove_all_filters('pre_http_request');
+        $GLOBALS['jlg_test_transients'] = [];
+        update_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
+        JLG_Helpers::flush_plugin_options_cache();
     }
 
     protected function tearDown(): void
     {
+        remove_all_filters('pre_http_request');
         $_POST = [];
+        $GLOBALS['jlg_test_transients'] = [];
+        JLG_Helpers::flush_plugin_options_cache();
         parent::tearDown();
     }
 
-    public function test_handle_rawg_search_accepts_special_characters(): void
+    public function test_handle_rawg_search_returns_normalized_results_from_api(): void
+    {
+        $_POST['search'] = 'Elden Ring';
+        $_POST['nonce'] = 'dummy-nonce';
+        $_POST['page'] = 2;
+
+        $settings = JLG_Helpers::get_default_settings();
+        $settings['rawg_api_key'] = 'demo-key';
+        update_option('notation_jlg_settings', $settings);
+        JLG_Helpers::flush_plugin_options_cache();
+
+        $captured_request = null;
+        add_filter(
+            'pre_http_request',
+            static function ($preempt, $args, $url) use (&$captured_request) {
+                $captured_request = [
+                    'args' => $args,
+                    'url' => $url,
+                ];
+
+                $payload = [
+                    'count' => 123,
+                    'next' => 'https://api.rawg.io/api/games?search=Elden+Ring&page=3',
+                    'previous' => 'https://api.rawg.io/api/games?search=Elden+Ring&page=1',
+                    'results' => [
+                        [
+                            'name' => 'Elden Ring',
+                            'released' => '2022-02-25',
+                            'developers' => [
+                                ['name' => 'FromSoftware'],
+                            ],
+                            'publishers' => [
+                                ['name' => 'Bandai Namco Entertainment'],
+                            ],
+                            'platforms' => [
+                                ['platform' => ['name' => 'PC']],
+                                ['platform' => ['name' => 'PlayStation 5']],
+                            ],
+                            'esrb_rating' => ['name' => 'Mature'],
+                        ],
+                    ],
+                ];
+
+                return [
+                    'body' => wp_json_encode($payload),
+                    'response' => ['code' => 200],
+                    'headers' => [],
+                ];
+            },
+            10,
+            3
+        );
+
+        $ajax = new JLG_Admin_Ajax();
+
+        try {
+            $ajax->handle_rawg_search();
+            $this->fail('Expected WP_Send_Json_Exception to be thrown.');
+        } catch (WP_Send_Json_Exception $exception) {
+            $this->assertTrue($exception->success);
+            $this->assertIsArray($exception->data);
+            $this->assertArrayHasKey('games', $exception->data);
+            $this->assertCount(1, $exception->data['games']);
+
+            $game = $exception->data['games'][0];
+            $this->assertSame('Elden Ring', $game['name']);
+            $this->assertSame('2022-02-25', $game['release_date']);
+            $this->assertSame(['FromSoftware'], $game['developers']);
+            $this->assertSame(['Bandai Namco Entertainment'], $game['publishers']);
+            $this->assertSame(['PC', 'PlayStation 5'], $game['platforms']);
+            $this->assertSame('', $game['pegi']);
+
+            $this->assertArrayHasKey('pagination', $exception->data);
+            $this->assertSame(2, $exception->data['pagination']['current_page']);
+            $this->assertSame(3, $exception->data['pagination']['next_page']);
+            $this->assertSame(1, $exception->data['pagination']['prev_page']);
+            $this->assertSame(123, $exception->data['pagination']['total_results']);
+
+            $cache_key = 'jlg_rawg_search_' . md5(wp_json_encode(['Elden Ring', 2]));
+            $this->assertSame($exception->data, get_transient($cache_key));
+
+            $this->assertNotNull($captured_request);
+            $this->assertSame(10, $captured_request['args']['timeout']);
+            $this->assertStringContainsString('key=demo-key', $captured_request['url']);
+            $this->assertStringContainsString('search=Elden+Ring', $captured_request['url']);
+        }
+    }
+
+    public function test_handle_rawg_search_returns_simulated_results_without_api_key(): void
     {
         $_POST['search'] = addslashes('The "Legend" & Co.');
         $_POST['nonce'] = 'dummy-nonce';
@@ -29,13 +160,8 @@ class AdminAjaxSearchTest extends TestCase
         } catch (WP_Send_Json_Exception $exception) {
             $this->assertTrue($exception->success);
             $this->assertArrayHasKey('games', $exception->data);
-            $this->assertIsArray($exception->data['games']);
             $this->assertNotEmpty($exception->data['games']);
-
-            $game = $exception->data['games'][0];
-
-            $this->assertArrayHasKey('name', $game);
-            $this->assertSame('The "Legend" & Co. - Résultat simulé', $game['name']);
+            $this->assertSame('The "Legend" & Co. - Résultat simulé', $exception->data['games'][0]['name']);
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch the admin RAWG search handler to call the real API when a key is configured, adding error handling, pagination data, and caching
- keep the simulated response as a fallback when no API key is available while reusing the new normalization helpers
- add a PHPUnit test that mocks the HTTP response via `pre_http_request` to verify the RAWG integration without external requests

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dc06d324c0832eb140186b6c0c999a