### PR TITLE
Allow overriding frontend templates from themes

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -90,6 +90,19 @@ Le plugin propose désormais une collection complète de blocs dynamiques pour l
 Chaque bloc repose sur le rendu PHP historique (shortcodes) et marque automatiquement l'exécution via
 `JLG_Frontend::mark_shortcode_rendered()` afin que les assets nécessaires soient chargés, y compris dans l'éditeur.
 
+### Surcharge des templates
+
+Pour personnaliser le HTML rendu par un shortcode ou un widget, copiez le fichier correspondant depuis
+`plugin-notation-jeux/templates/` dans votre thème (ou thème enfant) sous `notation-jlg/{template}.php`.
+Lors de l'appel, le plugin cherche d'abord `notation-jlg/shortcode-rating-block.php`, `notation-jlg/widget-latest-reviews.php`,
+etc., avant de revenir au fichier interne. Deux filtres sont disponibles pour aller plus loin :
+
+- `jlg_frontend_template_candidates` pour modifier la liste des chemins passés à `locate_template()` ;
+- `jlg_frontend_template_path` pour ajuster le chemin final utilisé.
+
+Ces mécanismes vous permettent de conserver vos surcharges lors des mises à jour tout en offrant des points d'ancrage
+programmatiques pour les intégrations avancées.
+
 ## Installation
 
 1. Téléchargez le plugin et décompressez l'archive

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -87,6 +87,18 @@ Le plugin expose huit blocs dynamiques prêts à l'emploi :
 Chaque bloc délègue le rendu à la logique PHP historique (shortcodes) tout en appelant `JLG_Frontend::mark_shortcode_rendered()`
 afin de charger automatiquement les scripts et feuilles de style requis dans l'éditeur.
 
+== Surcharge des templates ==
+
+Pour modifier le HTML rendu, copiez le fichier souhaité depuis `plugin-notation-jeux/templates/` vers votre thème (ou thème
+enfant) sous `notation-jlg/{template}.php`. Le plugin tente d'abord de charger cette version (par exemple
+`notation-jlg/shortcode-rating-block.php`, `notation-jlg/widget-latest-reviews.php`) via `locate_template()` avant de revenir à la
+version interne. Deux filtres permettent des personnalisations supplémentaires :
+
+* `jlg_frontend_template_candidates` pour ajuster la liste des chemins passés à `locate_template()` ;
+* `jlg_frontend_template_path` pour modifier le chemin final inclus.
+
+Ces points d'extension facilitent la conservation de vos surcharges lors des mises à jour du plugin.
+
 == Installation ==
 
 1. Téléchargez le plugin et décompressez l'archive


### PR DESCRIPTION
## Summary
- allow `JLG_Frontend::get_template_html()` to locate theme overrides before falling back to plugin templates
- expose filters around template selection for advanced integrations
- document the `notation-jlg/{template}.php` convention for overriding templates

## Testing
- composer test *(fails: phpunit: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc22e59238832ea7943e0c4e3ac235