### PR TITLE
Clean up user rating IPs on uninstall

### DIFF
--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -45,7 +45,7 @@ if ($delete_data) {
         '_jlg_cover_image_url', '_jlg_version',
         '_jlg_pegi', '_jlg_temps_de_jeu',
         '_jlg_user_ratings', '_jlg_user_rating_avg',
-        '_jlg_user_rating_count'
+        '_jlg_user_rating_count', '_jlg_user_rating_ips'
     ];
     
     foreach ($meta_keys as $meta_key) {


### PR DESCRIPTION
## Summary
- ensure uninstall removes stored user rating IP hashes by adding the meta key to the deletion list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc22e0bd54832ebcfdc6797b6128fb