### PR TITLE
Prime caches before building game explorer snapshot

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -559,15 +559,21 @@ class JLG_Shortcode_Game_Explorer {
             return $snapshot;
         }
 
+        $post_id_chunks = count($rated_posts) > 100 ? array_chunk($rated_posts, 100) : [$rated_posts];
+
         if (function_exists('update_meta_cache')) {
-            foreach (array_chunk($rated_posts, 100) as $post_id_chunk) {
-                update_meta_cache('post', $post_id_chunk);
+            foreach ($post_id_chunks as $post_id_chunk) {
+                if (!empty($post_id_chunk)) {
+                    update_meta_cache('post', $post_id_chunk);
+                }
             }
         }
 
         if (function_exists('update_object_term_cache')) {
-            foreach (array_chunk($rated_posts, 100) as $post_id_chunk) {
-                update_object_term_cache($post_id_chunk, 'post', ['category']);
+            foreach ($post_id_chunks as $post_id_chunk) {
+                if (!empty($post_id_chunk)) {
+                    update_object_term_cache($post_id_chunk, 'post', ['category']);
+                }
             }
         }
 

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -453,10 +453,12 @@ class FrontendGameExplorerAjaxTest extends TestCase
         $this->assertSame($this->buildSnapshotWithPosts(), $snapshot, 'Primed snapshot should match expected output.');
 
         $this->assertNotEmpty($GLOBALS['jlg_test_meta_cache_calls'], 'Meta cache priming should occur before building the snapshot.');
+        $this->assertCount(1, $GLOBALS['jlg_test_meta_cache_calls'], 'Meta cache priming should occur in a single batched call for two posts.');
         $this->assertSame('post', $GLOBALS['jlg_test_meta_cache_calls'][0][0]);
         $this->assertSame([101, 202], $GLOBALS['jlg_test_meta_cache_calls'][0][1]);
 
         $this->assertNotEmpty($GLOBALS['jlg_test_term_cache_calls'], 'Term cache priming should occur before building the snapshot.');
+        $this->assertCount(1, $GLOBALS['jlg_test_term_cache_calls'], 'Term cache priming should occur in a single batched call for two posts.');
         $this->assertSame([101, 202], $GLOBALS['jlg_test_term_cache_calls'][0][0]);
         $this->assertSame('post', $GLOBALS['jlg_test_term_cache_calls'][0][1]);
         $this->assertSame(['category'], $GLOBALS['jlg_test_term_cache_calls'][0][2]);


### PR DESCRIPTION
## Summary
- batch prime the post meta and category term caches before iterating rated posts in the game explorer snapshot builder
- extend the game explorer ajax test to assert the snapshot output is unchanged while caches are primed in a single batched call

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: MigrationScheduleTest requires WordPress function `trailingslashit()` which is unavailable in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68dc12ee9630832e8e98fb1b05b5d007