### PR TITLE
Namespace shortcode filter parameters by container

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -20,6 +20,7 @@ $sort_key = isset($sort_key) ? $sort_key : 'date';
 $sort_order = isset($sort_order) ? $sort_order : 'DESC';
 $pagination = is_array($pagination) ? $pagination : ['current' => 1, 'total' => 0];
 $config_payload = is_array($config_payload) ? $config_payload : [];
+$request_prefix = isset($request_prefix) ? (string) $request_prefix : '';
 $config_json = wp_json_encode($config_payload);
 if ($config_json === false) {
     $config_json = '{}';
@@ -42,6 +43,7 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
     data-config="<?php echo esc_attr($config_json); ?>"
     data-posts-per-page="<?php echo esc_attr($atts['posts_per_page']); ?>"
     data-total-items="<?php echo esc_attr($total_items); ?>"
+    data-request-prefix="<?php echo esc_attr($request_prefix); ?>"
 >
     <div class="jlg-ge-toolbar">
         <div class="jlg-ge-toolbar__left">

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -26,6 +26,15 @@ $columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $colum
 $genre_taxonomy = apply_filters('jlg_summary_genre_taxonomy', 'jlg_game_genre');
 $has_genre_taxonomy = !empty($genre_taxonomy) && taxonomy_exists($genre_taxonomy);
 $genre_terms = [];
+$request_prefix = isset($request_prefix) ? (string) $request_prefix : '';
+$request_keys = isset($request_keys) && is_array($request_keys) ? $request_keys : [];
+$resolve_request_key = static function ($key) use ($request_prefix, $request_keys) {
+    if (isset($request_keys[$key]) && is_string($request_keys[$key])) {
+        return $request_keys[$key];
+    }
+
+    return $request_prefix !== '' ? $key . '__' . $request_prefix : $key;
+};
 
 if ($show_filters && $has_genre_taxonomy) {
     $genre_terms = get_terms([
@@ -56,6 +65,7 @@ $letters = range('A', 'Z');
     data-cat-filter="<?php echo esc_attr($current_cat_filter); ?>"
     data-letter-filter="<?php echo esc_attr($current_letter_filter); ?>"
     data-genre-filter="<?php echo esc_attr($current_genre_filter); ?>"
+    data-request-prefix="<?php echo esc_attr($request_prefix); ?>"
 >
 
     <?php if ($show_filters) : ?>
@@ -94,15 +104,15 @@ $letters = range('A', 'Z');
             </div>
 
             <form method="get" action="" class="jlg-summary-filters-form">
-                <input type="hidden" name="orderby" value="<?php echo esc_attr($current_orderby); ?>">
-                <input type="hidden" name="order" value="<?php echo esc_attr($current_order); ?>">
-                <input type="hidden" name="letter_filter" value="<?php echo esc_attr($current_letter_filter); ?>">
+                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('orderby')); ?>" value="<?php echo esc_attr($current_orderby); ?>">
+                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('order')); ?>" value="<?php echo esc_attr($current_order); ?>">
+                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('letter_filter')); ?>" value="<?php echo esc_attr($current_letter_filter); ?>">
                 <?php
                 wp_dropdown_categories([
                     'show_option_all' => __('Toutes les catégories', 'notation-jlg'),
                     'orderby' => 'name',
                     'hide_empty' => 1,
-                    'name' => 'cat_filter',
+                    'name' => $resolve_request_key('cat_filter'),
                     'id' => $table_id . '_cat_filter',
                     'selected' => $current_cat_filter,
                     'hierarchical' => true,
@@ -113,7 +123,7 @@ $letters = range('A', 'Z');
                     <label for="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="screen-reader-text">
                         <?php esc_html_e('Filtrer par genre', 'notation-jlg'); ?>
                     </label>
-                    <select name="genre_filter" id="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="jlg-genre-filter-select">
+                    <select name="<?php echo esc_attr($resolve_request_key('genre_filter')); ?>" id="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="jlg-genre-filter-select">
                         <option value="" <?php selected($current_genre_filter, ''); ?>><?php esc_html_e('Tous les genres', 'notation-jlg'); ?></option>
                         <?php foreach ($genre_terms as $term) : ?>
                             <option value="<?php echo esc_attr($term->slug); ?>" <?php selected($current_genre_filter, $term->slug); ?>>
@@ -122,7 +132,7 @@ $letters = range('A', 'Z');
                         <?php endforeach; ?>
                     </select>
                 <?php else : ?>
-                    <input type="hidden" name="genre_filter" value="<?php echo esc_attr($current_genre_filter); ?>">
+                    <input type="hidden" name="<?php echo esc_attr($resolve_request_key('genre_filter')); ?>" value="<?php echo esc_attr($current_genre_filter); ?>">
                 <?php endif; ?>
                 <input type="submit" value="<?php echo esc_attr__('Filtrer', 'notation-jlg'); ?>">
             </form>

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -386,6 +386,39 @@ class FrontendGameExplorerAjaxTest extends TestCase
         $this->assertSame('<p>' . esc_html__('Aucun jeu ne correspond à vos filtres actuels.', 'notation-jlg') . '</p>', $context['message']);
     }
 
+    public function test_namespaced_request_parameters_are_isolated_between_instances(): void
+    {
+        $this->configureOptions();
+        $this->primeSnapshot($this->buildSnapshotWithPosts());
+
+        $attsOne = JLG_Shortcode_Game_Explorer::get_default_atts();
+        $attsOne['id'] = 'first-explorer';
+
+        $attsTwo = JLG_Shortcode_Game_Explorer::get_default_atts();
+        $attsTwo['id'] = 'second-explorer';
+
+        $request = [
+            'letter__first-explorer'   => 'A',
+            'orderby__first-explorer'  => 'title',
+            'order__first-explorer'    => 'ASC',
+            'letter__second-explorer'  => 'B',
+            'category__second-explorer'=> '11',
+        ];
+
+        $contextOne = JLG_Shortcode_Game_Explorer::get_render_context($attsOne, $request);
+        $contextTwo = JLG_Shortcode_Game_Explorer::get_render_context($attsTwo, $request);
+
+        $this->assertSame('A', $contextOne['current_filters']['letter']);
+        $this->assertSame('', $contextOne['current_filters']['category']);
+        $this->assertSame('title', $contextOne['sort_key']);
+        $this->assertSame('ASC', $contextOne['sort_order']);
+
+        $this->assertSame('B', $contextTwo['current_filters']['letter']);
+        $this->assertSame('11', $contextTwo['current_filters']['category']);
+        $this->assertSame('date', $contextTwo['sort_key']);
+        $this->assertSame('DESC', $contextTwo['sort_order']);
+    }
+
     public function test_snapshot_cleared_after_relevant_meta_update(): void
     {
         $this->configureOptions();

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -163,4 +163,33 @@ class ShortcodeSummarySortingTest extends TestCase
         $this->assertInstanceOf(WP_Query::class, $context['query']);
         $this->assertSame(['post', 'game_review'], $context['query']->args['post_type']);
     }
+
+    public function test_namespaced_request_parameters_are_scoped_to_each_table()
+    {
+        $attsOne = JLG_Shortcode_Summary_Display::get_default_atts();
+        $attsOne['id'] = 'table-one';
+
+        $attsTwo = JLG_Shortcode_Summary_Display::get_default_atts();
+        $attsTwo['id'] = 'table-two';
+
+        $request = [
+            'orderby__table-one'      => 'note',
+            'order__table-one'        => 'ASC',
+            'letter_filter__table-two'=> 'C',
+            'cat_filter__table-two'   => '123',
+        ];
+
+        $contextOne = JLG_Shortcode_Summary_Display::get_render_context($attsOne, $request);
+        $contextTwo = JLG_Shortcode_Summary_Display::get_render_context($attsTwo, $request);
+
+        $this->assertSame('note', $contextOne['orderby']);
+        $this->assertSame('ASC', $contextOne['order']);
+        $this->assertSame('', $contextOne['letter_filter']);
+        $this->assertSame(0, $contextOne['cat_filter']);
+
+        $this->assertSame('C', $contextTwo['letter_filter']);
+        $this->assertSame(123, $contextTwo['cat_filter']);
+        $this->assertSame('date', $contextTwo['orderby']);
+        $this->assertSame('DESC', $contextTwo['order']);
+    }
 }


### PR DESCRIPTION
## Summary
- namespace query parameters for the game explorer and summary shortcodes using container-specific prefixes and expose them through templates
- update frontend scripts and AJAX handlers to read and write the namespaced filter and sort parameters
- extend automated coverage to ensure multiple shortcode instances operate independently

## Testing
- `composer test` *(fails: phpunit executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc22edd5f8832e843ddf79c35c0398