### PR TITLE
Add CI workflow for Composer quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.1-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.1-
+
+      - name: Install dependencies
+        working-directory: plugin-notation-jeux_V4
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run tests
+        working-directory: plugin-notation-jeux_V4
+        run: composer test
+
+      - name: Run coding standards checks
+        working-directory: plugin-notation-jeux_V4
+        run: composer cs

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
   - [`includes/`](plugin-notation-jeux_V4/includes) contient le cœur PHP (helpers, frontend, admin, utils).
   - [`admin/templates/`](plugin-notation-jeux_V4/admin/templates) centralise les vues des onglets d’administration.
 
+## Intégration continue
+Un workflow GitHub Actions (`CI`) s’exécute sur chaque `push` et `pull_request`. Il installe les dépendances Composer du dossier [`plugin-notation-jeux_V4`](plugin-notation-jeux_V4), puis enchaîne deux commandes clés pour garantir la qualité :
+
+- `composer test` pour lancer la suite PHPUnit.
+- `composer cs` pour appliquer les vérifications de style via PHPCS.
+
+Assurez-vous que ces commandes passent en local avant de soumettre une contribution.
+
 ## Synchronisation du README WordPress
 La documentation WordPress (`plugin-notation-jeux_V4/README.txt`) doit rester alignée avec ce README Markdown. Toute modification de l’un doit être répercutée sur l’autre pour garantir des informations cohérentes dans l’interface WordPress.org.
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies, caches Composer, and runs the quality scripts on push and pull requests
- document the CI pipeline commands contributors should run locally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc34cf9318832e8ebbc7bc924097d9