### PR TITLE
Add PHPCS configuration and reformat plugin to WordPress standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
 La documentation WordPress (`plugin-notation-jeux_V4/README.txt`) doit rester alignée avec ce README Markdown. Toute modification de l’un doit être répercutée sur l’autre pour garantir des informations cohérentes dans l’interface WordPress.org.
 
 Bonne contribution ! Pensez à suivre les scripts Composer avant toute PR et à conserver la parité de contenu entre les deux README.
+
+### Vérification du style
+- Exécutez `composer install` pour récupérer les dépendances de développement (WordPress Coding Standards).
+- Lancez `composer cs` avant chaque commit afin de vérifier que vos modifications respectent le standard défini dans `phpcs.xml.dist`.
+- Si besoin, `composer cs-fix` peut corriger automatiquement une partie des avertissements avant un passage manuel.

--- a/plugin-notation-jeux_V4/composer.json
+++ b/plugin-notation-jeux_V4/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "wp-coding-standards/wpcs": "^2.3",
+        "wp-coding-standards/wpcs": "^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
     },
     "scripts": {

--- a/plugin-notation-jeux_V4/composer.lock
+++ b/plugin-notation-jeux_V4/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8037ae96334e23ffcc779f56d7043bb2",
+    "content-hash": "c03ebb4585a12cea299f1fe0f5381698",
     "packages": [],
     "packages-dev": [
         {
@@ -387,6 +387,181 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.2",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-05T06:54:52+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-05T00:00:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1953,30 +2128,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1993,6 +2176,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2000,7 +2184,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "aliases": [],

--- a/plugin-notation-jeux_V4/functions.php
+++ b/plugin-notation-jeux_V4/functions.php
@@ -1,9 +1,9 @@
 <?php
 // Fonction pour afficher la note sur les vignettes
-if (!function_exists('jlg_display_thumbnail_score')) {
-    function jlg_display_thumbnail_score($post_id = null) {
-        if (class_exists('JLG_Frontend')) {
-            echo JLG_Frontend::get_template_html('widget-thumbnail-score', ['post_id' => $post_id]);
+if ( ! function_exists( 'jlg_display_thumbnail_score' ) ) {
+    function jlg_display_thumbnail_score( $post_id = null ) {
+        if ( class_exists( 'JLG_Frontend' ) ) {
+            echo JLG_Frontend::get_template_html( 'widget-thumbnail-score', array( 'post_id' => $post_id ) );
         }
     }
 }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -1,284 +1,307 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Ajax {
-    
+
     public function __construct() {
-        add_action('wp_ajax_jlg_search_rawg_games', [$this, 'handle_rawg_search']);
-        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_ajax_assets']);
+        add_action( 'wp_ajax_jlg_search_rawg_games', array( $this, 'handle_rawg_search' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_ajax_assets' ) );
     }
 
-    public function enqueue_admin_ajax_assets($hook_suffix) {
-        $allowed_hooks = [
+    public function enqueue_admin_ajax_assets( $hook_suffix ) {
+        $allowed_hooks = array(
             'post.php',
             'post-new.php',
             'toplevel_page_notation_jlg_settings',
-        ];
+        );
 
-        if (!in_array($hook_suffix, $allowed_hooks, true)) {
+        if ( ! in_array( $hook_suffix, $allowed_hooks, true ) ) {
             return;
         }
 
         $script_handle = 'jlg-admin-api';
-        $script_url = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js';
-        $version = defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : false;
+        $script_url    = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js';
+        $version       = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
 
-        wp_register_script($script_handle, $script_url, ['jquery'], $version, true);
+        wp_register_script( $script_handle, $script_url, array( 'jquery' ), $version, true );
 
-        wp_localize_script($script_handle, 'jlg_admin_ajax', [
-            'nonce' => wp_create_nonce('jlg_admin_ajax_nonce'),
-            'ajax_url' => admin_url('admin-ajax.php'),
-        ]);
+        wp_localize_script(
+            $script_handle,
+            'jlg_admin_ajax',
+            array(
+				'nonce'    => wp_create_nonce( 'jlg_admin_ajax_nonce' ),
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+			)
+        );
 
-        wp_enqueue_script($script_handle);
+        wp_enqueue_script( $script_handle );
     }
 
     public function handle_rawg_search() {
-        check_ajax_referer('jlg_admin_ajax_nonce', 'nonce');
+        check_ajax_referer( 'jlg_admin_ajax_nonce', 'nonce' );
 
         // Sécurité basique
-        if (!current_user_can('edit_posts')) {
-            wp_send_json_error([
-                'message' => __('Permissions insuffisantes.', 'notation-jlg'),
-            ], 403);
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error(
+                array(
+					'message' => __( 'Permissions insuffisantes.', 'notation-jlg' ),
+                ),
+                403
+            );
         }
 
-        $search_term = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+        $search_term = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
 
-        if (empty($search_term)) {
-            wp_send_json_error([
-                'message' => __('Terme de recherche vide.', 'notation-jlg'),
-            ], 400);
+        if ( empty( $search_term ) ) {
+            wp_send_json_error(
+                array(
+					'message' => __( 'Terme de recherche vide.', 'notation-jlg' ),
+                ),
+                400
+            );
         }
 
-        $page = isset($_POST['page']) ? max(1, absint(wp_unslash($_POST['page']))) : 1;
+        $page = isset( $_POST['page'] ) ? max( 1, absint( wp_unslash( $_POST['page'] ) ) ) : 1;
 
         $options = JLG_Helpers::get_plugin_options();
-        $api_key = isset($options['rawg_api_key']) ? sanitize_text_field((string) $options['rawg_api_key']) : '';
+        $api_key = isset( $options['rawg_api_key'] ) ? sanitize_text_field( (string) $options['rawg_api_key'] ) : '';
 
-        if ($api_key === '') {
+        if ( $api_key === '' ) {
             // Simulation de réponse si aucune clé n'est configurée.
-            $mock_games = [
-                [
-                    'name' => $search_term . ' - Résultat simulé',
+            $mock_games = array(
+                array(
+                    'name'         => $search_term . ' - Résultat simulé',
                     'release_date' => '2024-01-15',
-                    'developers' => 'Studio Exemple',
-                    'publishers' => 'Éditeur Exemple',
-                    'platforms' => ['PC', 'PlayStation 5'],
-                    'pegi' => 'PEGI 12',
-                ]
-            ];
+                    'developers'   => 'Studio Exemple',
+                    'publishers'   => 'Éditeur Exemple',
+                    'platforms'    => array( 'PC', 'PlayStation 5' ),
+                    'pegi'         => 'PEGI 12',
+                ),
+            );
 
-            $normalized_games = array_map([$this, 'normalize_game_fields'], $mock_games);
+            $normalized_games = array_map( array( $this, 'normalize_game_fields' ), $mock_games );
 
-            wp_send_json_success([
-                'games' => $normalized_games,
-                'message' => __('Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg'),
-            ]);
+            wp_send_json_success(
+                array(
+					'games'   => $normalized_games,
+					'message' => __( 'Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg' ),
+                )
+            );
         }
 
-        $cache_key = 'jlg_rawg_search_' . md5(wp_json_encode([$search_term, $page]));
-        $cached_payload = get_transient($cache_key);
+        $cache_key      = 'jlg_rawg_search_' . md5( wp_json_encode( array( $search_term, $page ) ) );
+        $cached_payload = get_transient( $cache_key );
 
-        if ($cached_payload !== false && is_array($cached_payload)) {
-            wp_send_json_success($cached_payload);
+        if ( $cached_payload !== false && is_array( $cached_payload ) ) {
+            wp_send_json_success( $cached_payload );
         }
 
-        $endpoint = 'https://api.rawg.io/api/games';
-        $query_args = [
-            'search' => $search_term,
-            'page' => $page,
+        $endpoint   = 'https://api.rawg.io/api/games';
+        $query_args = array(
+            'search'    => $search_term,
+            'page'      => $page,
             'page_size' => 20,
-            'key' => $api_key,
-        ];
+            'key'       => $api_key,
+        );
 
         $request_args = apply_filters(
             'jlg_rawg_http_request_args',
-            [
+            array(
                 'timeout' => 10,
-                'headers' => [
+                'headers' => array(
                     'Accept' => 'application/json',
-                ],
-            ],
+                ),
+            ),
             $search_term,
             $page
         );
 
-        $response = wp_remote_get(add_query_arg($query_args, $endpoint), $request_args);
+        $response = wp_remote_get( add_query_arg( $query_args, $endpoint ), $request_args );
 
-        if (function_exists('is_wp_error') && is_wp_error($response)) {
-            wp_send_json_error([
-                'message' => __('Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement.', 'notation-jlg'),
-            ], 502);
-        }
-
-        $status_code = (int) wp_remote_retrieve_response_code($response);
-
-        if ($status_code < 200 || $status_code >= 300) {
-            wp_send_json_error([
-                'message' => sprintf(
-                    /* translators: %d: HTTP status code returned by RAWG.io */
-                    __('La requête RAWG.io a échoué avec le code HTTP %d.', 'notation-jlg'),
-                    $status_code
+        if ( function_exists( 'is_wp_error' ) && is_wp_error( $response ) ) {
+            wp_send_json_error(
+                array(
+					'message' => __( 'Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement.', 'notation-jlg' ),
                 ),
-            ], $status_code ?: 500);
+                502
+            );
         }
 
-        $body = wp_remote_retrieve_body($response);
-        $decoded = json_decode($body, true);
+        $status_code = (int) wp_remote_retrieve_response_code( $response );
 
-        if (!is_array($decoded)) {
-            wp_send_json_error([
-                'message' => __('Réponse RAWG.io invalide : données JSON non valides.', 'notation-jlg'),
-            ], 502);
+        if ( $status_code < 200 || $status_code >= 300 ) {
+            wp_send_json_error(
+                array(
+					'message' => sprintf(
+						/* translators: %d: HTTP status code returned by RAWG.io */
+						__( 'La requête RAWG.io a échoué avec le code HTTP %d.', 'notation-jlg' ),
+						$status_code
+					),
+                ),
+                $status_code ?: 500
+            );
         }
 
-        $raw_results = [];
-        if (!empty($decoded['results']) && is_array($decoded['results'])) {
-            $raw_results = array_map([$this, 'transform_rawg_game'], $decoded['results']);
+        $body    = wp_remote_retrieve_body( $response );
+        $decoded = json_decode( $body, true );
+
+        if ( ! is_array( $decoded ) ) {
+            wp_send_json_error(
+                array(
+					'message' => __( 'Réponse RAWG.io invalide : données JSON non valides.', 'notation-jlg' ),
+                ),
+                502
+            );
         }
 
-        $normalized_games = array_map([$this, 'normalize_game_fields'], $raw_results);
+        $raw_results = array();
+        if ( ! empty( $decoded['results'] ) && is_array( $decoded['results'] ) ) {
+            $raw_results = array_map( array( $this, 'transform_rawg_game' ), $decoded['results'] );
+        }
 
-        $payload = [
-            'games' => $normalized_games,
-            'pagination' => [
-                'current_page' => $page,
-                'next_page' => $this->extract_rawg_page($decoded['next'] ?? ''),
-                'prev_page' => $this->extract_rawg_page($decoded['previous'] ?? ''),
-                'total_results' => isset($decoded['count']) ? (int) $decoded['count'] : null,
-            ],
-            'message' => __('Résultats récupérés depuis RAWG.io.', 'notation-jlg'),
-        ];
+        $normalized_games = array_map( array( $this, 'normalize_game_fields' ), $raw_results );
 
-        set_transient($cache_key, $payload, 15 * MINUTE_IN_SECONDS);
+        $payload = array(
+            'games'      => $normalized_games,
+            'pagination' => array(
+                'current_page'  => $page,
+                'next_page'     => $this->extract_rawg_page( $decoded['next'] ?? '' ),
+                'prev_page'     => $this->extract_rawg_page( $decoded['previous'] ?? '' ),
+                'total_results' => isset( $decoded['count'] ) ? (int) $decoded['count'] : null,
+            ),
+            'message'    => __( 'Résultats récupérés depuis RAWG.io.', 'notation-jlg' ),
+        );
 
-        wp_send_json_success($payload);
+        set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
+
+        wp_send_json_success( $payload );
     }
 
-    private function transform_rawg_game(array $raw_game) {
-        $developers = [];
-        if (!empty($raw_game['developers']) && is_array($raw_game['developers'])) {
-            foreach ($raw_game['developers'] as $developer) {
-                if (is_array($developer) && isset($developer['name'])) {
+    private function transform_rawg_game( array $raw_game ) {
+        $developers = array();
+        if ( ! empty( $raw_game['developers'] ) && is_array( $raw_game['developers'] ) ) {
+            foreach ( $raw_game['developers'] as $developer ) {
+                if ( is_array( $developer ) && isset( $developer['name'] ) ) {
                     $developers[] = $developer['name'];
-                } elseif (is_string($developer)) {
+                } elseif ( is_string( $developer ) ) {
                     $developers[] = $developer;
                 }
             }
         }
 
-        $publishers = [];
-        if (!empty($raw_game['publishers']) && is_array($raw_game['publishers'])) {
-            foreach ($raw_game['publishers'] as $publisher) {
-                if (is_array($publisher) && isset($publisher['name'])) {
+        $publishers = array();
+        if ( ! empty( $raw_game['publishers'] ) && is_array( $raw_game['publishers'] ) ) {
+            foreach ( $raw_game['publishers'] as $publisher ) {
+                if ( is_array( $publisher ) && isset( $publisher['name'] ) ) {
                     $publishers[] = $publisher['name'];
-                } elseif (is_string($publisher)) {
+                } elseif ( is_string( $publisher ) ) {
                     $publishers[] = $publisher;
                 }
             }
         }
 
-        $platforms = [];
-        if (!empty($raw_game['platforms']) && is_array($raw_game['platforms'])) {
-            foreach ($raw_game['platforms'] as $platform) {
-                if (is_array($platform)) {
-                    if (isset($platform['platform']['name'])) {
+        $platforms = array();
+        if ( ! empty( $raw_game['platforms'] ) && is_array( $raw_game['platforms'] ) ) {
+            foreach ( $raw_game['platforms'] as $platform ) {
+                if ( is_array( $platform ) ) {
+                    if ( isset( $platform['platform']['name'] ) ) {
                         $platforms[] = $platform['platform']['name'];
-                    } elseif (isset($platform['name'])) {
+                    } elseif ( isset( $platform['name'] ) ) {
                         $platforms[] = $platform['name'];
                     }
-                } elseif (is_string($platform)) {
+                } elseif ( is_string( $platform ) ) {
                     $platforms[] = $platform;
                 }
             }
         }
 
         $pegi = '';
-        if (!empty($raw_game['age_rating']['name'])) {
+        if ( ! empty( $raw_game['age_rating']['name'] ) ) {
             $pegi = $raw_game['age_rating']['name'];
-        } elseif (!empty($raw_game['esrb_rating']['name'])) {
+        } elseif ( ! empty( $raw_game['esrb_rating']['name'] ) ) {
             $pegi = $raw_game['esrb_rating']['name'];
         }
 
-        return [
-            'name' => $raw_game['name'] ?? '',
+        return array(
+            'name'         => $raw_game['name'] ?? '',
             'release_date' => $raw_game['released'] ?? '',
-            'developers' => $developers,
-            'publishers' => $publishers,
-            'platforms' => $platforms,
-            'pegi' => $pegi,
-        ];
+            'developers'   => $developers,
+            'publishers'   => $publishers,
+            'platforms'    => $platforms,
+            'pegi'         => $pegi,
+        );
     }
 
-    private function normalize_game_fields(array $game) {
-        $defaults = [
-            'name' => '',
+    private function normalize_game_fields( array $game ) {
+        $defaults = array(
+            'name'         => '',
             'release_date' => '',
-            'developers' => '',
-            'publishers' => '',
-            'platforms' => [],
-            'pegi' => '',
-        ];
+            'developers'   => '',
+            'publishers'   => '',
+            'platforms'    => array(),
+            'pegi'         => '',
+        );
 
-        $game = array_merge($defaults, $game);
+        $game = array_merge( $defaults, $game );
 
-        $sanitize_scalar = static function($value) {
-            if (is_scalar($value)) {
-                return sanitize_text_field((string) $value);
+        $sanitize_scalar = static function ( $value ) {
+            if ( is_scalar( $value ) ) {
+                return sanitize_text_field( (string) $value );
             }
 
             return '';
         };
 
-        $game['name'] = $sanitize_scalar($game['name']);
+        $game['name'] = $sanitize_scalar( $game['name'] );
 
-        foreach (['developers', 'publishers'] as $field) {
-            if (is_array($game[$field])) {
-                $game[$field] = array_values(array_filter(array_map($sanitize_scalar, $game[$field]), 'strlen'));
+        foreach ( array( 'developers', 'publishers' ) as $field ) {
+            if ( is_array( $game[ $field ] ) ) {
+                $game[ $field ] = array_values( array_filter( array_map( $sanitize_scalar, $game[ $field ] ), 'strlen' ) );
             } else {
-                $game[$field] = $sanitize_scalar($game[$field]);
+                $game[ $field ] = $sanitize_scalar( $game[ $field ] );
             }
         }
 
-        if (is_array($game['platforms'])) {
-            $game['platforms'] = array_values(array_filter(array_map($sanitize_scalar, $game['platforms']), 'strlen'));
+        if ( is_array( $game['platforms'] ) ) {
+            $game['platforms'] = array_values( array_filter( array_map( $sanitize_scalar, $game['platforms'] ), 'strlen' ) );
         } else {
-            $game['platforms'] = $sanitize_scalar($game['platforms']);
-            $game['platforms'] = $game['platforms'] === '' ? [] : [$game['platforms']];
+            $game['platforms'] = $sanitize_scalar( $game['platforms'] );
+            $game['platforms'] = $game['platforms'] === '' ? array() : array( $game['platforms'] );
         }
 
-        if ($game['release_date'] !== '') {
-            $sanitized_date = JLG_Validator::sanitize_date($game['release_date']);
+        if ( $game['release_date'] !== '' ) {
+            $sanitized_date       = JLG_Validator::sanitize_date( $game['release_date'] );
             $game['release_date'] = $sanitized_date !== null ? $sanitized_date : '';
         }
 
-        if ($game['pegi'] !== '') {
-            $sanitized_pegi = JLG_Validator::sanitize_pegi($game['pegi']);
-            $game['pegi'] = $sanitized_pegi !== null ? $sanitized_pegi : '';
+        if ( $game['pegi'] !== '' ) {
+            $sanitized_pegi = JLG_Validator::sanitize_pegi( $game['pegi'] );
+            $game['pegi']   = $sanitized_pegi !== null ? $sanitized_pegi : '';
         }
 
         return $game;
     }
 
-    private function extract_rawg_page($url) {
-        if (!is_string($url) || $url === '') {
+    private function extract_rawg_page( $url ) {
+        if ( ! is_string( $url ) || $url === '' ) {
             return null;
         }
 
-        $parts = wp_parse_url($url);
+        $parts = wp_parse_url( $url );
 
-        if (!is_array($parts) || empty($parts['query'])) {
+        if ( ! is_array( $parts ) || empty( $parts['query'] ) ) {
             return null;
         }
 
-        parse_str($parts['query'], $query_args);
+        parse_str( $parts['query'], $query_args );
 
-        if (empty($query_args['page'])) {
+        if ( empty( $query_args['page'] ) ) {
             return null;
         }
 
-        $page = absint($query_args['page']);
+        $page = absint( $query_args['page'] );
 
         return $page > 0 ? $page : null;
     }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-core.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Core {
     private static $instance = null;
@@ -9,7 +11,7 @@ class JLG_Admin_Core {
     private $platforms;
 
     public static function get_instance() {
-        if (self::$instance === null) {
+        if ( self::$instance === null ) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -21,52 +23,57 @@ class JLG_Admin_Core {
     }
 
     private function load_admin_dependencies() {
-        $admin_files = [
+        $admin_files = array(
             'includes/admin/class-jlg-admin-menu.php',
             'includes/admin/class-jlg-admin-metaboxes.php',
             'includes/admin/class-jlg-admin-settings.php',
             'includes/admin/class-jlg-admin-ajax.php',
-            'includes/admin/class-jlg-admin-platforms.php'  // Ajout de la classe Platforms
-        ];
+            'includes/admin/class-jlg-admin-platforms.php',  // Ajout de la classe Platforms
+        );
 
-        foreach ($admin_files as $file) {
+        foreach ( $admin_files as $file ) {
             $path = JLG_NOTATION_PLUGIN_DIR . $file;
-            if (file_exists($path)) {
+            if ( file_exists( $path ) ) {
                 require_once $path;
             }
         }
     }
 
     private function init_admin_components() {
-        if (class_exists('JLG_Admin_Menu')) {
+        if ( class_exists( 'JLG_Admin_Menu' ) ) {
             $this->menu = new JLG_Admin_Menu();
         }
-        
-        if (class_exists('JLG_Admin_Metaboxes')) {
+
+        if ( class_exists( 'JLG_Admin_Metaboxes' ) ) {
             $this->metaboxes = new JLG_Admin_Metaboxes();
         }
-        
-        if (class_exists('JLG_Admin_Settings')) {
+
+        if ( class_exists( 'JLG_Admin_Settings' ) ) {
             $this->settings = new JLG_Admin_Settings();
         }
 
-        if (class_exists('JLG_Admin_Ajax')) {
+        if ( class_exists( 'JLG_Admin_Ajax' ) ) {
             new JLG_Admin_Ajax();
         }
-        
+
         // Initialiser la classe Platforms en mode singleton
-        if (class_exists('JLG_Admin_Platforms')) {
+        if ( class_exists( 'JLG_Admin_Platforms' ) ) {
             $this->platforms = JLG_Admin_Platforms::get_instance();
         }
     }
 
-    public function get_component($component_name) {
-        switch ($component_name) {
-            case 'menu': return $this->menu;
-            case 'metaboxes': return $this->metaboxes;
-            case 'settings': return $this->settings;
-            case 'platforms': return $this->platforms;
-            default: return null;
+    public function get_component( $component_name ) {
+        switch ( $component_name ) {
+            case 'menu':
+                return $this->menu;
+            case 'metaboxes':
+                return $this->metaboxes;
+            case 'settings':
+                return $this->settings;
+            case 'platforms':
+                return $this->platforms;
+            default:
+                return null;
         }
     }
 }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-menu.php
@@ -6,68 +6,76 @@
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Menu {
     private $page_slug = 'notation_jlg_settings';
 
     public function __construct() {
-        add_action('admin_menu', [$this, 'add_admin_menu']);
+        add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
     }
 
     public function add_admin_menu() {
         add_menu_page(
-            _x('Notation JLG', 'Admin page title', 'notation-jlg'),
-            _x('Notation - JLG', 'Admin menu title', 'notation-jlg'),
+            _x( 'Notation JLG', 'Admin page title', 'notation-jlg' ),
+            _x( 'Notation - JLG', 'Admin menu title', 'notation-jlg' ),
             'manage_options',
             $this->page_slug,
-            [$this, 'render_admin_page'],
+            array( $this, 'render_admin_page' ),
             'dashicons-star-filled',
             30
         );
     }
 
     public function render_admin_page() {
-        if (!current_user_can('manage_options')) {
-            wp_die(esc_html__('Accès refusé.', 'notation-jlg'));
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Accès refusé.', 'notation-jlg' ) );
         }
 
-        $tabs = $this->get_tabs();
-        $active_tab = isset($_GET['tab']) ? sanitize_key($_GET['tab']) : 'reglages';
-        if (!array_key_exists($active_tab, $tabs)) {
+        $tabs       = $this->get_tabs();
+        $active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'reglages';
+        if ( ! array_key_exists( $active_tab, $tabs ) ) {
             $active_tab = 'reglages';
         }
 
-        $tab_navigation = $this->get_tab_navigation_html($tabs, $active_tab);
-        $tab_content = $this->get_tab_content($active_tab);
+        $tab_navigation = $this->get_tab_navigation_html( $tabs, $active_tab );
+        $tab_content    = $this->get_tab_content( $active_tab );
 
-        JLG_Template_Loader::display_admin_template('admin-page', [
-            'page_title' => __('⭐ Notation JLG v5.0', 'notation-jlg'),
-            'tab_navigation' => $tab_navigation,
-            'tab_content' => $tab_content,
-        ]);
+        JLG_Template_Loader::display_admin_template(
+            'admin-page',
+            array(
+				'page_title'     => __( '⭐ Notation JLG v5.0', 'notation-jlg' ),
+				'tab_navigation' => $tab_navigation,
+				'tab_content'    => $tab_content,
+			)
+        );
     }
 
     private function get_tabs() {
-        return [
-            'reglages' => __('⚙️ Réglages', 'notation-jlg'),
-            'articles_notes' => __('📊 Articles Notés', 'notation-jlg'),
-            'plateformes' => __('🎮 Plateformes', 'notation-jlg'),
-            'shortcodes' => __('📝 Shortcodes', 'notation-jlg'),
-            'tutoriels' => __('📚 Tutoriels', 'notation-jlg'),
-        ];
+        return array(
+            'reglages'       => __( '⚙️ Réglages', 'notation-jlg' ),
+            'articles_notes' => __( '📊 Articles Notés', 'notation-jlg' ),
+            'plateformes'    => __( '🎮 Plateformes', 'notation-jlg' ),
+            'shortcodes'     => __( '📝 Shortcodes', 'notation-jlg' ),
+            'tutoriels'      => __( '📚 Tutoriels', 'notation-jlg' ),
+        );
     }
 
-    private function get_tab_navigation_html(array $tabs, $active_tab) {
-        return JLG_Template_Loader::get_admin_template('partials/tab-navigation', [
-            'tabs' => $tabs,
-            'active_tab' => $active_tab,
-            'page_slug' => $this->page_slug,
-        ]);
+    private function get_tab_navigation_html( array $tabs, $active_tab ) {
+        return JLG_Template_Loader::get_admin_template(
+            'partials/tab-navigation',
+            array(
+				'tabs'       => $tabs,
+				'active_tab' => $active_tab,
+				'page_slug'  => $this->page_slug,
+			)
+        );
     }
 
-    private function get_tab_content($active_tab) {
-        switch ($active_tab) {
+    private function get_tab_content( $active_tab ) {
+        switch ( $active_tab ) {
             case 'articles_notes':
                 return $this->get_posts_list_tab_content();
             case 'plateformes':
@@ -83,162 +91,186 @@ class JLG_Admin_Menu {
     }
 
     private function get_settings_tab_content() {
-        return JLG_Template_Loader::get_admin_template('tabs/settings', [
-            'settings_page' => 'notation_jlg_page',
-        ]);
+        return JLG_Template_Loader::get_admin_template(
+            'tabs/settings',
+            array(
+				'settings_page' => 'notation_jlg_page',
+			)
+        );
     }
 
     private function get_posts_list_tab_content() {
-        $rated_posts = array_values(array_unique(array_filter(array_map('intval', JLG_Helpers::get_rated_post_ids()))));
-        $empty_state = [
-            'create_post_url' => admin_url('post-new.php'),
-        ];
+        $rated_posts = array_values( array_unique( array_filter( array_map( 'intval', JLG_Helpers::get_rated_post_ids() ) ) ) );
+        $empty_state = array(
+            'create_post_url' => admin_url( 'post-new.php' ),
+        );
 
-        if (empty($rated_posts)) {
-            return JLG_Template_Loader::get_admin_template('tabs/posts-list', [
-                'has_rated_posts' => false,
-                'empty_state' => $empty_state,
-            ]);
+        if ( empty( $rated_posts ) ) {
+            return JLG_Template_Loader::get_admin_template(
+                'tabs/posts-list',
+                array(
+					'has_rated_posts' => false,
+					'empty_state'     => $empty_state,
+				)
+            );
         }
 
-        $per_page = 30;
-        $current_page = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
-        $orderby = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'date';
-        $order = isset($_GET['order']) && in_array(strtoupper($_GET['order']), ['ASC', 'DESC'], true) ? strtoupper($_GET['order']) : 'DESC';
+        $per_page     = 30;
+        $current_page = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
+        $orderby      = isset( $_GET['orderby'] ) ? sanitize_key( $_GET['orderby'] ) : 'date';
+        $order        = isset( $_GET['order'] ) && in_array( strtoupper( $_GET['order'] ), array( 'ASC', 'DESC' ), true ) ? strtoupper( $_GET['order'] ) : 'DESC';
 
-        $args = [
-            'post_type' => JLG_Helpers::get_allowed_post_types(),
-            'post__in' => $rated_posts,
+        $args = array(
+            'post_type'      => JLG_Helpers::get_allowed_post_types(),
+            'post__in'       => $rated_posts,
             'posts_per_page' => $per_page,
-            'paged' => $current_page,
-            'orderby' => $orderby === 'score' ? 'meta_value_num' : $orderby,
-            'order' => $order,
-        ];
+            'paged'          => $current_page,
+            'orderby'        => $orderby === 'score' ? 'meta_value_num' : $orderby,
+            'order'          => $order,
+        );
 
-        if ($orderby === 'score') {
+        if ( $orderby === 'score' ) {
             $args['meta_key'] = '_jlg_average_score';
         }
 
-        $query = new WP_Query($args);
+        $query = new WP_Query( $args );
 
-        $posts = [];
-        if ($query->have_posts()) {
-            while ($query->have_posts()) {
+        $posts = array();
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
                 $query->the_post();
-                $post_id = get_the_ID();
-                $score_data = JLG_Helpers::get_resolved_average_score($post_id);
+                $post_id     = get_the_ID();
+                $score_data  = JLG_Helpers::get_resolved_average_score( $post_id );
                 $score_value = $score_data['value'];
 
                 $score_color = '#0073aa';
-                if ($score_value !== null) {
-                    if ($score_value >= 8) {
+                if ( $score_value !== null ) {
+                    if ( $score_value >= 8 ) {
                         $score_color = '#22c55e';
-                    } elseif ($score_value >= 5) {
+                    } elseif ( $score_value >= 5 ) {
                         $score_color = '#f97316';
                     } else {
                         $score_color = '#ef4444';
                     }
                 }
 
-                $categories = get_the_category($post_id);
-                $cat_names = array_map(function ($cat) {
-                    return $cat->name;
-                }, $categories);
+                $categories = get_the_category( $post_id );
+                $cat_names  = array_map(
+                    function ( $cat ) {
+						return $cat->name;
+					},
+                    $categories
+                );
 
-                $posts[] = [
-                    'title' => JLG_Helpers::get_game_title($post_id),
-                    'edit_link' => get_edit_post_link($post_id),
-                    'view_link' => get_permalink($post_id),
-                    'date' => get_the_date('d/m/Y', $post_id),
-                    'score_display' => $score_data['formatted'] ?? __('N/A', 'notation-jlg'),
-                    'score_color' => $score_color,
-                    'categories' => $cat_names,
-                ];
+                $posts[] = array(
+                    'title'         => JLG_Helpers::get_game_title( $post_id ),
+                    'edit_link'     => get_edit_post_link( $post_id ),
+                    'view_link'     => get_permalink( $post_id ),
+                    'date'          => get_the_date( 'd/m/Y', $post_id ),
+                    'score_display' => $score_data['formatted'] ?? __( 'N/A', 'notation-jlg' ),
+                    'score_color'   => $score_color,
+                    'categories'    => $cat_names,
+                );
             }
         }
 
         wp_reset_postdata();
 
-        $total_items = count($rated_posts);
-        $total_pages = (int) ceil($total_items / $per_page);
-        $pagination = '';
+        $total_items = count( $rated_posts );
+        $total_pages = (int) ceil( $total_items / $per_page );
+        $pagination  = '';
 
-        if ($total_pages > 1) {
-            $pagination_args = [
-                'base' => add_query_arg('paged', '%#%'),
-                'format' => '',
-                'prev_text' => '&laquo;',
-                'next_text' => '&raquo;',
-                'total' => $total_pages,
-                'current' => $current_page,
-                'show_all' => false,
-                'end_size' => 1,
-                'mid_size' => 2,
-                'type' => 'plain',
-                'before_page_number' => '<span class="screen-reader-text">' . esc_html__('Page ', 'notation-jlg') . '</span>',
-            ];
+        if ( $total_pages > 1 ) {
+            $pagination_args = array(
+                'base'               => add_query_arg( 'paged', '%#%' ),
+                'format'             => '',
+                'prev_text'          => '&laquo;',
+                'next_text'          => '&raquo;',
+                'total'              => $total_pages,
+                'current'            => $current_page,
+                'show_all'           => false,
+                'end_size'           => 1,
+                'mid_size'           => 2,
+                'type'               => 'plain',
+                'before_page_number' => '<span class="screen-reader-text">' . esc_html__( 'Page ', 'notation-jlg' ) . '</span>',
+            );
 
-            if (isset($_GET['orderby'])) {
-                $pagination_args['add_args'] = [
+            if ( isset( $_GET['orderby'] ) ) {
+                $pagination_args['add_args'] = array(
                     'orderby' => $orderby,
-                    'order' => $order,
-                ];
+                    'order'   => $order,
+                );
             }
 
-            $pagination = paginate_links($pagination_args);
+            $pagination = paginate_links( $pagination_args );
         }
 
-        return JLG_Template_Loader::get_admin_template('tabs/posts-list', [
-            'has_rated_posts' => true,
-            'empty_state' => $empty_state,
-            'stats' => [
-                'total_items' => $total_items,
-                'current_page' => $current_page,
-                'total_pages' => $total_pages,
-                'display_count' => count($posts),
-            ],
-            'columns' => $this->get_sortable_columns($orderby, $order),
-            'posts' => $posts,
-            'pagination' => $pagination,
-            'print_button_label' => __('🖨️ Imprimer cette liste', 'notation-jlg'),
-        ]);
+        return JLG_Template_Loader::get_admin_template(
+            'tabs/posts-list',
+            array(
+				'has_rated_posts'    => true,
+				'empty_state'        => $empty_state,
+				'stats'              => array(
+					'total_items'   => $total_items,
+					'current_page'  => $current_page,
+					'total_pages'   => $total_pages,
+					'display_count' => count( $posts ),
+				),
+				'columns'            => $this->get_sortable_columns( $orderby, $order ),
+				'posts'              => $posts,
+				'pagination'         => $pagination,
+				'print_button_label' => __( '🖨️ Imprimer cette liste', 'notation-jlg' ),
+			)
+        );
     }
 
-    private function get_sortable_columns($current_orderby, $current_order) {
-        $columns = [
-            ['label' => __('Titre', 'notation-jlg'), 'key' => 'title'],
-            ['label' => __('Date', 'notation-jlg'), 'key' => 'date'],
-            ['label' => __('Note', 'notation-jlg'), 'key' => 'score'],
-        ];
+    private function get_sortable_columns( $current_orderby, $current_order ) {
+        $columns = array(
+            array(
+				'label' => __( 'Titre', 'notation-jlg' ),
+				'key'   => 'title',
+			),
+            array(
+				'label' => __( 'Date', 'notation-jlg' ),
+				'key'   => 'date',
+			),
+            array(
+				'label' => __( 'Note', 'notation-jlg' ),
+				'key'   => 'score',
+			),
+        );
 
-        $results = [];
-        foreach ($columns as $column) {
+        $results = array();
+        foreach ( $columns as $column ) {
             $column_key = $column['key'];
-            $new_order = ($current_orderby === $column_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
+            $new_order  = ( $current_orderby === $column_key && $current_order === 'ASC' ) ? 'DESC' : 'ASC';
 
-            $class = 'manage-column column-' . $column_key;
+            $class     = 'manage-column column-' . $column_key;
             $aria_sort = 'none';
-            if ($current_orderby === $column_key) {
-                $class .= ' sorted ' . strtolower($current_order);
-                $aria_sort = ($current_order === 'ASC') ? 'ascending' : 'descending';
+            if ( $current_orderby === $column_key ) {
+                $class    .= ' sorted ' . strtolower( $current_order );
+                $aria_sort = ( $current_order === 'ASC' ) ? 'ascending' : 'descending';
             } else {
                 $class .= ' sortable desc';
             }
 
-            $url = add_query_arg([
-                'page' => $this->page_slug,
-                'tab' => 'articles_notes',
-                'orderby' => $column_key,
-                'order' => $new_order,
-                'paged' => 1,
-            ], admin_url('admin.php'));
+            $url = add_query_arg(
+                array(
+					'page'    => $this->page_slug,
+					'tab'     => 'articles_notes',
+					'orderby' => $column_key,
+					'order'   => $new_order,
+					'paged'   => 1,
+                ),
+                admin_url( 'admin.php' )
+            );
 
-            $results[] = [
-                'label' => $column['label'],
-                'class' => $class,
-                'url' => $url,
+            $results[] = array(
+                'label'     => $column['label'],
+                'class'     => $class,
+                'url'       => $url,
                 'aria_sort' => $aria_sort,
-            ];
+            );
         }
 
         return $results;
@@ -246,133 +278,135 @@ class JLG_Admin_Menu {
 
     private function get_platforms_tab_content() {
         ob_start();
-        echo '<h2 class="title">' . esc_html__('🎮 Gestion des Plateformes', 'notation-jlg') . '</h2>';
+        echo '<h2 class="title">' . esc_html__( '🎮 Gestion des Plateformes', 'notation-jlg' ) . '</h2>';
         $this->render_platforms_tab();
         return ob_get_clean();
     }
 
     private function render_platforms_tab() {
         // Utiliser l'instance singleton de la classe Platforms
-        if (class_exists('JLG_Admin_Platforms')) {
+        if ( class_exists( 'JLG_Admin_Platforms' ) ) {
             $platforms_manager = JLG_Admin_Platforms::get_instance();
             $platforms_manager->render_platforms_page();
         } else {
             // Si la classe n'existe pas, essayer de la charger
             $path = JLG_NOTATION_PLUGIN_DIR . 'includes/admin/class-jlg-admin-platforms.php';
-            if (file_exists($path)) {
+            if ( file_exists( $path ) ) {
                 require_once $path;
-                if (class_exists('JLG_Admin_Platforms')) {
+                if ( class_exists( 'JLG_Admin_Platforms' ) ) {
                     $platforms_manager = JLG_Admin_Platforms::get_instance();
                     $platforms_manager->render_platforms_page();
                 } else {
-                    echo '<div class="notice notice-error"><p>' . esc_html__('La classe de gestion des plateformes n\'a pas pu être chargée.', 'notation-jlg') . '</p></div>';
+                    echo '<div class="notice notice-error"><p>' . esc_html__( 'La classe de gestion des plateformes n\'a pas pu être chargée.', 'notation-jlg' ) . '</p></div>';
                 }
             } else {
-                echo '<div class="notice notice-error"><p>' . esc_html__('Fichier class-jlg-admin-platforms.php introuvable.', 'notation-jlg') . '</p></div>';
+                echo '<div class="notice notice-error"><p>' . esc_html__( 'Fichier class-jlg-admin-platforms.php introuvable.', 'notation-jlg' ) . '</p></div>';
             }
         }
     }
 
     private function get_shortcodes_tab_content() {
-        return JLG_Template_Loader::get_admin_template('tabs/shortcodes');
+        return JLG_Template_Loader::get_admin_template( 'tabs/shortcodes' );
     }
 
     private function get_tutorials_tab_content() {
-        $tutorials = [
-            [
-                'title' => __('⚡ Démarrage rapide avec le Bloc Complet', 'notation-jlg'),
-                'content' => __('La méthode la plus simple pour créer un test professionnel.', 'notation-jlg'),
-                'steps' => [
-                    __('Créer un nouvel article', 'notation-jlg'),
-                    __('Remplir les notes dans la metabox (colonne droite)', 'notation-jlg'),
-                    __('Ajouter tagline et points forts/faibles', 'notation-jlg'),
-                    __('Insérer [jlg_bloc_complet] dans le contenu', 'notation-jlg'),
-                    __('C\'est tout ! Publiez votre test', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('🎮 Créer un test détaillé (méthode classique)', 'notation-jlg'),
-                'content' => __('Guide pas-à-pas pour un contrôle total.', 'notation-jlg'),
-                'steps' => [
-                    __('Créer un nouvel article', 'notation-jlg'),
-                    __('Remplir la metabox "Notation" (colonne droite)', 'notation-jlg'),
-                    __('Ajouter les détails du jeu (metabox principale)', 'notation-jlg'),
-                    __('Intégrer les shortcodes séparés si besoin', 'notation-jlg'),
-                    __('Publier et vérifier l\'affichage', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('🎨 Personnalisation du Bloc Complet', 'notation-jlg'),
-                'content' => __('Créez un rendu unique.', 'notation-jlg'),
-                'steps' => [
-                    __('Choisir le style (moderne/classique/compact)', 'notation-jlg'),
-                    __('Définir une couleur d\'accent personnalisée', 'notation-jlg'),
-                    __('Activer/désactiver les sections', 'notation-jlg'),
-                    __('Personnaliser les titres des sections', 'notation-jlg'),
-                    __('Combiner avec d\'autres shortcodes si besoin', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('🎨 Personnalisation visuelle globale', 'notation-jlg'),
-                'content' => __('Ajuster l\'apparence générale.', 'notation-jlg'),
-                'steps' => [
-                    __('Choisir le thème (clair/sombre)', 'notation-jlg'),
-                    __('Activer les effets Neon/Glow', 'notation-jlg'),
-                    __('Configurer la pulsation', 'notation-jlg'),
-                    __('Personnaliser les couleurs', 'notation-jlg'),
-                    __('Ajouter du CSS personnalisé', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('📊 Tableau récapitulatif avancé', 'notation-jlg'),
-                'content' => __('Maîtriser le shortcode tableau.', 'notation-jlg'),
-                'steps' => [
-                    __('Choisir entre table et grille', 'notation-jlg'),
-                    __('Sélectionner les colonnes à afficher', 'notation-jlg'),
-                    __('Filtrer par catégorie', 'notation-jlg'),
-                    __('Ajuster la pagination', 'notation-jlg'),
-                    __('Personnaliser les couleurs dans Réglages', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('⚡ Optimisations', 'notation-jlg'),
-                'content' => __('Améliorer les performances.', 'notation-jlg'),
-                'steps' => [
-                    __('Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes', 'notation-jlg'),
-                    __('Activer un plugin de cache', 'notation-jlg'),
-                    __('Optimiser les images de couverture', 'notation-jlg'),
-                    __('Limiter le nombre d\'articles affichés', 'notation-jlg'),
-                    __('Désactiver les animations si non nécessaires', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('🔧 Intégration dans le thème', 'notation-jlg'),
-                'content' => __('Pour les développeurs.', 'notation-jlg'),
-                'steps' => [
-                    __('Ajouter jlg_display_thumbnail_score() dans les templates', 'notation-jlg'),
-                    __('Utiliser jlg_get_post_rating() pour récupérer la note', 'notation-jlg'),
-                    __('Personnaliser les templates dans /templates/', 'notation-jlg'),
-                    __('Créer des hooks personnalisés', 'notation-jlg'),
-                    __('Surcharger les styles CSS du plugin', 'notation-jlg'),
-                ],
-            ],
-            [
-                'title' => __('❓ Dépannage', 'notation-jlg'),
-                'content' => __('Résoudre les problèmes courants.', 'notation-jlg'),
-                'steps' => [
-                    __('Vérifier les conflits de plugins', 'notation-jlg'),
-                    __('Vider le cache navigateur et site', 'notation-jlg'),
-                    __('Vérifier les permissions utilisateur', 'notation-jlg'),
-                    __('Consulter les logs d\'erreur', 'notation-jlg'),
-                    __('Réinitialiser les réglages si nécessaire', 'notation-jlg'),
-                ],
-            ],
-        ];
+        $tutorials = array(
+            array(
+                'title'   => __( '⚡ Démarrage rapide avec le Bloc Complet', 'notation-jlg' ),
+                'content' => __( 'La méthode la plus simple pour créer un test professionnel.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Créer un nouvel article', 'notation-jlg' ),
+                    __( 'Remplir les notes dans la metabox (colonne droite)', 'notation-jlg' ),
+                    __( 'Ajouter tagline et points forts/faibles', 'notation-jlg' ),
+                    __( 'Insérer [jlg_bloc_complet] dans le contenu', 'notation-jlg' ),
+                    __( 'C\'est tout ! Publiez votre test', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '🎮 Créer un test détaillé (méthode classique)', 'notation-jlg' ),
+                'content' => __( 'Guide pas-à-pas pour un contrôle total.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Créer un nouvel article', 'notation-jlg' ),
+                    __( 'Remplir la metabox "Notation" (colonne droite)', 'notation-jlg' ),
+                    __( 'Ajouter les détails du jeu (metabox principale)', 'notation-jlg' ),
+                    __( 'Intégrer les shortcodes séparés si besoin', 'notation-jlg' ),
+                    __( 'Publier et vérifier l\'affichage', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '🎨 Personnalisation du Bloc Complet', 'notation-jlg' ),
+                'content' => __( 'Créez un rendu unique.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Choisir le style (moderne/classique/compact)', 'notation-jlg' ),
+                    __( 'Définir une couleur d\'accent personnalisée', 'notation-jlg' ),
+                    __( 'Activer/désactiver les sections', 'notation-jlg' ),
+                    __( 'Personnaliser les titres des sections', 'notation-jlg' ),
+                    __( 'Combiner avec d\'autres shortcodes si besoin', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '🎨 Personnalisation visuelle globale', 'notation-jlg' ),
+                'content' => __( 'Ajuster l\'apparence générale.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Choisir le thème (clair/sombre)', 'notation-jlg' ),
+                    __( 'Activer les effets Neon/Glow', 'notation-jlg' ),
+                    __( 'Configurer la pulsation', 'notation-jlg' ),
+                    __( 'Personnaliser les couleurs', 'notation-jlg' ),
+                    __( 'Ajouter du CSS personnalisé', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '📊 Tableau récapitulatif avancé', 'notation-jlg' ),
+                'content' => __( 'Maîtriser le shortcode tableau.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Choisir entre table et grille', 'notation-jlg' ),
+                    __( 'Sélectionner les colonnes à afficher', 'notation-jlg' ),
+                    __( 'Filtrer par catégorie', 'notation-jlg' ),
+                    __( 'Ajuster la pagination', 'notation-jlg' ),
+                    __( 'Personnaliser les couleurs dans Réglages', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '⚡ Optimisations', 'notation-jlg' ),
+                'content' => __( 'Améliorer les performances.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes', 'notation-jlg' ),
+                    __( 'Activer un plugin de cache', 'notation-jlg' ),
+                    __( 'Optimiser les images de couverture', 'notation-jlg' ),
+                    __( 'Limiter le nombre d\'articles affichés', 'notation-jlg' ),
+                    __( 'Désactiver les animations si non nécessaires', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '🔧 Intégration dans le thème', 'notation-jlg' ),
+                'content' => __( 'Pour les développeurs.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Ajouter jlg_display_thumbnail_score() dans les templates', 'notation-jlg' ),
+                    __( 'Utiliser jlg_get_post_rating() pour récupérer la note', 'notation-jlg' ),
+                    __( 'Personnaliser les templates dans /templates/', 'notation-jlg' ),
+                    __( 'Créer des hooks personnalisés', 'notation-jlg' ),
+                    __( 'Surcharger les styles CSS du plugin', 'notation-jlg' ),
+                ),
+            ),
+            array(
+                'title'   => __( '❓ Dépannage', 'notation-jlg' ),
+                'content' => __( 'Résoudre les problèmes courants.', 'notation-jlg' ),
+                'steps'   => array(
+                    __( 'Vérifier les conflits de plugins', 'notation-jlg' ),
+                    __( 'Vider le cache navigateur et site', 'notation-jlg' ),
+                    __( 'Vérifier les permissions utilisateur', 'notation-jlg' ),
+                    __( 'Consulter les logs d\'erreur', 'notation-jlg' ),
+                    __( 'Réinitialiser les réglages si nécessaire', 'notation-jlg' ),
+                ),
+            ),
+        );
 
-        return JLG_Template_Loader::get_admin_template('tabs/tutorials', [
-            'tutorials' => $tutorials,
-            'platforms_url' => admin_url('admin.php?page=' . $this->page_slug . '&tab=plateformes'),
-        ]);
+        return JLG_Template_Loader::get_admin_template(
+            'tabs/tutorials',
+            array(
+				'tutorials'     => $tutorials,
+				'platforms_url' => admin_url( 'admin.php?page=' . $this->page_slug . '&tab=plateformes' ),
+			)
+        );
     }
 }
-

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -1,18 +1,20 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Metaboxes {
     private $error_transient_key = '';
 
     public function __construct() {
-        add_action('add_meta_boxes', [$this, 'register_metaboxes'], 10, 2);
-        add_action('save_post', [$this, 'save_meta_data']);
-        add_action('admin_notices', [$this, 'display_validation_errors']);
+        add_action( 'add_meta_boxes', array( $this, 'register_metaboxes' ), 10, 2 );
+        add_action( 'save_post', array( $this, 'save_meta_data' ) );
+        add_action( 'admin_notices', array( $this, 'display_validation_errors' ) );
     }
 
     private function get_error_transient_key() {
-        if ($this->error_transient_key === '') {
-            $user_id = get_current_user_id();
+        if ( $this->error_transient_key === '' ) {
+            $user_id                   = get_current_user_id();
             $this->error_transient_key = 'jlg_metabox_errors_' . (int) $user_id;
         }
 
@@ -20,31 +22,31 @@ class JLG_Admin_Metaboxes {
     }
 
     public function display_validation_errors() {
-        $errors = get_transient($this->get_error_transient_key());
+        $errors = get_transient( $this->get_error_transient_key() );
 
-        if (empty($errors) || !is_array($errors)) {
+        if ( empty( $errors ) || ! is_array( $errors ) ) {
             return;
         }
 
-        delete_transient($this->get_error_transient_key());
+        delete_transient( $this->get_error_transient_key() );
 
-        echo '<div class="notice notice-error"><p><strong>' . esc_html__('Notation JLG', 'notation-jlg') . ' :</strong></p><ul>';
-        foreach ($errors as $error) {
-            echo '<li>' . esc_html($error) . '</li>';
+        echo '<div class="notice notice-error"><p><strong>' . esc_html__( 'Notation JLG', 'notation-jlg' ) . ' :</strong></p><ul>';
+        foreach ( $errors as $error ) {
+            echo '<li>' . esc_html( $error ) . '</li>';
         }
         echo '</ul></div>';
     }
 
-    public function register_metaboxes($post_type, $post = null) {
+    public function register_metaboxes( $post_type, $post = null ) {
         // Vérifier qu'on est bien sur un post
-        if ($post_type !== 'post') {
+        if ( $post_type !== 'post' ) {
             return;
         }
 
         add_meta_box(
             'notation_jlg_metabox',
-            esc_html__('⭐ Notation du Jeu Vidéo', 'notation-jlg'),
-            [$this, 'render_notation_metabox'],
+            esc_html__( '⭐ Notation du Jeu Vidéo', 'notation-jlg' ),
+            array( $this, 'render_notation_metabox' ),
             $post_type,
             'side',
             'high'
@@ -52,336 +54,342 @@ class JLG_Admin_Metaboxes {
 
         add_meta_box(
             'jlg_details_metabox',
-            esc_html__('🎮 Détails du Test', 'notation-jlg'),
-            [$this, 'render_details_metabox'],
+            esc_html__( '🎮 Détails du Test', 'notation-jlg' ),
+            array( $this, 'render_details_metabox' ),
             $post_type,
             'normal',
             'high'
         );
     }
 
-    public function render_notation_metabox($post) {
+    public function render_notation_metabox( $post ) {
         // Vérification de sécurité
-        if (!$post || $post->post_type !== 'post') {
+        if ( ! $post || $post->post_type !== 'post' ) {
             return;
         }
-        
-        wp_nonce_field('jlg_save_notes_data', 'jlg_notation_nonce');
-        
+
+        wp_nonce_field( 'jlg_save_notes_data', 'jlg_notation_nonce' );
+
         // Récupérer les catégories de notation
-        $categories = [
-            'cat1' => __('Gameplay', 'notation-jlg'),
-            'cat2' => __('Graphismes', 'notation-jlg'),
-            'cat3' => __('Bande-son', 'notation-jlg'),
-            'cat4' => __('Durée de vie', 'notation-jlg'),
-            'cat5' => __('Scénario', 'notation-jlg'),
-            'cat6' => __('Originalité', 'notation-jlg')
-        ];
-        
+        $categories = array(
+            'cat1' => __( 'Gameplay', 'notation-jlg' ),
+            'cat2' => __( 'Graphismes', 'notation-jlg' ),
+            'cat3' => __( 'Bande-son', 'notation-jlg' ),
+            'cat4' => __( 'Durée de vie', 'notation-jlg' ),
+            'cat5' => __( 'Scénario', 'notation-jlg' ),
+            'cat6' => __( 'Originalité', 'notation-jlg' ),
+        );
+
         // Si la classe Helpers existe, on l'utilise
-        if (class_exists('JLG_Helpers')) {
-            $categories = JLG_Helpers::get_rating_categories();
-            $average_score = JLG_Helpers::get_average_score_for_post($post->ID);
+        if ( class_exists( 'JLG_Helpers' ) ) {
+            $categories    = JLG_Helpers::get_rating_categories();
+            $average_score = JLG_Helpers::get_average_score_for_post( $post->ID );
         } else {
             $average_score = null;
         }
-        
+
         echo '<div class="jlg-metabox-notation">';
-        echo '<p>' . esc_html__('Entrez les notes sur 10. Laissez vide si non pertinent.', 'notation-jlg') . '</p>';
-        
-        foreach ($categories as $key => $label) {
-            $value = get_post_meta($post->ID, '_note_' . $key, true);
+        echo '<p>' . esc_html__( 'Entrez les notes sur 10. Laissez vide si non pertinent.', 'notation-jlg' ) . '</p>';
+
+        foreach ( $categories as $key => $label ) {
+            $value = get_post_meta( $post->ID, '_note_' . $key, true );
             echo '<div style="margin-bottom:10px;">';
-            echo '<label><strong>' . esc_html($label) . ' :</strong></label><br>';
-            echo '<input type="number" step="0.1" min="0" max="10" name="_note_' . esc_attr($key) . '" value="' . esc_attr($value) . '" style="width:80px;" /> ' . esc_html_x('/ 10', 'score input suffix', 'notation-jlg');
+            echo '<label><strong>' . esc_html( $label ) . ' :</strong></label><br>';
+            echo '<input type="number" step="0.1" min="0" max="10" name="_note_' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" style="width:80px;" /> ' . esc_html_x( '/ 10', 'score input suffix', 'notation-jlg' );
             echo '</div>';
         }
-        
-        if ($average_score !== null) {
+
+        if ( $average_score !== null ) {
             echo '<div style="background:#f0f6fc; padding:10px; margin-top:15px; border-radius:4px;">';
             $average_display = sprintf(
                 /* translators: %s: average score value. */
-                __('%s / 10', 'notation-jlg'),
-                number_format_i18n($average_score, 1)
+                __( '%s / 10', 'notation-jlg' ),
+                number_format_i18n( $average_score, 1 )
             );
-            echo '<strong>' . esc_html__('Note moyenne :', 'notation-jlg') . '</strong> <span style="color:#0073aa; font-size:16px;">' . esc_html($average_display) . '</span>';
+            echo '<strong>' . esc_html__( 'Note moyenne :', 'notation-jlg' ) . '</strong> <span style="color:#0073aa; font-size:16px;">' . esc_html( $average_display ) . '</span>';
             echo '</div>';
         }
-        
+
         echo '</div>';
     }
 
-    public function render_details_metabox($post) {
+    public function render_details_metabox( $post ) {
         // Vérification de sécurité
-        if (!$post || $post->post_type !== 'post') {
+        if ( ! $post || $post->post_type !== 'post' ) {
             return;
         }
-        
-        wp_nonce_field('jlg_save_details_data', 'jlg_details_nonce');
-        
+
+        wp_nonce_field( 'jlg_save_details_data', 'jlg_details_nonce' );
+
         // Récupérer les métadonnées
-        $meta = [];
-        $keys = ['game_title', 'tagline_fr', 'tagline_en', 'points_forts', 'points_faibles', 'developpeur', 'editeur', 'date_sortie', 'version', 'pegi', 'temps_de_jeu', 'plateformes', 'cover_image_url'];
-        foreach ($keys as $key) {
-            $meta[$key] = get_post_meta($post->ID, '_jlg_' . $key, true);
+        $meta = array();
+        $keys = array( 'game_title', 'tagline_fr', 'tagline_en', 'points_forts', 'points_faibles', 'developpeur', 'editeur', 'date_sortie', 'version', 'pegi', 'temps_de_jeu', 'plateformes', 'cover_image_url' );
+        foreach ( $keys as $key ) {
+            $meta[ $key ] = get_post_meta( $post->ID, '_jlg_' . $key, true );
         }
 
         echo '<div class="jlg-metabox-details">';
 
         echo '<div style="margin-bottom:20px;">';
-        echo '<label for="jlg_game_title"><strong>' . esc_html__('Nom du jeu', 'notation-jlg') . ' :</strong></label><br>';
-        echo '<input type="text" id="jlg_game_title" name="jlg_game_title" value="' . esc_attr($meta['game_title'] ?? '') . '" style="width:100%;">';
-        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__('Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée.', 'notation-jlg') . '</p>';
+        echo '<label for="jlg_game_title"><strong>' . esc_html__( 'Nom du jeu', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="text" id="jlg_game_title" name="jlg_game_title" value="' . esc_attr( $meta['game_title'] ?? '' ) . '" style="width:100%;">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée.', 'notation-jlg' ) . '</p>';
         echo '</div>';
 
         // Fiche technique
-        echo '<h3>' . esc_html__('📋 Fiche Technique', 'notation-jlg') . '</h3>';
+        echo '<h3>' . esc_html__( '📋 Fiche Technique', 'notation-jlg' ) . '</h3>';
         echo '<div style="display:grid; grid-template-columns:repeat(3,1fr); gap:15px; margin-bottom:20px;">';
 
-        $fields = [
-            'developpeur' => __('Développeur(s)', 'notation-jlg'),
-            'editeur' => __('Éditeur(s)', 'notation-jlg'),
-            'date_sortie' => __('Date de sortie', 'notation-jlg'),
-            'version' => __('Version testée', 'notation-jlg'),
-            'pegi' => __('PEGI', 'notation-jlg'),
-            'temps_de_jeu' => __('Temps de jeu', 'notation-jlg'),
-            'cover_image_url' => __('URL de la jaquette', 'notation-jlg')
-        ];
+        $fields = array(
+            'developpeur'     => __( 'Développeur(s)', 'notation-jlg' ),
+            'editeur'         => __( 'Éditeur(s)', 'notation-jlg' ),
+            'date_sortie'     => __( 'Date de sortie', 'notation-jlg' ),
+            'version'         => __( 'Version testée', 'notation-jlg' ),
+            'pegi'            => __( 'PEGI', 'notation-jlg' ),
+            'temps_de_jeu'    => __( 'Temps de jeu', 'notation-jlg' ),
+            'cover_image_url' => __( 'URL de la jaquette', 'notation-jlg' ),
+        );
 
-        foreach ($fields as $key => $label) {
-            $type = ($key === 'date_sortie') ? 'date' : 'text';
+        foreach ( $fields as $key => $label ) {
+            $type = ( $key === 'date_sortie' ) ? 'date' : 'text';
             echo '<div>';
-            echo '<label><strong>' . esc_html($label) . ' :</strong></label><br>';
-            $id_attribute = ($key === 'cover_image_url') ? ' id="jlg_cover_image_url"' : '';
-            echo '<input type="' . $type . '" name="jlg_' . esc_attr($key) . '"' . $id_attribute . ' value="' . esc_attr($meta[$key] ?? '') . '" style="width:100%;">';
+            echo '<label><strong>' . esc_html( $label ) . ' :</strong></label><br>';
+            $id_attribute = ( $key === 'cover_image_url' ) ? ' id="jlg_cover_image_url"' : '';
+            echo '<input type="' . $type . '" name="jlg_' . esc_attr( $key ) . '"' . $id_attribute . ' value="' . esc_attr( $meta[ $key ] ?? '' ) . '" style="width:100%;">';
             echo '</div>';
         }
-        
+
         echo '</div>';
-        
+
         // Plateformes
         echo '<div style="margin-bottom:20px;">';
-        echo '<p><strong>' . esc_html__('Plateformes :', 'notation-jlg') . '</strong></p>';
-        
-        // Récupérer les plateformes depuis la classe JLG_Admin_Platforms
-        $platforms_list = [
-            'PC' => __('PC', 'notation-jlg'),
-            'PlayStation 5' => __('PlayStation 5', 'notation-jlg'),
-            'Xbox Series S/X' => __('Xbox Series S/X', 'notation-jlg'),
-            'Nintendo Switch' => __('Nintendo Switch', 'notation-jlg'),
-            'PlayStation 4' => __('PlayStation 4', 'notation-jlg'),
-            'Xbox One' => __('Xbox One', 'notation-jlg'),
-        ];
+        echo '<p><strong>' . esc_html__( 'Plateformes :', 'notation-jlg' ) . '</strong></p>';
 
-        if (class_exists('JLG_Admin_Platforms')) {
+        // Récupérer les plateformes depuis la classe JLG_Admin_Platforms
+        $platforms_list = array(
+            'PC'              => __( 'PC', 'notation-jlg' ),
+            'PlayStation 5'   => __( 'PlayStation 5', 'notation-jlg' ),
+            'Xbox Series S/X' => __( 'Xbox Series S/X', 'notation-jlg' ),
+            'Nintendo Switch' => __( 'Nintendo Switch', 'notation-jlg' ),
+            'PlayStation 4'   => __( 'PlayStation 4', 'notation-jlg' ),
+            'Xbox One'        => __( 'Xbox One', 'notation-jlg' ),
+        );
+
+        if ( class_exists( 'JLG_Admin_Platforms' ) ) {
             $platforms_manager = JLG_Admin_Platforms::get_instance();
-            $all_platforms = $platforms_manager->get_platform_names();
-            if (!empty($all_platforms)) {
-                $platforms_list = array_values($all_platforms);
+            $all_platforms     = $platforms_manager->get_platform_names();
+            if ( ! empty( $all_platforms ) ) {
+                $platforms_list = array_values( $all_platforms );
             }
         }
 
-        $selected = is_array($meta['plateformes']) ? $meta['plateformes'] : [];
+        $selected = is_array( $meta['plateformes'] ) ? $meta['plateformes'] : array();
 
-        foreach ($platforms_list as $platform_value => $platform_label) {
-            if (is_int($platform_value)) {
+        foreach ( $platforms_list as $platform_value => $platform_label ) {
+            if ( is_int( $platform_value ) ) {
                 $platform_value = $platform_label;
             }
 
             $display_label = $platform_label;
-            $checked = in_array($platform_value, $selected) ? 'checked' : '';
+            $checked       = in_array( $platform_value, $selected ) ? 'checked' : '';
             echo '<label style="margin-right:15px;">';
-            echo '<input type="checkbox" name="jlg_plateformes[]" value="' . esc_attr($platform_value) . '" ' . $checked . '> ';
-            echo esc_html($display_label);
+            echo '<input type="checkbox" name="jlg_plateformes[]" value="' . esc_attr( $platform_value ) . '" ' . $checked . '> ';
+            echo esc_html( $display_label );
             echo '</label>';
         }
         echo '</div>';
-        
+
         // Taglines
-        echo '<h3>' . esc_html__('💬 Taglines', 'notation-jlg') . '</h3>';
+        echo '<h3>' . esc_html__( '💬 Taglines', 'notation-jlg' ) . '</h3>';
         echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px; margin-bottom:20px;">';
         echo '<div>';
-        echo '<label><strong>' . esc_html__('Française :', 'notation-jlg') . '</strong></label><br>';
-        echo '<textarea name="jlg_tagline_fr" rows="3" style="width:100%;">' . esc_textarea($meta['tagline_fr'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__( 'Française :', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<textarea name="jlg_tagline_fr" rows="3" style="width:100%;">' . esc_textarea( $meta['tagline_fr'] ?? '' ) . '</textarea>';
         echo '</div>';
         echo '<div>';
-        echo '<label><strong>' . esc_html__('Anglaise :', 'notation-jlg') . '</strong></label><br>';
-        echo '<textarea name="jlg_tagline_en" rows="3" style="width:100%;">' . esc_textarea($meta['tagline_en'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__( 'Anglaise :', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<textarea name="jlg_tagline_en" rows="3" style="width:100%;">' . esc_textarea( $meta['tagline_en'] ?? '' ) . '</textarea>';
         echo '</div>';
         echo '</div>';
 
         // Points forts/faibles
-        echo '<h3>' . esc_html__('⚖️ Points Forts & Faibles', 'notation-jlg') . '</h3>';
-        echo '<p style="font-style:italic;">' . esc_html__('Un point par ligne', 'notation-jlg') . '</p>';
+        echo '<h3>' . esc_html__( '⚖️ Points Forts & Faibles', 'notation-jlg' ) . '</h3>';
+        echo '<p style="font-style:italic;">' . esc_html__( 'Un point par ligne', 'notation-jlg' ) . '</p>';
         echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px;">';
         echo '<div>';
-        echo '<label><strong>' . esc_html__('Points Forts :', 'notation-jlg') . '</strong></label><br>';
-        echo '<textarea name="jlg_points_forts" rows="8" style="width:100%;" placeholder="' . esc_attr__("Gameplay addictif\nGraphismes superbes", 'notation-jlg') . '">' . esc_textarea($meta['points_forts'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__( 'Points Forts :', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<textarea name="jlg_points_forts" rows="8" style="width:100%;" placeholder="' . esc_attr__( "Gameplay addictif\nGraphismes superbes", 'notation-jlg' ) . '">' . esc_textarea( $meta['points_forts'] ?? '' ) . '</textarea>';
         echo '</div>';
         echo '<div>';
-        echo '<label><strong>' . esc_html__('Points Faibles :', 'notation-jlg') . '</strong></label><br>';
-        echo '<textarea name="jlg_points_faibles" rows="8" style="width:100%;" placeholder="' . esc_attr__("Durée de vie courte\nBugs occasionnels", 'notation-jlg') . '">' . esc_textarea($meta['points_faibles'] ?? '') . '</textarea>';
+        echo '<label><strong>' . esc_html__( 'Points Faibles :', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<textarea name="jlg_points_faibles" rows="8" style="width:100%;" placeholder="' . esc_attr__( "Durée de vie courte\nBugs occasionnels", 'notation-jlg' ) . '">' . esc_textarea( $meta['points_faibles'] ?? '' ) . '</textarea>';
         echo '</div>';
         echo '</div>';
-        
+
         echo '</div>';
     }
 
-    public function save_meta_data($post_id) {
+    public function save_meta_data( $post_id ) {
         // Vérifications de base
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
             return;
         }
-        
-        if (!current_user_can('edit_post', $post_id)) {
+
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
             return;
         }
-        
+
         // Vérifier le type de post
-        if (get_post_type($post_id) !== 'post') {
+        if ( get_post_type( $post_id ) !== 'post' ) {
             return;
         }
 
         // Sauvegarder les notes
-        if (isset($_POST['jlg_notation_nonce']) && wp_verify_nonce($_POST['jlg_notation_nonce'], 'jlg_save_notes_data')) {
-            $categories = ['cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6'];
+        if ( isset( $_POST['jlg_notation_nonce'] ) && wp_verify_nonce( $_POST['jlg_notation_nonce'], 'jlg_save_notes_data' ) ) {
+            $categories     = array( 'cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6' );
             $scores_changed = false;
 
-            foreach ($categories as $key) {
+            foreach ( $categories as $key ) {
                 $field_name = '_note_' . $key;
-                if (isset($_POST[$field_name])) {
-                    $raw_value = wp_unslash($_POST[$field_name]);
-                    $value = sanitize_text_field($raw_value);
+                if ( isset( $_POST[ $field_name ] ) ) {
+                    $raw_value = wp_unslash( $_POST[ $field_name ] );
+                    $value     = sanitize_text_field( $raw_value );
 
-                    if ($value === '') {
-                        $deleted = delete_post_meta($post_id, $field_name);
+                    if ( $value === '' ) {
+                        $deleted        = delete_post_meta( $post_id, $field_name );
                         $scores_changed = $scores_changed || (bool) $deleted;
-                    } elseif (is_numeric($value) && $value >= 0 && $value <= 10) {
-                        $updated = update_post_meta($post_id, $field_name, round(floatval($value), 1));
+                    } elseif ( is_numeric( $value ) && $value >= 0 && $value <= 10 ) {
+                        $updated        = update_post_meta( $post_id, $field_name, round( floatval( $value ), 1 ) );
                         $scores_changed = $scores_changed || (bool) $updated;
                     }
                 }
             }
 
             // Recalculer la moyenne si la classe Helpers existe
-            if (class_exists('JLG_Helpers')) {
-                $average = JLG_Helpers::get_average_score_for_post($post_id);
-                if ($average !== null) {
-                    update_post_meta($post_id, '_jlg_average_score', $average);
+            if ( class_exists( 'JLG_Helpers' ) ) {
+                $average = JLG_Helpers::get_average_score_for_post( $post_id );
+                if ( $average !== null ) {
+                    update_post_meta( $post_id, '_jlg_average_score', $average );
                 } else {
-                    delete_post_meta($post_id, '_jlg_average_score');
+                    delete_post_meta( $post_id, '_jlg_average_score' );
                 }
 
-                if ($scores_changed) {
+                if ( $scores_changed ) {
                     JLG_Helpers::clear_rated_post_ids_cache();
                 }
             }
         }
 
-        $validation_errors = [];
+        $validation_errors = array();
 
         // Sauvegarder les détails
-        if (isset($_POST['jlg_details_nonce']) && wp_verify_nonce($_POST['jlg_details_nonce'], 'jlg_save_details_data')) {
+        if ( isset( $_POST['jlg_details_nonce'] ) && wp_verify_nonce( $_POST['jlg_details_nonce'], 'jlg_save_details_data' ) ) {
             // Champs texte simples
-            $text_fields = [
-                'game_title' => __('Nom du jeu', 'notation-jlg'),
-                'developpeur' => __('Développeur(s)', 'notation-jlg'),
-                'editeur' => __('Éditeur(s)', 'notation-jlg'),
-                'date_sortie' => __('Date de sortie', 'notation-jlg'),
-                'version' => __('Version testée', 'notation-jlg'),
-                'pegi' => __('PEGI', 'notation-jlg'),
-                'temps_de_jeu' => __('Temps de jeu', 'notation-jlg'),
-            ];
-            foreach ($text_fields as $field => $label) {
-                if (isset($_POST['jlg_' . $field])) {
-                    $raw_value = wp_unslash($_POST['jlg_' . $field]);
-                    $value = sanitize_text_field($raw_value);
-                    if ($field === 'game_title' && $value !== '') {
-                        if (function_exists('mb_substr')) {
-                            $value = mb_substr($value, 0, 150);
+            $text_fields = array(
+                'game_title'   => __( 'Nom du jeu', 'notation-jlg' ),
+                'developpeur'  => __( 'Développeur(s)', 'notation-jlg' ),
+                'editeur'      => __( 'Éditeur(s)', 'notation-jlg' ),
+                'date_sortie'  => __( 'Date de sortie', 'notation-jlg' ),
+                'version'      => __( 'Version testée', 'notation-jlg' ),
+                'pegi'         => __( 'PEGI', 'notation-jlg' ),
+                'temps_de_jeu' => __( 'Temps de jeu', 'notation-jlg' ),
+            );
+            foreach ( $text_fields as $field => $label ) {
+                if ( isset( $_POST[ 'jlg_' . $field ] ) ) {
+                    $raw_value = wp_unslash( $_POST[ 'jlg_' . $field ] );
+                    $value     = sanitize_text_field( $raw_value );
+                    if ( $field === 'game_title' && $value !== '' ) {
+                        if ( function_exists( 'mb_substr' ) ) {
+                            $value = mb_substr( $value, 0, 150 );
                         } else {
-                            $value = substr($value, 0, 150);
+                            $value = substr( $value, 0, 150 );
                         }
                     }
-                    if ($value === '') {
-                        delete_post_meta($post_id, '_jlg_' . $field);
+                    if ( $value === '' ) {
+                        delete_post_meta( $post_id, '_jlg_' . $field );
                         continue;
                     }
 
-                    if ($field === 'date_sortie') {
-                        $sanitized_date = JLG_Validator::sanitize_date($value);
-                        if ($sanitized_date === null) {
-                            delete_post_meta($post_id, '_jlg_' . $field);
+                    if ( $field === 'date_sortie' ) {
+                        $sanitized_date = JLG_Validator::sanitize_date( $value );
+                        if ( $sanitized_date === null ) {
+                            delete_post_meta( $post_id, '_jlg_' . $field );
                             $validation_errors[] = sprintf(
                                 /* translators: %s is the field label. */
-                                __('%s : format de date invalide. Utilisez AAAA-MM-JJ.', 'notation-jlg'),
+                                __( '%s : format de date invalide. Utilisez AAAA-MM-JJ.', 'notation-jlg' ),
                                 $label
                             );
                             continue;
                         }
 
-                        update_post_meta($post_id, '_jlg_' . $field, $sanitized_date);
+                        update_post_meta( $post_id, '_jlg_' . $field, $sanitized_date );
                         continue;
                     }
 
-                    if ($field === 'pegi') {
-                        if (!JLG_Validator::validate_pegi($value, false)) {
-                            delete_post_meta($post_id, '_jlg_' . $field);
+                    if ( $field === 'pegi' ) {
+                        if ( ! JLG_Validator::validate_pegi( $value, false ) ) {
+                            delete_post_meta( $post_id, '_jlg_' . $field );
                             $validation_errors[] = sprintf(
                                 /* translators: %s is a list of allowed PEGI values */
-                                __('PEGI invalide. Valeurs acceptées : %s.', 'notation-jlg'),
-                                implode(', ', array_map(function($rating) {
-                                    return 'PEGI ' . $rating;
-                                }, JLG_Validator::get_allowed_pegi_values()))
+                                __( 'PEGI invalide. Valeurs acceptées : %s.', 'notation-jlg' ),
+                                implode(
+                                    ', ',
+                                    array_map(
+                                        function ( $rating ) {
+                                            return 'PEGI ' . $rating;
+                                        },
+                                        JLG_Validator::get_allowed_pegi_values()
+                                    )
+                                )
                             );
                             continue;
                         }
 
-                        $sanitized_pegi = JLG_Validator::sanitize_pegi($value);
-                        update_post_meta($post_id, '_jlg_' . $field, $sanitized_pegi);
+                        $sanitized_pegi = JLG_Validator::sanitize_pegi( $value );
+                        update_post_meta( $post_id, '_jlg_' . $field, $sanitized_pegi );
                         continue;
                     }
 
-                    update_post_meta($post_id, '_jlg_' . $field, $value);
+                    update_post_meta( $post_id, '_jlg_' . $field, $value );
                 }
             }
 
-            if (isset($_POST['jlg_cover_image_url'])) {
-                $cover_image_url = esc_url_raw(wp_unslash($_POST['jlg_cover_image_url']));
-                if (!empty($cover_image_url)) {
-                    update_post_meta($post_id, '_jlg_cover_image_url', $cover_image_url);
+            if ( isset( $_POST['jlg_cover_image_url'] ) ) {
+                $cover_image_url = esc_url_raw( wp_unslash( $_POST['jlg_cover_image_url'] ) );
+                if ( ! empty( $cover_image_url ) ) {
+                    update_post_meta( $post_id, '_jlg_cover_image_url', $cover_image_url );
                 } else {
-                    delete_post_meta($post_id, '_jlg_cover_image_url');
+                    delete_post_meta( $post_id, '_jlg_cover_image_url' );
                 }
             }
 
             // Champs textarea
-            $textarea_fields = ['tagline_fr', 'tagline_en', 'points_forts', 'points_faibles'];
-            foreach ($textarea_fields as $field) {
-                if (isset($_POST['jlg_' . $field])) {
-                    $raw_value = wp_unslash($_POST['jlg_' . $field]);
-                    $value = sanitize_textarea_field($raw_value);
-                    if (!empty($value)) {
-                        update_post_meta($post_id, '_jlg_' . $field, $value);
+            $textarea_fields = array( 'tagline_fr', 'tagline_en', 'points_forts', 'points_faibles' );
+            foreach ( $textarea_fields as $field ) {
+                if ( isset( $_POST[ 'jlg_' . $field ] ) ) {
+                    $raw_value = wp_unslash( $_POST[ 'jlg_' . $field ] );
+                    $value     = sanitize_textarea_field( $raw_value );
+                    if ( ! empty( $value ) ) {
+                        update_post_meta( $post_id, '_jlg_' . $field, $value );
                     } else {
-                        delete_post_meta($post_id, '_jlg_' . $field);
+                        delete_post_meta( $post_id, '_jlg_' . $field );
                     }
                 }
             }
-            
+
             // Plateformes (checkboxes)
-            if (isset($_POST['jlg_plateformes']) && is_array($_POST['jlg_plateformes'])) {
-                $raw_platforms = wp_unslash($_POST['jlg_plateformes']);
-                $raw_platforms = is_array($raw_platforms) ? $raw_platforms : [];
-                $platforms = JLG_Validator::sanitize_platforms($raw_platforms);
-                update_post_meta($post_id, '_jlg_plateformes', $platforms);
+            if ( isset( $_POST['jlg_plateformes'] ) && is_array( $_POST['jlg_plateformes'] ) ) {
+                $raw_platforms = wp_unslash( $_POST['jlg_plateformes'] );
+                $raw_platforms = is_array( $raw_platforms ) ? $raw_platforms : array();
+                $platforms     = JLG_Validator::sanitize_platforms( $raw_platforms );
+                update_post_meta( $post_id, '_jlg_plateformes', $platforms );
             } else {
-                delete_post_meta($post_id, '_jlg_plateformes');
+                delete_post_meta( $post_id, '_jlg_plateformes' );
             }
         }
 
-        if (!empty($validation_errors)) {
-            set_transient($this->get_error_transient_key(), $validation_errors, MINUTE_IN_SECONDS);
+        if ( ! empty( $validation_errors ) ) {
+            set_transient( $this->get_error_transient_key(), $validation_errors, MINUTE_IN_SECONDS );
         }
     }
 }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
@@ -1,87 +1,130 @@
 <?php
 /**
  * Gestion des plateformes/consoles
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Platforms {
 
-    private $option_name = 'jlg_platforms_list';
-    private $default_platforms = [
-        'pc' => ['name' => 'PC', 'icon' => '💻', 'order' => 1, 'custom' => false],
-        'playstation-5' => ['name' => 'PlayStation 5', 'icon' => '🎮', 'order' => 2, 'custom' => false],
-        'xbox-series-x' => ['name' => 'Xbox Series S/X', 'icon' => '🎮', 'order' => 3, 'custom' => false],
-        'nintendo-switch' => ['name' => 'Nintendo Switch', 'icon' => '🎮', 'order' => 4, 'custom' => false],
-        'playstation-4' => ['name' => 'PlayStation 4', 'icon' => '🎮', 'order' => 5, 'custom' => false],
-        'xbox-one' => ['name' => 'Xbox One', 'icon' => '🎮', 'order' => 6, 'custom' => false],
-        'steam-deck' => ['name' => 'Steam Deck', 'icon' => '🎮', 'order' => 7, 'custom' => false],
-    ];
-    private static $debug_messages = [];
-    private static $instance = null;
-    private $debug_enabled = null;
-    
+    private $option_name           = 'jlg_platforms_list';
+    private $default_platforms     = array(
+        'pc'              => array(
+			'name'   => 'PC',
+			'icon'   => '💻',
+			'order'  => 1,
+			'custom' => false,
+		),
+        'playstation-5'   => array(
+			'name'   => 'PlayStation 5',
+			'icon'   => '🎮',
+			'order'  => 2,
+			'custom' => false,
+		),
+        'xbox-series-x'   => array(
+			'name'   => 'Xbox Series S/X',
+			'icon'   => '🎮',
+			'order'  => 3,
+			'custom' => false,
+		),
+        'nintendo-switch' => array(
+			'name'   => 'Nintendo Switch',
+			'icon'   => '🎮',
+			'order'  => 4,
+			'custom' => false,
+		),
+        'playstation-4'   => array(
+			'name'   => 'PlayStation 4',
+			'icon'   => '🎮',
+			'order'  => 5,
+			'custom' => false,
+		),
+        'xbox-one'        => array(
+			'name'   => 'Xbox One',
+			'icon'   => '🎮',
+			'order'  => 6,
+			'custom' => false,
+		),
+        'steam-deck'      => array(
+			'name'   => 'Steam Deck',
+			'icon'   => '🎮',
+			'order'  => 7,
+			'custom' => false,
+		),
+    );
+    private static $debug_messages = array();
+    private static $instance       = null;
+    private $debug_enabled         = null;
+
     /**
      * Singleton pattern pour s'assurer qu'une seule instance existe
      */
     public static function get_instance() {
-        if (self::$instance === null) {
+        if ( self::$instance === null ) {
             self::$instance = new self();
         }
         return self::$instance;
     }
-    
+
     public function __construct() {
         // Important: Hook sur admin_init pour traiter les actions POST
-        add_action('admin_init', [$this, 'handle_platform_actions'], 5);
-        $this->log_debug('✅ Classe JLG_Admin_Platforms initialisée');
+        add_action( 'admin_init', array( $this, 'handle_platform_actions' ), 5 );
+        $this->log_debug( '✅ Classe JLG_Admin_Platforms initialisée' );
     }
-    
+
     /**
      * Obtenir la liste des plateformes
      */
     public function get_platforms() {
-        $stored_platforms = $this->get_stored_platform_data();
+        $stored_platforms  = $this->get_stored_platform_data();
         $default_platforms = $this->get_default_platform_definitions();
 
         $platforms = $default_platforms;
 
-        foreach ($stored_platforms['custom_platforms'] as $key => $custom_platform) {
-            if (!is_array($custom_platform)) {
+        foreach ( $stored_platforms['custom_platforms'] as $key => $custom_platform ) {
+            if ( ! is_array( $custom_platform ) ) {
                 continue;
             }
 
-            $platforms[$key] = array_merge([
-                'name' => '',
-                'icon' => '🎮',
-                'custom' => true,
-            ], $custom_platform);
+            $platforms[ $key ] = array_merge(
+                array(
+					'name'   => '',
+					'icon'   => '🎮',
+					'custom' => true,
+                ),
+                $custom_platform
+            );
         }
 
-        $order_map = $stored_platforms['order'];
-        $platform_keys = array_keys($platforms);
+        $order_map     = $stored_platforms['order'];
+        $platform_keys = array_keys( $platforms );
 
-        usort($platform_keys, function($a, $b) use ($order_map, $platforms) {
-            $order_a = isset($order_map[$a]) ? (int) $order_map[$a] : (int) ($platforms[$a]['order'] ?? PHP_INT_MAX);
-            $order_b = isset($order_map[$b]) ? (int) $order_map[$b] : (int) ($platforms[$b]['order'] ?? PHP_INT_MAX);
+        usort(
+            $platform_keys,
+            function ( $a, $b ) use ( $order_map, $platforms ) {
+				$order_a = isset( $order_map[ $a ] ) ? (int) $order_map[ $a ] : (int) ( $platforms[ $a ]['order'] ?? PHP_INT_MAX );
+				$order_b = isset( $order_map[ $b ] ) ? (int) $order_map[ $b ] : (int) ( $platforms[ $b ]['order'] ?? PHP_INT_MAX );
 
-            if ($order_a === $order_b) {
-                return strcmp($a, $b);
-            }
+				if ( $order_a === $order_b ) {
+					return strcmp( $a, $b );
+				}
 
-            return $order_a <=> $order_b;
-        });
+				return $order_a <=> $order_b;
+			}
+        );
 
-        $ordered_platforms = [];
-        foreach ($platform_keys as $index => $key) {
-            $platform = $platforms[$key];
-            $platform['order'] = isset($order_map[$key])
-                ? (int) $order_map[$key]
-                : (int) ($platform['order'] ?? ($index + 1));
-            $ordered_platforms[$key] = $platform;
+        $ordered_platforms = array();
+        foreach ( $platform_keys as $index => $key ) {
+            $platform                  = $platforms[ $key ];
+            $platform['order']         = isset( $order_map[ $key ] )
+                ? (int) $order_map[ $key ]
+                : (int) ( $platform['order'] ?? ( $index + 1 ) );
+            $ordered_platforms[ $key ] = $platform;
         }
 
         return $ordered_platforms;
@@ -92,435 +135,471 @@ class JLG_Admin_Platforms {
     }
 
     private function get_stored_platform_data() {
-        $stored = get_option($this->option_name, []);
+        $stored = get_option( $this->option_name, array() );
 
-        if (!is_array($stored)) {
-            $stored = [];
+        if ( ! is_array( $stored ) ) {
+            $stored = array();
         }
 
-        if (isset($stored['custom_platforms']) || isset($stored['order'])) {
-            $custom = isset($stored['custom_platforms']) && is_array($stored['custom_platforms'])
+        if ( isset( $stored['custom_platforms'] ) || isset( $stored['order'] ) ) {
+            $custom = isset( $stored['custom_platforms'] ) && is_array( $stored['custom_platforms'] )
                 ? $stored['custom_platforms']
-                : [];
-            $order = isset($stored['order']) && is_array($stored['order'])
-                ? array_map('intval', $stored['order'])
-                : [];
+                : array();
+            $order  = isset( $stored['order'] ) && is_array( $stored['order'] )
+                ? array_map( 'intval', $stored['order'] )
+                : array();
 
-            return [
+            return array(
                 'custom_platforms' => $custom,
-                'order' => $order,
-            ];
+                'order'            => $order,
+            );
         }
 
-        $custom = [];
-        $order = [];
-        foreach ($stored as $key => $platform) {
-            if (!is_array($platform)) {
+        $custom = array();
+        $order  = array();
+        foreach ( $stored as $key => $platform ) {
+            if ( ! is_array( $platform ) ) {
                 continue;
             }
 
-            if (!empty($platform['custom'])) {
-                $custom[$key] = [
-                    'name' => $platform['name'] ?? '',
-                    'icon' => $platform['icon'] ?? '🎮',
+            if ( ! empty( $platform['custom'] ) ) {
+                $custom[ $key ] = array(
+                    'name'   => $platform['name'] ?? '',
+                    'icon'   => $platform['icon'] ?? '🎮',
                     'custom' => true,
-                ];
+                );
             }
 
-            if (isset($platform['order'])) {
-                $order[$key] = (int) $platform['order'];
+            if ( isset( $platform['order'] ) ) {
+                $order[ $key ] = (int) $platform['order'];
             }
         }
 
-        return [
+        return array(
             'custom_platforms' => $custom,
-            'order' => $order,
-        ];
+            'order'            => $order,
+        );
     }
 
-    private function ensure_storage_structure(&$platforms) {
-        if (!isset($platforms['custom_platforms']) || !is_array($platforms['custom_platforms'])) {
-            $platforms['custom_platforms'] = [];
+    private function ensure_storage_structure( &$platforms ) {
+        if ( ! isset( $platforms['custom_platforms'] ) || ! is_array( $platforms['custom_platforms'] ) ) {
+            $platforms['custom_platforms'] = array();
         }
 
-        if (!isset($platforms['order']) || !is_array($platforms['order'])) {
-            $platforms['order'] = [];
+        if ( ! isset( $platforms['order'] ) || ! is_array( $platforms['order'] ) ) {
+            $platforms['order'] = array();
         }
     }
-    
+
     /**
      * Obtenir uniquement les noms des plateformes (pour les metaboxes)
      */
     public function get_platform_names() {
         $platforms = $this->get_platforms();
-        $names = [];
-        foreach ($platforms as $key => $platform) {
-            $names[$key] = $platform['name'];
+        $names     = array();
+        foreach ( $platforms as $key => $platform ) {
+            $names[ $key ] = $platform['name'];
         }
         return $names;
     }
-    
+
     /**
      * Gérer les actions (ajout, suppression, modification)
      */
     public function handle_platform_actions() {
         // Ne traiter que sur la page des plateformes
-        if (!isset($_GET['page']) || $_GET['page'] !== 'notation_jlg_settings') {
+        if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'notation_jlg_settings' ) {
             return;
         }
-        
-        if (!isset($_GET['tab']) || $_GET['tab'] !== 'plateformes') {
+
+        if ( ! isset( $_GET['tab'] ) || $_GET['tab'] !== 'plateformes' ) {
             return;
         }
-        
+
         // Debug : Enregistrer l'appel de la méthode
-        $this->log_debug('🔄 handle_platform_actions() appelé');
-        $this->log_debug('📍 Page actuelle : ' . ($_GET['page'] ?? 'non définie'));
-        $this->log_debug('📍 Onglet actuel : ' . ($_GET['tab'] ?? 'non défini'));
+        $this->log_debug( '🔄 handle_platform_actions() appelé' );
+        $this->log_debug( '📍 Page actuelle : ' . ( $_GET['page'] ?? 'non définie' ) );
+        $this->log_debug( '📍 Onglet actuel : ' . ( $_GET['tab'] ?? 'non défini' ) );
 
         // Debug : Vérifier les données POST
-        if (!empty($_POST)) {
-            $this->log_debug('📨 Données POST reçues : ' . json_encode(array_keys($_POST)));
+        if ( ! empty( $_POST ) ) {
+            $this->log_debug( '📨 Données POST reçues : ' . json_encode( array_keys( $_POST ) ) );
         }
 
-        if (!isset($_POST['jlg_platform_action'])) {
-            if (!empty($_POST)) {
-                $this->log_debug('❌ jlg_platform_action non trouvé dans POST');
+        if ( ! isset( $_POST['jlg_platform_action'] ) ) {
+            if ( ! empty( $_POST ) ) {
+                $this->log_debug( '❌ jlg_platform_action non trouvé dans POST' );
             }
             return;
         }
 
-        $posted_action = wp_unslash($_POST['jlg_platform_action']);
-        $sanitized_action = sanitize_text_field($posted_action);
-        $this->log_debug('✅ Action détectée : ' . $sanitized_action);
-        
+        $posted_action    = wp_unslash( $_POST['jlg_platform_action'] );
+        $sanitized_action = sanitize_text_field( $posted_action );
+        $this->log_debug( '✅ Action détectée : ' . $sanitized_action );
+
         // Vérifier les permissions
-        if (!current_user_can('manage_options')) {
-            $this->log_debug('❌ Permissions insuffisantes');
-            wp_die(esc_html__('Permissions insuffisantes', 'notation-jlg'));
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->log_debug( '❌ Permissions insuffisantes' );
+            wp_die( esc_html__( 'Permissions insuffisantes', 'notation-jlg' ) );
         }
-        $this->log_debug('✅ Permissions OK');
+        $this->log_debug( '✅ Permissions OK' );
 
         // Vérifier le nonce
-        if (!isset($_POST['jlg_platform_nonce'])) {
-            $this->log_debug('❌ Nonce non trouvé');
+        if ( ! isset( $_POST['jlg_platform_nonce'] ) ) {
+            $this->log_debug( '❌ Nonce non trouvé' );
             return;
         }
 
-        $posted_nonce = wp_unslash($_POST['jlg_platform_nonce']);
-        $sanitized_nonce = sanitize_text_field($posted_nonce);
-        if (!wp_verify_nonce($posted_nonce, 'jlg_platform_action')) {
-            $this->log_debug('❌ Nonce invalide : ' . $sanitized_nonce);
-            wp_die(esc_html__('Erreur de sécurité', 'notation-jlg'));
+        $posted_nonce    = wp_unslash( $_POST['jlg_platform_nonce'] );
+        $sanitized_nonce = sanitize_text_field( $posted_nonce );
+        if ( ! wp_verify_nonce( $posted_nonce, 'jlg_platform_action' ) ) {
+            $this->log_debug( '❌ Nonce invalide : ' . $sanitized_nonce );
+            wp_die( esc_html__( 'Erreur de sécurité', 'notation-jlg' ) );
         }
-        $this->log_debug('✅ Nonce valide');
+        $this->log_debug( '✅ Nonce valide' );
 
-        $action = $sanitized_action;
+        $action    = $sanitized_action;
         $platforms = $this->get_stored_platform_data();
-        $this->log_debug('📦 Plateformes actuelles dans la DB : ' . count($platforms['custom_platforms']) . ' personnalisées');
+        $this->log_debug( '📦 Plateformes actuelles dans la DB : ' . count( $platforms['custom_platforms'] ) . ' personnalisées' );
 
         $success = false;
         $message = '';
 
-        switch ($action) {
+        switch ( $action ) {
             case 'add':
-                $result = $this->add_platform($platforms);
+                $result  = $this->add_platform( $platforms );
                 $success = $result['success'];
                 $message = $result['message'];
                 break;
-                
+
             case 'delete':
-                $result = $this->delete_platform($platforms);
+                $result  = $this->delete_platform( $platforms );
                 $success = $result['success'];
                 $message = $result['message'];
                 break;
-                
+
             case 'update_order':
-                $result = $this->update_platform_order($platforms);
+                $result  = $this->update_platform_order( $platforms );
                 $success = $result['success'];
                 $message = $result['message'];
                 break;
-                
+
             case 'reset':
-                delete_option($this->option_name);
+                delete_option( $this->option_name );
                 $success = true;
-                $message = esc_html__('Plateformes réinitialisées avec succès !', 'notation-jlg');
-                $this->log_debug('🔄 Option supprimée de la DB');
+                $message = esc_html__( 'Plateformes réinitialisées avec succès !', 'notation-jlg' );
+                $this->log_debug( '🔄 Option supprimée de la DB' );
                 break;
         }
 
         // Stocker le message pour l'affichage
-        if ($success) {
-            $this->log_debug('✅ Action réussie : ' . $message);
+        if ( $success ) {
+            $this->log_debug( '✅ Action réussie : ' . $message );
         } else {
-            $this->log_debug('❌ Erreur : ' . $message);
+            $this->log_debug( '❌ Erreur : ' . $message );
         }
 
-        $message_data = [
-            'type' => $success ? 'success' : 'error',
+        $message_data = array(
+            'type'    => $success ? 'success' : 'error',
             'message' => $message,
-        ];
+        );
 
-        set_transient('jlg_platforms_message', $message_data, 30);
+        set_transient( 'jlg_platforms_message', $message_data, 30 );
 
-        $redirect_args = [
+        $redirect_args = array(
             'page' => 'notation_jlg_settings',
-            'tab' => 'plateformes',
-        ];
+            'tab'  => 'plateformes',
+        );
 
-        if (isset($_GET['debug'])) {
-            $redirect_args['debug'] = sanitize_text_field(wp_unslash($_GET['debug']));
+        if ( isset( $_GET['debug'] ) ) {
+            $redirect_args['debug'] = sanitize_text_field( wp_unslash( $_GET['debug'] ) );
         }
 
-        $redirect_url = add_query_arg($redirect_args, admin_url('admin.php'));
+        $redirect_url = add_query_arg( $redirect_args, admin_url( 'admin.php' ) );
 
         // Stocker les messages de debug dans un transient
-        if ($this->is_debug_enabled() && !empty(self::$debug_messages)) {
-            set_transient('jlg_platforms_debug', self::$debug_messages, 60);
+        if ( $this->is_debug_enabled() && ! empty( self::$debug_messages ) ) {
+            set_transient( 'jlg_platforms_debug', self::$debug_messages, 60 );
         }
 
-        wp_safe_redirect($redirect_url);
+        wp_safe_redirect( $redirect_url );
         exit;
     }
-    
+
     /**
      * Ajouter une nouvelle plateforme
      */
-    private function add_platform(&$platforms) {
-        $this->log_debug("🎯 Tentative d'ajout de plateforme");
+    private function add_platform( &$platforms ) {
+        $this->log_debug( "🎯 Tentative d'ajout de plateforme" );
 
-        $this->ensure_storage_structure($platforms);
+        $this->ensure_storage_structure( $platforms );
 
-        if (empty($_POST['new_platform_name'])) {
-            $this->log_debug("❌ Nom de plateforme vide");
-            return ['success' => false, 'message' => esc_html__('Le nom de la plateforme est requis.', 'notation-jlg')];
+        if ( empty( $_POST['new_platform_name'] ) ) {
+            $this->log_debug( '❌ Nom de plateforme vide' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Le nom de la plateforme est requis.', 'notation-jlg' ),
+			);
         }
 
-        $name = sanitize_text_field(wp_unslash($_POST['new_platform_name']));
-        $icon_input = isset($_POST['new_platform_icon']) ? wp_unslash($_POST['new_platform_icon']) : '🎮';
-        $icon = sanitize_text_field($icon_input);
-        
-        $this->log_debug("📝 Nom : $name, Icône : $icon");
-        
+        $name       = sanitize_text_field( wp_unslash( $_POST['new_platform_name'] ) );
+        $icon_input = isset( $_POST['new_platform_icon'] ) ? wp_unslash( $_POST['new_platform_icon'] ) : '🎮';
+        $icon       = sanitize_text_field( $icon_input );
+
+        $this->log_debug( "📝 Nom : $name, Icône : $icon" );
+
         // Générer une clé unique
-        $key = sanitize_title($name);
-        if (empty($key)) {
-            $this->log_debug("❌ Clé générée vide pour le nom : $name");
-            return ['success' => false, 'message' => esc_html__('Nom de plateforme invalide.', 'notation-jlg')];
+        $key = sanitize_title( $name );
+        if ( empty( $key ) ) {
+            $this->log_debug( "❌ Clé générée vide pour le nom : $name" );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Nom de plateforme invalide.', 'notation-jlg' ),
+			);
         }
-        
+
         // Ajouter un suffixe si la clé existe déjà
-        $original_key = $key;
-        $suffix = 1;
+        $original_key  = $key;
+        $suffix        = 1;
         $all_platforms = $this->get_platforms();
-        while (isset($all_platforms[$key])) {
+        while ( isset( $all_platforms[ $key ] ) ) {
             $key = $original_key . '-' . $suffix;
-            $suffix++;
+            ++$suffix;
         }
-        
-        $this->log_debug("🔑 Clé générée : $key");
-        
+
+        $this->log_debug( "🔑 Clé générée : $key" );
+
         // Trouver l'ordre maximum
         $max_order = 0;
-        foreach ($all_platforms as $platform) {
-            $max_order = max($max_order, $platform['order'] ?? 0);
+        foreach ( $all_platforms as $platform ) {
+            $max_order = max( $max_order, $platform['order'] ?? 0 );
         }
 
         // Ajouter la nouvelle plateforme
-        $platforms['custom_platforms'][$key] = [
-            'name' => $name,
-            'icon' => $icon,
+        $platforms['custom_platforms'][ $key ] = array(
+            'name'   => $name,
+            'icon'   => $icon,
             'custom' => true,
-        ];
-        $platforms['order'][$key] = $max_order + 1;
+        );
+        $platforms['order'][ $key ]            = $max_order + 1;
 
-        $this->log_debug("💾 Tentative de sauvegarde dans la DB");
-        $this->log_debug("📊 Données à sauvegarder : " . json_encode($platforms['custom_platforms'][$key]));
+        $this->log_debug( '💾 Tentative de sauvegarde dans la DB' );
+        $this->log_debug( '📊 Données à sauvegarder : ' . json_encode( $platforms['custom_platforms'][ $key ] ) );
 
-        $result = update_option($this->option_name, $platforms);
-        
-        if ($result || get_option($this->option_name) !== false) {
-            $this->log_debug("✅ Plateforme ajoutée et sauvegardée");
-            
+        $result = update_option( $this->option_name, $platforms );
+
+        if ( $result || get_option( $this->option_name ) !== false ) {
+            $this->log_debug( '✅ Plateforme ajoutée et sauvegardée' );
+
             // Vérification que la sauvegarde a bien fonctionné
-            $saved = get_option($this->option_name);
-            if (isset($saved['custom_platforms'][$key])) {
-                $this->log_debug("✅ Vérification : plateforme bien présente dans la DB");
+            $saved = get_option( $this->option_name );
+            if ( isset( $saved['custom_platforms'][ $key ] ) ) {
+                $this->log_debug( '✅ Vérification : plateforme bien présente dans la DB' );
             } else {
-                $this->log_debug("⚠️ La plateforme a été sauvegardée mais n'apparaît pas dans la vérification");
+                $this->log_debug( "⚠️ La plateforme a été sauvegardée mais n'apparaît pas dans la vérification" );
             }
-            
-            return [
+
+            return array(
                 'success' => true,
                 'message' => sprintf(
                     /* translators: %s: platform name. */
-                    esc_html__("Plateforme '%s' ajoutée avec succès !", 'notation-jlg'),
+                    esc_html__( "Plateforme '%s' ajoutée avec succès !", 'notation-jlg' ),
                     $name
                 ),
-            ];
+            );
         } else {
-            $this->log_debug("❌ Échec de la sauvegarde dans la DB");
-            return ['success' => false, 'message' => esc_html__('Erreur lors de la sauvegarde.', 'notation-jlg')];
+            $this->log_debug( '❌ Échec de la sauvegarde dans la DB' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Erreur lors de la sauvegarde.', 'notation-jlg' ),
+			);
         }
     }
-    
+
     /**
      * Supprimer une plateforme
      */
-    private function delete_platform(&$platforms) {
-        $this->log_debug("🗑️ Tentative de suppression de plateforme");
+    private function delete_platform( &$platforms ) {
+        $this->log_debug( '🗑️ Tentative de suppression de plateforme' );
 
-        $this->ensure_storage_structure($platforms);
+        $this->ensure_storage_structure( $platforms );
 
-        if (empty($_POST['platform_key'])) {
-            $this->log_debug("❌ Clé de plateforme manquante");
-            return ['success' => false, 'message' => esc_html__('Clé de plateforme manquante.', 'notation-jlg')];
+        if ( empty( $_POST['platform_key'] ) ) {
+            $this->log_debug( '❌ Clé de plateforme manquante' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Clé de plateforme manquante.', 'notation-jlg' ),
+			);
         }
 
-        $key = sanitize_text_field(wp_unslash($_POST['platform_key']));
-        $this->log_debug("🔑 Clé à supprimer : $key");
-        
+        $key = sanitize_text_field( wp_unslash( $_POST['platform_key'] ) );
+        $this->log_debug( "🔑 Clé à supprimer : $key" );
+
         $all_platforms = $this->get_platforms();
-        if (!isset($all_platforms[$key])) {
-            $this->log_debug("❌ Plateforme introuvable");
-            return ['success' => false, 'message' => esc_html__('Plateforme introuvable.', 'notation-jlg')];
+        if ( ! isset( $all_platforms[ $key ] ) ) {
+            $this->log_debug( '❌ Plateforme introuvable' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Plateforme introuvable.', 'notation-jlg' ),
+			);
         }
 
-        if (!isset($platforms['custom_platforms'][$key]) || empty($platforms['custom_platforms'][$key]['custom'])) {
-            $platform_name = $all_platforms[$key]['name'] ?? 'Inconnue';
-            $this->log_debug("❌ Suppression refusée pour la plateforme non personnalisée '$platform_name'");
-            return [
+        if ( ! isset( $platforms['custom_platforms'][ $key ] ) || empty( $platforms['custom_platforms'][ $key ]['custom'] ) ) {
+            $platform_name = $all_platforms[ $key ]['name'] ?? 'Inconnue';
+            $this->log_debug( "❌ Suppression refusée pour la plateforme non personnalisée '$platform_name'" );
+            return array(
                 'success' => false,
                 'message' => sprintf(
                     /* translators: %s: platform name. */
-                    esc_html__("La plateforme '%s' est une plateforme par défaut et ne peut pas être supprimée.", 'notation-jlg'),
+                    esc_html__( "La plateforme '%s' est une plateforme par défaut et ne peut pas être supprimée.", 'notation-jlg' ),
                     $platform_name
                 ),
-            ];
+            );
         }
 
-        $platform_name = $platforms['custom_platforms'][$key]['name'] ?? $all_platforms[$key]['name'] ?? 'Inconnue';
-        unset($platforms['custom_platforms'][$key]);
-        unset($platforms['order'][$key]);
-        
-        $result = update_option($this->option_name, $platforms);
-        
-        if ($result || get_option($this->option_name) !== false) {
-            $this->log_debug("✅ Plateforme '$platform_name' supprimée");
-            return [
+        $platform_name = $platforms['custom_platforms'][ $key ]['name'] ?? $all_platforms[ $key ]['name'] ?? 'Inconnue';
+        unset( $platforms['custom_platforms'][ $key ] );
+        unset( $platforms['order'][ $key ] );
+
+        $result = update_option( $this->option_name, $platforms );
+
+        if ( $result || get_option( $this->option_name ) !== false ) {
+            $this->log_debug( "✅ Plateforme '$platform_name' supprimée" );
+            return array(
                 'success' => true,
                 'message' => sprintf(
                     /* translators: %s: platform name. */
-                    esc_html__("Plateforme '%s' supprimée avec succès !", 'notation-jlg'),
+                    esc_html__( "Plateforme '%s' supprimée avec succès !", 'notation-jlg' ),
                     $platform_name
                 ),
-            ];
+            );
         } else {
-            $this->log_debug("❌ Échec de la suppression");
-            return ['success' => false, 'message' => esc_html__('Erreur lors de la suppression.', 'notation-jlg')];
+            $this->log_debug( '❌ Échec de la suppression' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Erreur lors de la suppression.', 'notation-jlg' ),
+			);
         }
     }
-    
+
     /**
      * Mettre à jour l'ordre des plateformes
      */
-    private function update_platform_order(&$platforms) {
-        $this->log_debug("🔄 Mise à jour de l'ordre des plateformes");
+    private function update_platform_order( &$platforms ) {
+        $this->log_debug( "🔄 Mise à jour de l'ordre des plateformes" );
 
-        $this->ensure_storage_structure($platforms);
+        $this->ensure_storage_structure( $platforms );
 
-        if (!isset($_POST['platform_order']) || !is_array($_POST['platform_order'])) {
-            $this->log_debug("❌ Données d'ordre manquantes");
-            return ['success' => false, 'message' => esc_html__('Données d\'ordre manquantes.', 'notation-jlg')];
+        if ( ! isset( $_POST['platform_order'] ) || ! is_array( $_POST['platform_order'] ) ) {
+            $this->log_debug( "❌ Données d'ordre manquantes" );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Données d\'ordre manquantes.', 'notation-jlg' ),
+			);
         }
 
-        $raw_order = array_filter(wp_unslash($_POST['platform_order']), 'strlen');
-        $submitted_order = array_map(function($value) {
-            return sanitize_text_field($value);
-        }, array_values($raw_order));
-        if (empty($submitted_order)) {
-            $this->log_debug("❌ Ordre soumis vide");
-            return ['success' => false, 'message' => esc_html__('Ordre soumis invalide.', 'notation-jlg')];
+        $raw_order       = array_filter( wp_unslash( $_POST['platform_order'] ), 'strlen' );
+        $submitted_order = array_map(
+            function ( $value ) {
+				return sanitize_text_field( $value );
+			},
+            array_values( $raw_order )
+        );
+        if ( empty( $submitted_order ) ) {
+            $this->log_debug( '❌ Ordre soumis vide' );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Ordre soumis invalide.', 'notation-jlg' ),
+			);
         }
 
         $all_platforms = $this->get_platforms();
-        $ordered_keys = [];
+        $ordered_keys  = array();
 
-        foreach ($submitted_order as $key) {
-            if (!isset($all_platforms[$key])) {
-                $this->log_debug("⚠️ Plateforme inconnue ignorée : $key");
+        foreach ( $submitted_order as $key ) {
+            if ( ! isset( $all_platforms[ $key ] ) ) {
+                $this->log_debug( "⚠️ Plateforme inconnue ignorée : $key" );
                 continue;
             }
 
-            if (in_array($key, $ordered_keys, true)) {
-                $this->log_debug("⚠️ Doublon ignoré dans l'ordre : $key");
+            if ( in_array( $key, $ordered_keys, true ) ) {
+                $this->log_debug( "⚠️ Doublon ignoré dans l'ordre : $key" );
                 continue;
             }
 
             $ordered_keys[] = $key;
         }
 
-        if (empty($ordered_keys)) {
-            $this->log_debug("❌ Aucun élément valide dans l'ordre soumis");
-            return ['success' => false, 'message' => esc_html__('Aucune plateforme valide reçue.', 'notation-jlg')];
+        if ( empty( $ordered_keys ) ) {
+            $this->log_debug( "❌ Aucun élément valide dans l'ordre soumis" );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Aucune plateforme valide reçue.', 'notation-jlg' ),
+			);
         }
 
-        foreach ($all_platforms as $key => $platform_data) {
-            if (!in_array($key, $ordered_keys, true)) {
+        foreach ( $all_platforms as $key => $platform_data ) {
+            if ( ! in_array( $key, $ordered_keys, true ) ) {
                 $ordered_keys[] = $key;
             }
         }
 
-        $new_order = [];
-        foreach ($ordered_keys as $position => $key) {
-            $new_order[$key] = $position + 1;
+        $new_order = array();
+        foreach ( $ordered_keys as $position => $key ) {
+            $new_order[ $key ] = $position + 1;
         }
 
         $platforms['order'] = $new_order;
-        $this->log_debug("📊 " . count($new_order) . " positions sauvegardées");
+        $this->log_debug( '📊 ' . count( $new_order ) . ' positions sauvegardées' );
 
-        $result = update_option($this->option_name, $platforms);
+        $result = update_option( $this->option_name, $platforms );
 
-        if ($result || get_option($this->option_name) !== false) {
-            $this->log_debug("✅ Ordre sauvegardé");
-            return ['success' => true, 'message' => esc_html__('Ordre des plateformes mis à jour !', 'notation-jlg')];
+        if ( $result || get_option( $this->option_name ) !== false ) {
+            $this->log_debug( '✅ Ordre sauvegardé' );
+            return array(
+				'success' => true,
+				'message' => esc_html__( 'Ordre des plateformes mis à jour !', 'notation-jlg' ),
+			);
         } else {
-            $this->log_debug("❌ Échec de la sauvegarde de l'ordre");
-            return ['success' => false, 'message' => esc_html__('Erreur lors de la mise à jour.', 'notation-jlg')];
+            $this->log_debug( "❌ Échec de la sauvegarde de l'ordre" );
+            return array(
+				'success' => false,
+				'message' => esc_html__( 'Erreur lors de la mise à jour.', 'notation-jlg' ),
+			);
         }
     }
-    
+
     /**
      * Afficher la page de gestion
      */
     public function render_platforms_page() {
         // Récupérer et afficher le message s'il existe
-        $message = get_transient('jlg_platforms_message');
-        if ($message) {
+        $message = get_transient( 'jlg_platforms_message' );
+        if ( $message ) {
             $class = $message['type'] === 'success' ? 'notice-success' : 'notice-error';
-            echo '<div class="notice ' . $class . ' is-dismissible"><p>' . esc_html($message['message']) . '</p></div>';
-            delete_transient('jlg_platforms_message');
+            echo '<div class="notice ' . $class . ' is-dismissible"><p>' . esc_html( $message['message'] ) . '</p></div>';
+            delete_transient( 'jlg_platforms_message' );
         }
-        
+
         $platforms = $this->get_platforms();
         ?>
 
         <!-- ZONE DE DEBUG AMÉLIORÉE -->
         <?php
         $show_debug = $this->is_debug_enabled();
-        if ($show_debug) :
-            $debug_messages = get_transient('jlg_platforms_debug');
-        ?>
+        if ( $show_debug ) :
+            $debug_messages = get_transient( 'jlg_platforms_debug' );
+			?>
             <div style="background: #fff3cd; border: 1px solid #ffc107; padding: 15px; margin: 20px 0; border-radius: 5px;">
                 <h3 style="margin-top: 0;">🐛 Mode Debug - Informations de diagnostic</h3>
 
-                <?php if ($debug_messages && !empty($debug_messages)) : ?>
+                <?php if ( $debug_messages && ! empty( $debug_messages ) ) : ?>
                 <div style="background: #fff; padding: 10px; border-radius: 3px; font-family: monospace; font-size: 12px; max-height: 300px; overflow-y: auto;">
-                    <?php foreach ($debug_messages as $msg): ?>
-                        <div style="margin: 5px 0;"><?php echo esc_html($msg); ?></div>
+                    <?php foreach ( $debug_messages as $msg ) : ?>
+                        <div style="margin: 5px 0;"><?php echo esc_html( $msg ); ?></div>
                     <?php endforeach; ?>
                 </div>
-                <?php else: ?>
+                <?php else : ?>
                 <p>Aucun message de debug pour le moment. Essayez d'effectuer une action.</p>
                 <?php endif; ?>
                 
@@ -530,37 +609,37 @@ class JLG_Admin_Platforms {
                     <summary style="cursor: pointer; font-weight: bold;">📊 Informations système</summary>
                     <ul style="font-family: monospace; font-size: 12px; margin-top: 10px;">
                         <li>PHP Version : <?php echo PHP_VERSION; ?></li>
-                        <li>WordPress Version : <?php echo get_bloginfo('version'); ?></li>
-                        <li>Page actuelle : <?php echo esc_html($_GET['page'] ?? 'non définie'); ?></li>
-                        <li>Onglet actuel : <?php echo esc_html($_GET['tab'] ?? 'non défini'); ?></li>
-                        <li>URL actuelle : <?php echo esc_url($_SERVER['REQUEST_URI']); ?></li>
+                        <li>WordPress Version : <?php echo get_bloginfo( 'version' ); ?></li>
+                        <li>Page actuelle : <?php echo esc_html( $_GET['page'] ?? 'non définie' ); ?></li>
+                        <li>Onglet actuel : <?php echo esc_html( $_GET['tab'] ?? 'non défini' ); ?></li>
+                        <li>URL actuelle : <?php echo esc_url( $_SERVER['REQUEST_URI'] ); ?></li>
                         <li>Méthode HTTP : <?php echo esc_html( $_SERVER['REQUEST_METHOD'] ?? 'inconnue' ); ?></li>
-                        <li>Plateformes sauvegardées : <?php echo count($this->get_stored_platform_data()['custom_platforms']); ?> personnalisées</li>
-                        <li>Total plateformes : <?php echo count($platforms); ?></li>
-                        <li>Hook admin_init exécuté : <?php echo did_action('admin_init'); ?> fois</li>
-                        <li>Utilisateur peut gérer les options : <?php echo current_user_can('manage_options') ? 'Oui' : 'Non'; ?></li>
+                        <li>Plateformes sauvegardées : <?php echo count( $this->get_stored_platform_data()['custom_platforms'] ); ?> personnalisées</li>
+                        <li>Total plateformes : <?php echo count( $platforms ); ?></li>
+                        <li>Hook admin_init exécuté : <?php echo did_action( 'admin_init' ); ?> fois</li>
+                        <li>Utilisateur peut gérer les options : <?php echo current_user_can( 'manage_options' ) ? 'Oui' : 'Non'; ?></li>
                     </ul>
                 </details>
                 
-                <?php if (!empty($_POST)): ?>
+                <?php if ( ! empty( $_POST ) ) : ?>
                 <details style="margin-top: 15px;">
                     <summary style="cursor: pointer; font-weight: bold;">📨 Données POST reçues</summary>
                     <pre style="background: #f5f5f5; padding: 10px; overflow: auto; margin-top: 10px; font-size: 11px;">
-                        <?php echo esc_html(print_r($_POST, true)); ?>
+                        <?php echo esc_html( print_r( $_POST, true ) ); ?>
                     </pre>
                 </details>
                 <?php endif; ?>
                 
                 <p style="margin-top: 15px; margin-bottom: 0;">
-                    <a href="<?php echo esc_url(add_query_arg('debug', '0')); ?>" class="button button-small">Masquer le debug</a>
+                    <a href="<?php echo esc_url( add_query_arg( 'debug', '0' ) ); ?>" class="button button-small">Masquer le debug</a>
                 </p>
             </div>
-        <?php
-        delete_transient('jlg_platforms_debug');
-        else:
-        ?>
+			<?php
+			delete_transient( 'jlg_platforms_debug' );
+        else :
+			?>
         <p style="text-align: right;">
-            <a href="<?php echo esc_url(add_query_arg('debug', '1')); ?>" class="button button-small">🐛 Activer le mode debug</a>
+            <a href="<?php echo esc_url( add_query_arg( 'debug', '1' ) ); ?>" class="button button-small">🐛 Activer le mode debug</a>
         </p>
         <?php endif; ?>
 
@@ -571,7 +650,7 @@ class JLG_Admin_Platforms {
                 <h3>Plateformes actuelles</h3>
 
                 <form method="post" action="">
-                    <?php wp_nonce_field('jlg_platform_action', 'jlg_platform_nonce'); ?>
+                    <?php wp_nonce_field( 'jlg_platform_action', 'jlg_platform_nonce' ); ?>
                     <input type="hidden" name="jlg_platform_action" value="update_order">
 
                     <table class="wp-list-table widefat striped jlg-platforms-table">
@@ -587,39 +666,42 @@ class JLG_Admin_Platforms {
                             </tr>
                         </thead>
                         <tbody id="platforms-list" class="jlg-sortable-list">
-                            <?php $position = 1; foreach ($platforms as $key => $platform): ?>
-                            <tr class="jlg-platform-row" data-key="<?php echo esc_attr($key); ?>">
+                            <?php $position = 1; foreach ( $platforms as $key => $platform ) : ?>
+                            <tr class="jlg-platform-row" data-key="<?php echo esc_attr( $key ); ?>">
                                 <td class="jlg-sort-handle" style="cursor: move; text-align: center;" title="Glissez pour réordonner">
                                     <span class="dashicons dashicons-menu" aria-hidden="true"></span>
-                                    <span class="screen-reader-text">Réordonner <?php echo esc_html($platform['name']); ?></span>
+                                    <span class="screen-reader-text">Réordonner <?php echo esc_html( $platform['name'] ); ?></span>
                                 </td>
                                 <td class="jlg-platform-position">
-                                    <?php echo esc_html($position); ?>
+                                    <?php echo esc_html( $position ); ?>
                                 </td>
                                 <td style="text-align: center; font-size: 20px;">
-                                    <?php echo esc_html($platform['icon'] ?? '🎮'); ?>
+                                    <?php echo esc_html( $platform['icon'] ?? '🎮' ); ?>
                                 </td>
                                 <td>
-                                    <strong><?php echo esc_html($platform['name']); ?></strong>
-                                    <?php if (isset($platform['custom']) && $platform['custom']): ?>
+                                    <strong><?php echo esc_html( $platform['name'] ); ?></strong>
+                                    <?php if ( isset( $platform['custom'] ) && $platform['custom'] ) : ?>
                                         <span style="color: #666; font-size: 12px;">(Personnalisée)</span>
                                     <?php endif; ?>
                                 </td>
                                 <td>
-                                    <?php if (isset($platform['custom']) && $platform['custom']): ?>
+                                    <?php if ( isset( $platform['custom'] ) && $platform['custom'] ) : ?>
                                         <button type="button"
                                                 class="button button-small delete-platform"
-                                                data-key="<?php echo esc_attr($key); ?>"
-                                                data-name="<?php echo esc_attr($platform['name']); ?>">
+                                                data-key="<?php echo esc_attr( $key ); ?>"
+                                                data-name="<?php echo esc_attr( $platform['name'] ); ?>">
                                             ❌ Supprimer
                                         </button>
-                                    <?php else: ?>
+                                    <?php else : ?>
                                         <span style="color: #999;">Par défaut</span>
                                     <?php endif; ?>
-                                    <input type="hidden" name="platform_order[]" value="<?php echo esc_attr($key); ?>">
+                                    <input type="hidden" name="platform_order[]" value="<?php echo esc_attr( $key ); ?>">
                                 </td>
                             </tr>
-                            <?php $position++; endforeach; ?>
+								<?php
+								++$position;
+endforeach;
+							?>
                         </tbody>
                     </table>
 
@@ -639,7 +721,7 @@ class JLG_Admin_Platforms {
                     <h3>➕ Ajouter une plateforme</h3>
 
                     <form method="post" action="">
-                        <?php wp_nonce_field('jlg_platform_action', 'jlg_platform_nonce'); ?>
+                        <?php wp_nonce_field( 'jlg_platform_action', 'jlg_platform_nonce' ); ?>
                         <input type="hidden" name="jlg_platform_action" value="add">
 
                         <table class="form-table">
@@ -647,11 +729,11 @@ class JLG_Admin_Platforms {
                                 <th><label for="new_platform_name">Nom de la plateforme <span style="color:red;">*</span></label></th>
                                 <td>
                                     <input type="text"
-                                           id="new_platform_name"
-                                           name="new_platform_name"
-                                           class="regular-text"
-                                           placeholder="Ex: PlayStation 6"
-                                           required>
+                                            id="new_platform_name"
+                                            name="new_platform_name"
+                                            class="regular-text"
+                                            placeholder="Ex: PlayStation 6"
+                                            required>
                                     <p class="description">Entrez le nom de la nouvelle plateforme</p>
                                 </td>
                             </tr>
@@ -683,7 +765,7 @@ class JLG_Admin_Platforms {
                     <h3>⚙️ Actions</h3>
 
                     <form method="post" action="" class="jlg-reset-platforms-form">
-                        <?php wp_nonce_field('jlg_platform_action', 'jlg_platform_nonce'); ?>
+                        <?php wp_nonce_field( 'jlg_platform_action', 'jlg_platform_nonce' ); ?>
                         <input type="hidden" name="jlg_platform_action" value="reset">
 
                         <p>
@@ -713,16 +795,16 @@ class JLG_Admin_Platforms {
     }
 
     private function is_debug_enabled() {
-        if ($this->debug_enabled !== null) {
+        if ( $this->debug_enabled !== null ) {
             return $this->debug_enabled;
         }
 
         $options = JLG_Helpers::get_plugin_options();
-        $enabled = !empty($options['debug_mode_enabled']);
+        $enabled = ! empty( $options['debug_mode_enabled'] );
 
-        if (isset($_GET['debug'])) {
-            $raw_debug = sanitize_text_field(wp_unslash($_GET['debug']));
-            if ($raw_debug === '0' || strtolower($raw_debug) === 'false') {
+        if ( isset( $_GET['debug'] ) ) {
+            $raw_debug = sanitize_text_field( wp_unslash( $_GET['debug'] ) );
+            if ( $raw_debug === '0' || strtolower( $raw_debug ) === 'false' ) {
                 $enabled = false;
             } else {
                 $enabled = true;
@@ -734,16 +816,16 @@ class JLG_Admin_Platforms {
         return $this->debug_enabled;
     }
 
-    private function log_debug($message) {
-        if (!$this->is_debug_enabled()) {
+    private function log_debug( $message ) {
+        if ( ! $this->is_debug_enabled() ) {
             return;
         }
 
-        if (is_scalar($message)) {
+        if ( is_scalar( $message ) ) {
             self::$debug_messages[] = (string) $message;
             return;
         }
 
-        self::$debug_messages[] = wp_json_encode($message);
+        self::$debug_messages[] = wp_json_encode( $message );
     }
 }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-settings.php
@@ -1,78 +1,80 @@
 <?php
 /**
  * Gestion des réglages du plugin
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Admin_Settings {
 
-    private $option_name = 'notation_jlg_settings';
-    private $field_constraints = [];
+    private $option_name       = 'notation_jlg_settings';
+    private $field_constraints = array();
 
     public function __construct() {
-        add_action('admin_init', [$this, 'register_settings']);
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
     }
 
     public function register_settings() {
-        register_setting('notation_jlg_page', $this->option_name, [$this, 'sanitize_options']);
+        register_setting( 'notation_jlg_page', $this->option_name, array( $this, 'sanitize_options' ) );
         $this->register_all_sections();
     }
 
-    public function sanitize_options($input) {
-        if (!is_array($input)) {
+    public function sanitize_options( $input ) {
+        if ( ! is_array( $input ) ) {
             return JLG_Helpers::get_default_settings();
         }
 
-        $sanitized = [];
-        $defaults = JLG_Helpers::get_default_settings();
+        $sanitized = array();
+        $defaults  = JLG_Helpers::get_default_settings();
 
         // IMPORTANT: Traiter d'abord les champs select pour les modes de couleur
         // Ces champs doivent être traités spécialement pour conserver leur valeur
-        $select_fields = [
-            'visual_theme' => ['dark', 'light'],
-            'score_layout' => ['text', 'circle'],
-            'text_glow_color_mode' => ['dynamic', 'custom'],
-            'circle_glow_color_mode' => ['dynamic', 'custom'],
-            'table_border_style' => ['none', 'horizontal', 'full'],
-        ];
+        $select_fields = array(
+            'visual_theme'           => array( 'dark', 'light' ),
+            'score_layout'           => array( 'text', 'circle' ),
+            'text_glow_color_mode'   => array( 'dynamic', 'custom' ),
+            'circle_glow_color_mode' => array( 'dynamic', 'custom' ),
+            'table_border_style'     => array( 'none', 'horizontal', 'full' ),
+        );
 
-        foreach ($select_fields as $field => $allowed_values) {
-            if (isset($input[$field])) {
-                $value = sanitize_key(wp_unslash($input[$field]));
+        foreach ( $select_fields as $field => $allowed_values ) {
+            if ( isset( $input[ $field ] ) ) {
+                $value = sanitize_key( wp_unslash( $input[ $field ] ) );
 
-                if (in_array($value, $allowed_values, true)) {
-                    $sanitized[$field] = $value;
+                if ( in_array( $value, $allowed_values, true ) ) {
+                    $sanitized[ $field ] = $value;
                     continue;
                 }
             }
 
-            $sanitized[$field] = $defaults[$field] ?? '';
+            $sanitized[ $field ] = $defaults[ $field ] ?? '';
         }
 
         // Traiter les autres champs
-        foreach ($defaults as $key => $default_value) {
+        foreach ( $defaults as $key => $default_value ) {
             // Skip les champs déjà traités
-            if (array_key_exists($key, $select_fields)) {
+            if ( array_key_exists( $key, $select_fields ) ) {
                 continue;
             }
 
-            if (isset($input[$key])) {
-                $sanitized[$key] = $this->sanitize_option_value($key, $input[$key], $default_value);
+            if ( isset( $input[ $key ] ) ) {
+                $sanitized[ $key ] = $this->sanitize_option_value( $key, $input[ $key ], $default_value );
             } else {
                 // Pour les checkboxes non cochées
                 if (
-                    strpos($key, 'enabled') !== false ||
-                    strpos($key, 'pulse') !== false ||
-                    strpos($key, 'striping') !== false ||
-                    strpos($key, 'enable_') === 0
+                    strpos( $key, 'enabled' ) !== false ||
+                    strpos( $key, 'pulse' ) !== false ||
+                    strpos( $key, 'striping' ) !== false ||
+                    strpos( $key, 'enable_' ) === 0
                 ) {
-                    $sanitized[$key] = 0;
+                    $sanitized[ $key ] = 0;
                 } else {
-                    $sanitized[$key] = $default_value;
+                    $sanitized[ $key ] = $default_value;
                 }
             }
         }
@@ -82,161 +84,161 @@ class JLG_Admin_Settings {
         return $sanitized;
     }
 
-    private function sanitize_option_value($key, $value, $default_value = '') {
-        if (isset($this->field_constraints[$key])) {
-            return $this->normalize_numeric_value($key, $value, $default_value);
+    private function sanitize_option_value( $key, $value, $default_value = '' ) {
+        if ( isset( $this->field_constraints[ $key ] ) ) {
+            return $this->normalize_numeric_value( $key, $value, $default_value );
         }
 
         // Couleurs
-        if (strpos($key, 'color') !== false && strpos($key, 'color_mode') === false) {
-            $allow_transparent_fields = [
+        if ( strpos( $key, 'color' ) !== false && strpos( $key, 'color_mode' ) === false ) {
+            $allow_transparent_fields = array(
                 'table_row_bg_color',
                 'table_zebra_bg_color',
-            ];
+            );
 
-            $trimmed_value = is_string($value) ? strtolower(trim($value)) : '';
+            $trimmed_value = is_string( $value ) ? strtolower( trim( $value ) ) : '';
 
             if (
                 $trimmed_value === 'transparent'
-                && in_array($key, $allow_transparent_fields, true)
+                && in_array( $key, $allow_transparent_fields, true )
             ) {
                 return 'transparent';
             }
 
-            $sanitized_color = sanitize_hex_color($value);
+            $sanitized_color = sanitize_hex_color( $value );
 
-            if (!empty($sanitized_color)) {
+            if ( ! empty( $sanitized_color ) ) {
                 return $sanitized_color;
             }
 
-            $default_trimmed = is_string($default_value) ? strtolower(trim($default_value)) : '';
+            $default_trimmed = is_string( $default_value ) ? strtolower( trim( $default_value ) ) : '';
 
             if (
                 $default_trimmed === 'transparent'
-                && in_array($key, $allow_transparent_fields, true)
+                && in_array( $key, $allow_transparent_fields, true )
             ) {
                 return 'transparent';
             }
 
-            $sanitized_default = is_string($default_value) ? sanitize_hex_color($default_value) : '';
+            $sanitized_default = is_string( $default_value ) ? sanitize_hex_color( $default_value ) : '';
 
             return $sanitized_default ? $sanitized_default : '';
         }
-        
+
         // Nombres
-        if (strpos($key, 'size') !== false || strpos($key, 'width') !== false ||
-            strpos($key, 'padding') !== false || strpos($key, 'radius') !== false ||
-            strpos($key, 'intensity') !== false || strpos($key, 'speed') !== false) {
-            return is_numeric($value) ? floatval($value) : (is_numeric($default_value) ? floatval($default_value) : 0);
+        if ( strpos( $key, 'size' ) !== false || strpos( $key, 'width' ) !== false ||
+            strpos( $key, 'padding' ) !== false || strpos( $key, 'radius' ) !== false ||
+            strpos( $key, 'intensity' ) !== false || strpos( $key, 'speed' ) !== false ) {
+            return is_numeric( $value ) ? floatval( $value ) : ( is_numeric( $default_value ) ? floatval( $default_value ) : 0 );
         }
-        
+
         // Checkboxes
         if (
-            strpos($key, 'enabled') !== false ||
-            strpos($key, 'pulse') !== false ||
-            strpos($key, 'striping') !== false ||
-            strpos($key, 'enable_') === 0
+            strpos( $key, 'enabled' ) !== false ||
+            strpos( $key, 'pulse' ) !== false ||
+            strpos( $key, 'striping' ) !== false ||
+            strpos( $key, 'enable_' ) === 0
         ) {
-            return !empty($value) ? 1 : 0;
+            return ! empty( $value ) ? 1 : 0;
         }
 
         // CSS personnalisé
-        if ($key === 'custom_css') {
-            return wp_strip_all_tags($value);
+        if ( $key === 'custom_css' ) {
+            return wp_strip_all_tags( $value );
         }
 
         // API Key
-        if ($key === 'rawg_api_key') {
-            return sanitize_text_field($value);
+        if ( $key === 'rawg_api_key' ) {
+            return sanitize_text_field( $value );
         }
-        
+
         // Texte par défaut
-        return sanitize_text_field($value);
+        return sanitize_text_field( $value );
     }
 
-    private function normalize_numeric_value($key, $value, $default_value) {
-        $constraints = $this->field_constraints[$key];
+    private function normalize_numeric_value( $key, $value, $default_value ) {
+        $constraints = $this->field_constraints[ $key ];
 
-        $min = isset($constraints['min']) ? floatval($constraints['min']) : null;
-        $max = isset($constraints['max']) ? floatval($constraints['max']) : null;
-        $step = isset($constraints['step']) ? floatval($constraints['step']) : null;
+        $min  = isset( $constraints['min'] ) ? floatval( $constraints['min'] ) : null;
+        $max  = isset( $constraints['max'] ) ? floatval( $constraints['max'] ) : null;
+        $step = isset( $constraints['step'] ) ? floatval( $constraints['step'] ) : null;
 
-        if (!is_numeric($value)) {
-            if (is_numeric($default_value)) {
-                $number = floatval($default_value);
-            } elseif ($min !== null) {
+        if ( ! is_numeric( $value ) ) {
+            if ( is_numeric( $default_value ) ) {
+                $number = floatval( $default_value );
+            } elseif ( $min !== null ) {
                 $number = $min;
             } else {
                 $number = 0;
             }
         } else {
-            $number = floatval($value);
+            $number = floatval( $value );
         }
 
-        if ($min !== null) {
-            $number = max($number, $min);
+        if ( $min !== null ) {
+            $number = max( $number, $min );
         }
 
-        if ($max !== null) {
-            $number = min($number, $max);
+        if ( $max !== null ) {
+            $number = min( $number, $max );
         }
 
-        if ($step !== null && $step > 0) {
-            $base = ($min !== null) ? $min : 0.0;
-            $steps = round(($number - $base) / $step);
-            $number = $base + ($steps * $step);
-            $number = $this->round_to_step_precision($number, $step);
+        if ( $step !== null && $step > 0 ) {
+            $base   = ( $min !== null ) ? $min : 0.0;
+            $steps  = round( ( $number - $base ) / $step );
+            $number = $base + ( $steps * $step );
+            $number = $this->round_to_step_precision( $number, $step );
 
-            if ($min !== null) {
-                $number = max($number, $min);
+            if ( $min !== null ) {
+                $number = max( $number, $min );
             }
 
-            if ($max !== null) {
-                $number = min($number, $max);
+            if ( $max !== null ) {
+                $number = min( $number, $max );
             }
         }
 
-        if ($this->should_cast_to_int($step, $min, $max, $default_value)) {
-            return (int) round($number);
+        if ( $this->should_cast_to_int( $step, $min, $max, $default_value ) ) {
+            return (int) round( $number );
         }
 
         return $number;
     }
 
-    private function round_to_step_precision($value, $step) {
-        $precision = $this->get_step_precision($step);
+    private function round_to_step_precision( $value, $step ) {
+        $precision = $this->get_step_precision( $step );
 
-        if ($precision > 0) {
-            return round($value, $precision);
+        if ( $precision > 0 ) {
+            return round( $value, $precision );
         }
 
-        return round($value);
+        return round( $value );
     }
 
-    private function get_step_precision($step) {
-        $formatted = rtrim(rtrim(sprintf('%.10F', $step), '0'), '.');
-        $decimal_position = strpos($formatted, '.');
+    private function get_step_precision( $step ) {
+        $formatted        = rtrim( rtrim( sprintf( '%.10F', $step ), '0' ), '.' );
+        $decimal_position = strpos( $formatted, '.' );
 
-        if ($decimal_position === false) {
+        if ( $decimal_position === false ) {
             return 0;
         }
 
-        return strlen($formatted) - $decimal_position - 1;
+        return strlen( $formatted ) - $decimal_position - 1;
     }
 
-    private function should_cast_to_int($step, $min, $max, $default_value) {
+    private function should_cast_to_int( $step, $min, $max, $default_value ) {
         $step = $step ?? 1.0;
 
-        if (!$this->is_integer_like($step)) {
+        if ( ! $this->is_integer_like( $step ) ) {
             return false;
         }
 
-        foreach ([$min, $max, $default_value] as $value) {
-            if ($value === null || $value === '') {
+        foreach ( array( $min, $max, $default_value ) as $value ) {
+            if ( $value === null || $value === '' ) {
                 continue;
             }
 
-            if (!$this->is_integer_like($value)) {
+            if ( ! $this->is_integer_like( $value ) ) {
                 return false;
             }
         }
@@ -244,414 +246,847 @@ class JLG_Admin_Settings {
         return true;
     }
 
-    private function is_integer_like($value) {
-        if (!is_numeric($value)) {
+    private function is_integer_like( $value ) {
+        if ( ! is_numeric( $value ) ) {
             return false;
         }
 
-        return abs($value - round($value)) < 0.000001;
+        return abs( $value - round( $value ) ) < 0.000001;
     }
 
-    private function store_field_constraints(array $args) {
-        if (($args['type'] ?? '') !== 'number' || empty($args['id'])) {
+    private function store_field_constraints( array $args ) {
+        if ( ( $args['type'] ?? '' ) !== 'number' || empty( $args['id'] ) ) {
             return;
         }
 
-        $this->field_constraints[$args['id']] = [
-            'min' => $args['min'] ?? null,
-            'max' => $args['max'] ?? null,
+        $this->field_constraints[ $args['id'] ] = array(
+            'min'  => $args['min'] ?? null,
+            'max'  => $args['max'] ?? null,
             'step' => $args['step'] ?? null,
-        ];
+        );
     }
 
     private function register_all_sections() {
         // Section 1: Libellés
-        add_settings_section('jlg_labels', '1. 📝 Libellés des Catégories', null, 'notation_jlg_page');
-        for ($i = 1; $i <= 6; $i++) {
+        add_settings_section( 'jlg_labels', '1. 📝 Libellés des Catégories', null, 'notation_jlg_page' );
+        for ( $i = 1; $i <= 6; $i++ ) {
             add_settings_field(
                 'label_cat' . $i,
                 'Catégorie ' . $i,
-                [$this, 'render_field'],
+                array( $this, 'render_field' ),
                 'notation_jlg_page',
                 'jlg_labels',
-                ['id' => 'label_cat' . $i, 'type' => 'text', 'placeholder' => $this->get_default_label($i)]
+                array(
+					'id'          => 'label_cat' . $i,
+					'type'        => 'text',
+					'placeholder' => $this->get_default_label( $i ),
+				)
             );
         }
 
         // Section 2: Présentation de la Note Globale
-        add_settings_section('jlg_layout', '2. 🎨 Présentation de la Note Globale', null, 'notation_jlg_page');
-        add_settings_field('score_layout', 'Style d\'affichage', [$this, 'render_field'], 'notation_jlg_page', 'jlg_layout',
-            ['id' => 'score_layout', 'type' => 'select', 'options' => ['text' => 'Texte simple', 'circle' => 'Dans un cercle']]
+        add_settings_section( 'jlg_layout', '2. 🎨 Présentation de la Note Globale', null, 'notation_jlg_page' );
+        add_settings_field(
+            'score_layout',
+            'Style d\'affichage',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
+            array(
+				'id'      => 'score_layout',
+				'type'    => 'select',
+				'options' => array(
+					'text'   => 'Texte simple',
+					'circle' => 'Dans un cercle',
+				),
+			)
         );
-        add_settings_field('circle_dynamic_bg_enabled', 'Fond dynamique (Mode Cercle)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_layout',
-            ['id' => 'circle_dynamic_bg_enabled', 'type' => 'checkbox', 'desc' => 'La couleur du cercle change selon la note']
+        add_settings_field(
+            'circle_dynamic_bg_enabled',
+            'Fond dynamique (Mode Cercle)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
+            array(
+				'id'   => 'circle_dynamic_bg_enabled',
+				'type' => 'checkbox',
+				'desc' => 'La couleur du cercle change selon la note',
+			)
         );
-        add_settings_field('circle_border_enabled', 'Activer la bordure (Mode Cercle)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_layout',
-            ['id' => 'circle_border_enabled', 'type' => 'checkbox']
+        add_settings_field(
+            'circle_border_enabled',
+            'Activer la bordure (Mode Cercle)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
+            array(
+				'id'   => 'circle_border_enabled',
+				'type' => 'checkbox',
+			)
         );
-        $circle_border_width_args = ['id' => 'circle_border_width', 'type' => 'number', 'min' => 1, 'max' => 20];
-        add_settings_field('circle_border_width', 'Épaisseur bordure (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_layout',
+        $circle_border_width_args = array(
+			'id'   => 'circle_border_width',
+			'type' => 'number',
+			'min'  => 1,
+			'max'  => 20,
+		);
+        add_settings_field(
+            'circle_border_width',
+            'Épaisseur bordure (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
             $circle_border_width_args
         );
-        $this->store_field_constraints($circle_border_width_args);
-        add_settings_field('circle_border_color', 'Couleur de la bordure', [$this, 'render_field'], 'notation_jlg_page', 'jlg_layout',
-            ['id' => 'circle_border_color', 'type' => 'color']
+        $this->store_field_constraints( $circle_border_width_args );
+        add_settings_field(
+            'circle_border_color',
+            'Couleur de la bordure',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
+            array(
+				'id'   => 'circle_border_color',
+				'type' => 'color',
+			)
         );
 
         // Section 3: Couleurs & Thèmes
-        add_settings_section('jlg_colors', '3. 🌈 Couleurs & Thèmes', null, 'notation_jlg_page');
-        add_settings_field('visual_theme', 'Thème Visuel Principal', [$this, 'render_field'], 'notation_jlg_page', 'jlg_colors',
-            ['id' => 'visual_theme', 'type' => 'select', 'options' => ['dark' => 'Thème Sombre', 'light' => 'Thème Clair']]
+        add_settings_section( 'jlg_colors', '3. 🌈 Couleurs & Thèmes', null, 'notation_jlg_page' );
+        add_settings_field(
+            'visual_theme',
+            'Thème Visuel Principal',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_colors',
+            array(
+				'id'      => 'visual_theme',
+				'type'    => 'select',
+				'options' => array(
+					'dark'  => 'Thème Sombre',
+					'light' => 'Thème Clair',
+				),
+			)
         );
-        
+
         // Couleurs thème sombre
-        add_settings_field('dark_theme_header', '<h4>Couleurs du Thème Sombre</h4>', function(){}, 'notation_jlg_page', 'jlg_colors');
-        $dark_colors = [
-            'dark_bg_color' => 'Fond principal',
-            'dark_bg_color_secondary' => 'Fond secondaire',
-            'dark_text_color' => 'Texte principal',
+        add_settings_field( 'dark_theme_header', '<h4>Couleurs du Thème Sombre</h4>', function () {}, 'notation_jlg_page', 'jlg_colors' );
+        $dark_colors = array(
+            'dark_bg_color'             => 'Fond principal',
+            'dark_bg_color_secondary'   => 'Fond secondaire',
+            'dark_text_color'           => 'Texte principal',
             'dark_text_color_secondary' => 'Texte secondaire',
-            'dark_border_color' => 'Bordures'
-        ];
-        foreach ($dark_colors as $id => $label) {
-            add_settings_field($id, $label, [$this, 'render_field'], 'notation_jlg_page', 'jlg_colors',
-                ['id' => $id, 'type' => 'color']
+            'dark_border_color'         => 'Bordures',
+        );
+        foreach ( $dark_colors as $id => $label ) {
+            add_settings_field(
+                $id,
+                $label,
+                array( $this, 'render_field' ),
+                'notation_jlg_page',
+                'jlg_colors',
+                array(
+					'id'   => $id,
+					'type' => 'color',
+				)
             );
         }
 
         // Couleurs thème clair
-        add_settings_field('light_theme_header', '<h4>Couleurs du Thème Clair</h4>', function(){}, 'notation_jlg_page', 'jlg_colors');
-        $light_colors = [
-            'light_bg_color' => 'Fond principal',
-            'light_bg_color_secondary' => 'Fond secondaire',
-            'light_text_color' => 'Texte principal',
+        add_settings_field( 'light_theme_header', '<h4>Couleurs du Thème Clair</h4>', function () {}, 'notation_jlg_page', 'jlg_colors' );
+        $light_colors = array(
+            'light_bg_color'             => 'Fond principal',
+            'light_bg_color_secondary'   => 'Fond secondaire',
+            'light_text_color'           => 'Texte principal',
             'light_text_color_secondary' => 'Texte secondaire',
-            'light_border_color' => 'Bordures'
-        ];
-        foreach ($light_colors as $id => $label) {
-            add_settings_field($id, $label, [$this, 'render_field'], 'notation_jlg_page', 'jlg_colors',
-                ['id' => $id, 'type' => 'color']
+            'light_border_color'         => 'Bordures',
+        );
+        foreach ( $light_colors as $id => $label ) {
+            add_settings_field(
+                $id,
+                $label,
+                array( $this, 'render_field' ),
+                'notation_jlg_page',
+                'jlg_colors',
+                array(
+					'id'   => $id,
+					'type' => 'color',
+				)
             );
         }
 
         // Couleurs sémantiques
-        add_settings_field('semantic_colors_header', '<h4>Couleurs Sémantiques</h4>', function(){}, 'notation_jlg_page', 'jlg_colors');
-        $semantic_colors = [
+        add_settings_field( 'semantic_colors_header', '<h4>Couleurs Sémantiques</h4>', function () {}, 'notation_jlg_page', 'jlg_colors' );
+        $semantic_colors = array(
             'score_gradient_1' => 'Dégradé Note 1',
             'score_gradient_2' => 'Dégradé Note 2',
-            'color_low' => 'Notes Faibles (0-3)',
-            'color_mid' => 'Notes Moyennes (4-7)',
-            'color_high' => 'Notes Élevées (8-10)'
-        ];
-        foreach ($semantic_colors as $id => $label) {
-            add_settings_field($id, $label, [$this, 'render_field'], 'notation_jlg_page', 'jlg_colors',
-                ['id' => $id, 'type' => 'color']
+            'color_low'        => 'Notes Faibles (0-3)',
+            'color_mid'        => 'Notes Moyennes (4-7)',
+            'color_high'       => 'Notes Élevées (8-10)',
+        );
+        foreach ( $semantic_colors as $id => $label ) {
+            add_settings_field(
+                $id,
+                $label,
+                array( $this, 'render_field' ),
+                'notation_jlg_page',
+                'jlg_colors',
+                array(
+					'id'   => $id,
+					'type' => 'color',
+				)
             );
         }
 
         // Section 4: Effet Glow/Neon (Mode Texte)
-        add_settings_section('jlg_glow_text', '4. ✨ Effet Neon - Mode Texte', null, 'notation_jlg_page');
-        add_settings_field('text_glow_enabled', 'Activer l\'effet Neon', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
-            ['id' => 'text_glow_enabled', 'type' => 'checkbox', 'desc' => 'Ajoute un halo lumineux à la note en mode texte']
+        add_settings_section( 'jlg_glow_text', '4. ✨ Effet Neon - Mode Texte', null, 'notation_jlg_page' );
+        add_settings_field(
+            'text_glow_enabled',
+            'Activer l\'effet Neon',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
+            array(
+				'id'   => 'text_glow_enabled',
+				'type' => 'checkbox',
+				'desc' => 'Ajoute un halo lumineux à la note en mode texte',
+			)
         );
-        add_settings_field('text_glow_color_mode', 'Mode de couleur', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
-            ['id' => 'text_glow_color_mode', 'type' => 'select', 
-             'options' => ['dynamic' => 'Dynamique (selon la note)', 'custom' => 'Couleur fixe'],
-             'desc' => 'Dynamique = couleur change selon la note (vert/orange/rouge), Fixe = couleur personnalisée']
+        add_settings_field(
+            'text_glow_color_mode',
+            'Mode de couleur',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
+            array(
+				'id'      => 'text_glow_color_mode',
+				'type'    => 'select',
+				'options' => array(
+					'dynamic' => 'Dynamique (selon la note)',
+					'custom'  => 'Couleur fixe',
+				),
+				'desc'    => 'Dynamique = couleur change selon la note (vert/orange/rouge), Fixe = couleur personnalisée',
+			)
         );
-        add_settings_field('text_glow_custom_color', 'Couleur personnalisée', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
-            ['id' => 'text_glow_custom_color', 'type' => 'color', 'desc' => 'Utilisée uniquement si mode "Couleur fixe" est sélectionné']
+        add_settings_field(
+            'text_glow_custom_color',
+            'Couleur personnalisée',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
+            array(
+				'id'   => 'text_glow_custom_color',
+				'type' => 'color',
+				'desc' => 'Utilisée uniquement si mode "Couleur fixe" est sélectionné',
+			)
         );
-        $text_glow_intensity_args = ['id' => 'text_glow_intensity', 'type' => 'number', 'min' => 5, 'max' => 50];
-        add_settings_field('text_glow_intensity', 'Intensité (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
+        $text_glow_intensity_args = array(
+			'id'   => 'text_glow_intensity',
+			'type' => 'number',
+			'min'  => 5,
+			'max'  => 50,
+		);
+        add_settings_field(
+            'text_glow_intensity',
+            'Intensité (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
             $text_glow_intensity_args
         );
-        $this->store_field_constraints($text_glow_intensity_args);
-        add_settings_field('text_glow_pulse', 'Activer la pulsation', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
-            ['id' => 'text_glow_pulse', 'type' => 'checkbox', 'desc' => 'Animation de pulsation du halo']
+        $this->store_field_constraints( $text_glow_intensity_args );
+        add_settings_field(
+            'text_glow_pulse',
+            'Activer la pulsation',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
+            array(
+				'id'   => 'text_glow_pulse',
+				'type' => 'checkbox',
+				'desc' => 'Animation de pulsation du halo',
+			)
         );
-        $text_glow_speed_args = ['id' => 'text_glow_speed', 'type' => 'number', 'min' => 0.5, 'max' => 10, 'step' => 0.1];
-        add_settings_field('text_glow_speed', 'Vitesse pulsation (sec)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_text',
+        $text_glow_speed_args = array(
+			'id'   => 'text_glow_speed',
+			'type' => 'number',
+			'min'  => 0.5,
+			'max'  => 10,
+			'step' => 0.1,
+		);
+        add_settings_field(
+            'text_glow_speed',
+            'Vitesse pulsation (sec)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_text',
             $text_glow_speed_args
         );
-        $this->store_field_constraints($text_glow_speed_args);
+        $this->store_field_constraints( $text_glow_speed_args );
 
         // Section 5: Effet Glow/Neon (Mode Cercle)
-        add_settings_section('jlg_glow_circle', '5. ✨ Effet Neon - Mode Cercle', null, 'notation_jlg_page');
-        add_settings_field('circle_glow_enabled', 'Activer l\'effet Neon', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
-            ['id' => 'circle_glow_enabled', 'type' => 'checkbox', 'desc' => 'Ajoute un halo lumineux au cercle']
+        add_settings_section( 'jlg_glow_circle', '5. ✨ Effet Neon - Mode Cercle', null, 'notation_jlg_page' );
+        add_settings_field(
+            'circle_glow_enabled',
+            'Activer l\'effet Neon',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
+            array(
+				'id'   => 'circle_glow_enabled',
+				'type' => 'checkbox',
+				'desc' => 'Ajoute un halo lumineux au cercle',
+			)
         );
-        add_settings_field('circle_glow_color_mode', 'Mode de couleur', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
-            ['id' => 'circle_glow_color_mode', 'type' => 'select',
-             'options' => ['dynamic' => 'Dynamique (selon la note)', 'custom' => 'Couleur fixe'],
-             'desc' => 'Dynamique = couleur change selon la note (vert/orange/rouge), Fixe = couleur personnalisée']
+        add_settings_field(
+            'circle_glow_color_mode',
+            'Mode de couleur',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
+            array(
+				'id'      => 'circle_glow_color_mode',
+				'type'    => 'select',
+				'options' => array(
+					'dynamic' => 'Dynamique (selon la note)',
+					'custom'  => 'Couleur fixe',
+				),
+				'desc'    => 'Dynamique = couleur change selon la note (vert/orange/rouge), Fixe = couleur personnalisée',
+			)
         );
-        add_settings_field('circle_glow_custom_color', 'Couleur personnalisée', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
-            ['id' => 'circle_glow_custom_color', 'type' => 'color', 'desc' => 'Utilisée uniquement si mode "Couleur fixe" est sélectionné']
+        add_settings_field(
+            'circle_glow_custom_color',
+            'Couleur personnalisée',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
+            array(
+				'id'   => 'circle_glow_custom_color',
+				'type' => 'color',
+				'desc' => 'Utilisée uniquement si mode "Couleur fixe" est sélectionné',
+			)
         );
-        $circle_glow_intensity_args = ['id' => 'circle_glow_intensity', 'type' => 'number', 'min' => 5, 'max' => 50];
-        add_settings_field('circle_glow_intensity', 'Intensité (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
+        $circle_glow_intensity_args = array(
+			'id'   => 'circle_glow_intensity',
+			'type' => 'number',
+			'min'  => 5,
+			'max'  => 50,
+		);
+        add_settings_field(
+            'circle_glow_intensity',
+            'Intensité (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
             $circle_glow_intensity_args
         );
-        $this->store_field_constraints($circle_glow_intensity_args);
-        add_settings_field('circle_glow_pulse', 'Activer la pulsation', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
-            ['id' => 'circle_glow_pulse', 'type' => 'checkbox']
+        $this->store_field_constraints( $circle_glow_intensity_args );
+        add_settings_field(
+            'circle_glow_pulse',
+            'Activer la pulsation',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
+            array(
+				'id'   => 'circle_glow_pulse',
+				'type' => 'checkbox',
+			)
         );
-        $circle_glow_speed_args = ['id' => 'circle_glow_speed', 'type' => 'number', 'min' => 0.5, 'max' => 10, 'step' => 0.1];
-        add_settings_field('circle_glow_speed', 'Vitesse pulsation (sec)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_glow_circle',
+        $circle_glow_speed_args = array(
+			'id'   => 'circle_glow_speed',
+			'type' => 'number',
+			'min'  => 0.5,
+			'max'  => 10,
+			'step' => 0.1,
+		);
+        add_settings_field(
+            'circle_glow_speed',
+            'Vitesse pulsation (sec)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_glow_circle',
             $circle_glow_speed_args
         );
-        $this->store_field_constraints($circle_glow_speed_args);
+        $this->store_field_constraints( $circle_glow_speed_args );
 
         // Section 6: Modules
-        add_settings_section('jlg_modules', '6. 🧩 Modules', null, 'notation_jlg_page');
-        $module_fields = [
+        add_settings_section( 'jlg_modules', '6. 🧩 Modules', null, 'notation_jlg_page' );
+        $module_fields = array(
             'user_rating_enabled' => 'Notation utilisateurs',
-            'tagline_enabled' => 'Taglines bilingues',
-            'seo_schema_enabled' => 'Schéma SEO (étoiles Google)',
-            'enable_animations' => 'Animations des barres'
-        ];
-        foreach ($module_fields as $id => $title) {
-            add_settings_field($id, $title, [$this, 'render_field'], 'notation_jlg_page', 'jlg_modules',
-                ['id' => $id, 'type' => 'checkbox']
+            'tagline_enabled'     => 'Taglines bilingues',
+            'seo_schema_enabled'  => 'Schéma SEO (étoiles Google)',
+            'enable_animations'   => 'Animations des barres',
+        );
+        foreach ( $module_fields as $id => $title ) {
+            add_settings_field(
+                $id,
+                $title,
+                array( $this, 'render_field' ),
+                'notation_jlg_page',
+                'jlg_modules',
+                array(
+					'id'   => $id,
+					'type' => 'checkbox',
+				)
             );
         }
 
         // Section 7: Modules - Tagline
-        add_settings_section('jlg_tagline_section', '7. 💬 Module Tagline', null, 'notation_jlg_page');
-        $tagline_font_size_args = ['id' => 'tagline_font_size', 'type' => 'number', 'min' => 12, 'max' => 32];
-        add_settings_field('tagline_font_size', 'Taille de police (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_tagline_section',
+        add_settings_section( 'jlg_tagline_section', '7. 💬 Module Tagline', null, 'notation_jlg_page' );
+        $tagline_font_size_args = array(
+			'id'   => 'tagline_font_size',
+			'type' => 'number',
+			'min'  => 12,
+			'max'  => 32,
+		);
+        add_settings_field(
+            'tagline_font_size',
+            'Taille de police (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_tagline_section',
             $tagline_font_size_args
         );
-        $this->store_field_constraints($tagline_font_size_args);
-        add_settings_field('tagline_bg_color', 'Fond de la tagline', [$this, 'render_field'], 'notation_jlg_page', 'jlg_tagline_section',
-            ['id' => 'tagline_bg_color', 'type' => 'color']
+        $this->store_field_constraints( $tagline_font_size_args );
+        add_settings_field(
+            'tagline_bg_color',
+            'Fond de la tagline',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_tagline_section',
+            array(
+				'id'   => 'tagline_bg_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('tagline_text_color', 'Texte de la tagline', [$this, 'render_field'], 'notation_jlg_page', 'jlg_tagline_section',
-            ['id' => 'tagline_text_color', 'type' => 'color']
+        add_settings_field(
+            'tagline_text_color',
+            'Texte de la tagline',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_tagline_section',
+            array(
+				'id'   => 'tagline_text_color',
+				'type' => 'color',
+			)
         );
 
         // Section 8: Modules - Notation Utilisateurs
-        add_settings_section('jlg_user_rating_section', '8. ⭐ Module Notation Utilisateurs', null, 'notation_jlg_page');
-        add_settings_field('user_rating_title_color', 'Couleur du titre', [$this, 'render_field'], 'notation_jlg_page', 'jlg_user_rating_section',
-            ['id' => 'user_rating_title_color', 'type' => 'color']
+        add_settings_section( 'jlg_user_rating_section', '8. ⭐ Module Notation Utilisateurs', null, 'notation_jlg_page' );
+        add_settings_field(
+            'user_rating_title_color',
+            'Couleur du titre',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_user_rating_section',
+            array(
+				'id'   => 'user_rating_title_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('user_rating_text_color', 'Couleur du texte', [$this, 'render_field'], 'notation_jlg_page', 'jlg_user_rating_section',
-            ['id' => 'user_rating_text_color', 'type' => 'color']
+        add_settings_field(
+            'user_rating_text_color',
+            'Couleur du texte',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_user_rating_section',
+            array(
+				'id'   => 'user_rating_text_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('user_rating_star_color', 'Couleur des étoiles', [$this, 'render_field'], 'notation_jlg_page', 'jlg_user_rating_section',
-            ['id' => 'user_rating_star_color', 'type' => 'color']
+        add_settings_field(
+            'user_rating_star_color',
+            'Couleur des étoiles',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_user_rating_section',
+            array(
+				'id'   => 'user_rating_star_color',
+				'type' => 'color',
+			)
         );
 
         // Section 9: Tableau Récapitulatif
-        add_settings_section('jlg_table', '9. 📊 Tableau Récapitulatif', null, 'notation_jlg_page');
-        add_settings_field('table_header_bg_color', 'Fond de l\'en-tête', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_header_bg_color', 'type' => 'color']
+        add_settings_section( 'jlg_table', '9. 📊 Tableau Récapitulatif', null, 'notation_jlg_page' );
+        add_settings_field(
+            'table_header_bg_color',
+            'Fond de l\'en-tête',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_header_bg_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('table_header_text_color', 'Texte de l\'en-tête', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_header_text_color', 'type' => 'color']
+        add_settings_field(
+            'table_header_text_color',
+            'Texte de l\'en-tête',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_header_text_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('table_row_bg_color', 'Fond des lignes', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_row_bg_color', 'type' => 'color']
+        add_settings_field(
+            'table_row_bg_color',
+            'Fond des lignes',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_row_bg_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('table_row_text_color', 'Texte des lignes', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_row_text_color', 'type' => 'color']
+        add_settings_field(
+            'table_row_text_color',
+            'Texte des lignes',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_row_text_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('table_zebra_striping', 'Alternance de couleurs', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_zebra_striping', 'type' => 'checkbox']
+        add_settings_field(
+            'table_zebra_striping',
+            'Alternance de couleurs',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_zebra_striping',
+				'type' => 'checkbox',
+			)
         );
-        add_settings_field('table_zebra_bg_color', 'Fond lignes alternées', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_zebra_bg_color', 'type' => 'color']
+        add_settings_field(
+            'table_zebra_bg_color',
+            'Fond lignes alternées',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'   => 'table_zebra_bg_color',
+				'type' => 'color',
+			)
         );
-        add_settings_field('table_border_style', 'Style des bordures', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
-            ['id' => 'table_border_style', 'type' => 'select',
-             'options' => ['none' => 'Aucune', 'horizontal' => 'Horizontales', 'full' => 'Grille complète']]
+        add_settings_field(
+            'table_border_style',
+            'Style des bordures',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
+            array(
+				'id'      => 'table_border_style',
+				'type'    => 'select',
+				'options' => array(
+					'none'       => 'Aucune',
+					'horizontal' => 'Horizontales',
+					'full'       => 'Grille complète',
+				),
+			)
         );
-        $table_border_width_args = ['id' => 'table_border_width', 'type' => 'number', 'min' => 0, 'max' => 10];
-        add_settings_field('table_border_width', 'Épaisseur bordures (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_table',
+        $table_border_width_args = array(
+			'id'   => 'table_border_width',
+			'type' => 'number',
+			'min'  => 0,
+			'max'  => 10,
+		);
+        add_settings_field(
+            'table_border_width',
+            'Épaisseur bordures (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_table',
             $table_border_width_args
         );
-        $this->store_field_constraints($table_border_width_args);
+        $this->store_field_constraints( $table_border_width_args );
 
         // Section 10: Style des Vignettes
-        add_settings_section('jlg_thumbnail_section', '10. 🖼️ Style des Vignettes', null, 'notation_jlg_page');
-        add_settings_field('thumb_text_color', 'Couleur du texte', [$this, 'render_field'], 'notation_jlg_page', 'jlg_thumbnail_section',
-            ['id' => 'thumb_text_color', 'type' => 'color']
+        add_settings_section( 'jlg_thumbnail_section', '10. 🖼️ Style des Vignettes', null, 'notation_jlg_page' );
+        add_settings_field(
+            'thumb_text_color',
+            'Couleur du texte',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_thumbnail_section',
+            array(
+				'id'   => 'thumb_text_color',
+				'type' => 'color',
+			)
         );
-        $thumb_font_size_args = ['id' => 'thumb_font_size', 'type' => 'number', 'min' => 10, 'max' => 24];
-        add_settings_field('thumb_font_size', 'Taille de police (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_thumbnail_section',
+        $thumb_font_size_args = array(
+			'id'   => 'thumb_font_size',
+			'type' => 'number',
+			'min'  => 10,
+			'max'  => 24,
+		);
+        add_settings_field(
+            'thumb_font_size',
+            'Taille de police (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_thumbnail_section',
             $thumb_font_size_args
         );
-        $this->store_field_constraints($thumb_font_size_args);
+        $this->store_field_constraints( $thumb_font_size_args );
 
-        $thumb_padding_args = ['id' => 'thumb_padding', 'type' => 'number', 'min' => 2, 'max' => 20];
-        add_settings_field('thumb_padding', 'Espacement intérieur (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_thumbnail_section',
+        $thumb_padding_args = array(
+			'id'   => 'thumb_padding',
+			'type' => 'number',
+			'min'  => 2,
+			'max'  => 20,
+		);
+        add_settings_field(
+            'thumb_padding',
+            'Espacement intérieur (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_thumbnail_section',
             $thumb_padding_args
         );
-        $this->store_field_constraints($thumb_padding_args);
+        $this->store_field_constraints( $thumb_padding_args );
 
-        $thumb_border_radius_args = ['id' => 'thumb_border_radius', 'type' => 'number', 'min' => 0, 'max' => 50];
-        add_settings_field('thumb_border_radius', 'Arrondi des coins (px)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_thumbnail_section',
+        $thumb_border_radius_args = array(
+			'id'   => 'thumb_border_radius',
+			'type' => 'number',
+			'min'  => 0,
+			'max'  => 50,
+		);
+        add_settings_field(
+            'thumb_border_radius',
+            'Arrondi des coins (px)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_thumbnail_section',
             $thumb_border_radius_args
         );
-        $this->store_field_constraints($thumb_border_radius_args);
+        $this->store_field_constraints( $thumb_border_radius_args );
 
         // Section 11: CSS Personnalisé
-        add_settings_section('jlg_custom', '11. 🎨 CSS Personnalisé', null, 'notation_jlg_page');
-        add_settings_field('custom_css', 'Votre CSS', [$this, 'render_field'], 'notation_jlg_page', 'jlg_custom',
-            ['id' => 'custom_css', 'type' => 'textarea', 'placeholder' => '.review-box-jlg { margin: 50px 0; }']
+        add_settings_section( 'jlg_custom', '11. 🎨 CSS Personnalisé', null, 'notation_jlg_page' );
+        add_settings_field(
+            'custom_css',
+            'Votre CSS',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_custom',
+            array(
+				'id'          => 'custom_css',
+				'type'        => 'textarea',
+				'placeholder' => '.review-box-jlg { margin: 50px 0; }',
+			)
         );
 
         // Section 12: SEO
-        add_settings_section('jlg_seo_section', '12. 🔍 SEO', null, 'notation_jlg_page');
-        add_settings_field('seo_schema_enabled', 'Activer le schéma de notation (JSON-LD)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_seo_section',
-            ['id' => 'seo_schema_enabled', 'type' => 'checkbox', 'desc' => 'Aide Google à afficher des étoiles de notation']
+        add_settings_section( 'jlg_seo_section', '12. 🔍 SEO', null, 'notation_jlg_page' );
+        add_settings_field(
+            'seo_schema_enabled',
+            'Activer le schéma de notation (JSON-LD)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_seo_section',
+            array(
+				'id'   => 'seo_schema_enabled',
+				'type' => 'checkbox',
+				'desc' => 'Aide Google à afficher des étoiles de notation',
+			)
         );
 
         // Section 13: API
-        add_settings_section('jlg_api_section', '13. 🌐 API', null, 'notation_jlg_page');
-        add_settings_field('rawg_api_key', 'Clé API RAWG.io', [$this, 'render_field'], 'notation_jlg_page', 'jlg_api_section',
-            ['id' => 'rawg_api_key', 'type' => 'text', 'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs']
+        add_settings_section( 'jlg_api_section', '13. 🌐 API', null, 'notation_jlg_page' );
+        add_settings_field(
+            'rawg_api_key',
+            'Clé API RAWG.io',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_api_section',
+            array(
+				'id'   => 'rawg_api_key',
+				'type' => 'text',
+				'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs',
+			)
         );
 
         // Section 14: Debug
-        add_settings_section('jlg_debug_section', '14. 🔧 Debug', null, 'notation_jlg_page');
-        add_settings_field('debug_mode_enabled', 'Activer le mode debug', [$this, 'render_field'], 'notation_jlg_page', 'jlg_debug_section',
-            ['id' => 'debug_mode_enabled', 'type' => 'checkbox', 'desc' => 'Affiche des informations de diagnostic dans le code source']
+        add_settings_section( 'jlg_debug_section', '14. 🔧 Debug', null, 'notation_jlg_page' );
+        add_settings_field(
+            'debug_mode_enabled',
+            'Activer le mode debug',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_debug_section',
+            array(
+				'id'   => 'debug_mode_enabled',
+				'type' => 'checkbox',
+				'desc' => 'Affiche des informations de diagnostic dans le code source',
+			)
         );
 
         // Ajout d'un bouton de debug pour voir les options actuelles
-        add_settings_field('debug_current_options', 'Options actuelles', [$this, 'render_debug_info'], 'notation_jlg_page', 'jlg_debug_section');
+        add_settings_field( 'debug_current_options', 'Options actuelles', array( $this, 'render_debug_info' ), 'notation_jlg_page', 'jlg_debug_section' );
 
         // Section 15: Game Explorer
-        add_settings_section('jlg_game_explorer', '15. 🧭 Game Explorer', null, 'notation_jlg_page');
+        add_settings_section( 'jlg_game_explorer', '15. 🧭 Game Explorer', null, 'notation_jlg_page' );
 
-        $game_explorer_columns_args = ['id' => 'game_explorer_columns', 'type' => 'number', 'min' => 2, 'max' => 4];
-        add_settings_field('game_explorer_columns', 'Colonnes (desktop)', [$this, 'render_field'], 'notation_jlg_page', 'jlg_game_explorer',
+        $game_explorer_columns_args = array(
+			'id'   => 'game_explorer_columns',
+			'type' => 'number',
+			'min'  => 2,
+			'max'  => 4,
+		);
+        add_settings_field(
+            'game_explorer_columns',
+            'Colonnes (desktop)',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_game_explorer',
             $game_explorer_columns_args
         );
-        $this->store_field_constraints($game_explorer_columns_args);
+        $this->store_field_constraints( $game_explorer_columns_args );
 
-        $game_explorer_ppp_args = ['id' => 'game_explorer_posts_per_page', 'type' => 'number', 'min' => 6, 'max' => 36];
-        add_settings_field('game_explorer_posts_per_page', 'Jeux par page', [$this, 'render_field'], 'notation_jlg_page', 'jlg_game_explorer',
+        $game_explorer_ppp_args = array(
+			'id'   => 'game_explorer_posts_per_page',
+			'type' => 'number',
+			'min'  => 6,
+			'max'  => 36,
+		);
+        add_settings_field(
+            'game_explorer_posts_per_page',
+            'Jeux par page',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_game_explorer',
             $game_explorer_ppp_args
         );
-        $this->store_field_constraints($game_explorer_ppp_args);
+        $this->store_field_constraints( $game_explorer_ppp_args );
 
-        add_settings_field('game_explorer_filters', 'Filtres disponibles', [$this, 'render_field'], 'notation_jlg_page', 'jlg_game_explorer',
-            [
-                'id' => 'game_explorer_filters',
-                'type' => 'text',
+        add_settings_field(
+            'game_explorer_filters',
+            'Filtres disponibles',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_game_explorer',
+            array(
+                'id'          => 'game_explorer_filters',
+                'type'        => 'text',
                 'placeholder' => 'letter,category,platform,availability',
-                'desc' => __('Liste séparée par des virgules. Options disponibles : letter, category, platform, availability.', 'notation-jlg'),
-            ]
+                'desc'        => __( 'Liste séparée par des virgules. Options disponibles : letter, category, platform, availability.', 'notation-jlg' ),
+            )
         );
     }
 
-    public function render_field($args) {
-        $type = $args['type'] ?? 'text';
+    public function render_field( $args ) {
+        $type   = $args['type'] ?? 'text';
         $method = $type . '_field';
-        
-        if (method_exists('JLG_Form_Renderer', $method)) {
-            call_user_func(['JLG_Form_Renderer', $method], $args);
+
+        if ( method_exists( 'JLG_Form_Renderer', $method ) ) {
+            call_user_func( array( 'JLG_Form_Renderer', $method ), $args );
         } else {
             // Fallback pour les autres types
             $options = JLG_Helpers::get_plugin_options();
-            
-            if ($type === 'textarea') {
+
+            if ( $type === 'textarea' ) {
                 printf(
                     '<textarea name="%s[%s]" rows="10" cols="50" class="large-text code" placeholder="%s">%s</textarea>',
-                    esc_attr($this->option_name),
-                    esc_attr($args['id']),
-                    esc_attr($args['placeholder'] ?? ''),
-                    esc_textarea($options[$args['id']] ?? '')
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $args['placeholder'] ?? '' ),
+                    esc_textarea( $options[ $args['id'] ] ?? '' )
                 );
-            } elseif ($type === 'number') {
-                $min = $args['min'] ?? 0;
-                $max = $args['max'] ?? 100;
+            } elseif ( $type === 'number' ) {
+                $min  = $args['min'] ?? 0;
+                $max  = $args['max'] ?? 100;
                 $step = $args['step'] ?? 1;
                 printf(
                     '<input type="number" class="small-text" name="%s[%s]" value="%s" min="%s" max="%s" step="%s" />',
-                    esc_attr($this->option_name),
-                    esc_attr($args['id']),
-                    esc_attr($options[$args['id']] ?? $min),
-                    esc_attr($min),
-                    esc_attr($max),
-                    esc_attr($step)
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $options[ $args['id'] ] ?? $min ),
+                    esc_attr( $min ),
+                    esc_attr( $max ),
+                    esc_attr( $step )
                 );
-            } elseif ($type === 'select') {
-                $value = $options[$args['id']] ?? '';
-                printf('<select name="%s[%s]" id="%s">', 
-                    esc_attr($this->option_name), 
-                    esc_attr($args['id']),
-                    esc_attr($args['id'])
+            } elseif ( $type === 'select' ) {
+                $value = $options[ $args['id'] ] ?? '';
+                printf(
+                    '<select name="%s[%s]" id="%s">',
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $args['id'] )
                 );
-                foreach ($args['options'] as $key => $label) {
-                    printf('<option value="%s"%s>%s</option>', 
-                        esc_attr($key), 
-                        selected($value, $key, false), 
-                        esc_html($label)
+                foreach ( $args['options'] as $key => $label ) {
+                    printf(
+                        '<option value="%s"%s>%s</option>',
+                        esc_attr( $key ),
+                        selected( $value, $key, false ),
+                        esc_html( $label )
                     );
                 }
                 echo '</select>';
-            } elseif ($type === 'checkbox') {
+            } elseif ( $type === 'checkbox' ) {
                 printf(
                     '<input type="checkbox" name="%s[%s]" id="%s" value="1" %s />',
-                    esc_attr($this->option_name),
-                    esc_attr($args['id']),
-                    esc_attr($args['id']),
-                    checked(1, $options[$args['id']] ?? 0, false)
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $args['id'] ),
+                    checked( 1, $options[ $args['id'] ] ?? 0, false )
                 );
-            } elseif ($type === 'color') {
+            } elseif ( $type === 'color' ) {
                 printf(
                     '<input type="color" name="%s[%s]" id="%s" value="%s" />',
-                    esc_attr($this->option_name),
-                    esc_attr($args['id']),
-                    esc_attr($args['id']),
-                    esc_attr($options[$args['id']] ?? '#000000')
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $options[ $args['id'] ] ?? '#000000' )
                 );
             } else {
                 // Type text par défaut
                 printf(
                     '<input type="text" class="regular-text" name="%s[%s]" id="%s" value="%s" placeholder="%s" />',
-                    esc_attr($this->option_name),
-                    esc_attr($args['id']),
-                    esc_attr($args['id']),
-                    esc_attr($options[$args['id']] ?? ''),
-                    esc_attr($args['placeholder'] ?? '')
+                    esc_attr( $this->option_name ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $args['id'] ),
+                    esc_attr( $options[ $args['id'] ] ?? '' ),
+                    esc_attr( $args['placeholder'] ?? '' )
                 );
             }
-            
-            if (isset($args['desc'])) {
-                printf('<p class="description">%s</p>', wp_kses_post($args['desc']));
+
+            if ( isset( $args['desc'] ) ) {
+                printf( '<p class="description">%s</p>', wp_kses_post( $args['desc'] ) );
             }
         }
     }
-    
+
     public function render_debug_info() {
-        $options = get_option($this->option_name);
-        if (!empty($options['debug_mode_enabled'])) {
+        $options = get_option( $this->option_name );
+        if ( ! empty( $options['debug_mode_enabled'] ) ) {
             echo '<details style="background:#f5f5f5; padding:10px; border:1px solid #ccc; border-radius:4px;">';
             echo '<summary style="cursor:pointer; font-weight:bold;">Voir les valeurs des options Glow/Neon</summary>';
             echo '<pre style="font-size:11px; overflow:auto;">';
-            echo 'text_glow_enabled: ' . (isset($options['text_glow_enabled']) ? $options['text_glow_enabled'] : 'not set') . "\n";
-            echo 'text_glow_color_mode: ' . (isset($options['text_glow_color_mode']) ? $options['text_glow_color_mode'] : 'not set') . "\n";
-            echo 'text_glow_custom_color: ' . (isset($options['text_glow_custom_color']) ? $options['text_glow_custom_color'] : 'not set') . "\n";
+            echo 'text_glow_enabled: ' . ( isset( $options['text_glow_enabled'] ) ? $options['text_glow_enabled'] : 'not set' ) . "\n";
+            echo 'text_glow_color_mode: ' . ( isset( $options['text_glow_color_mode'] ) ? $options['text_glow_color_mode'] : 'not set' ) . "\n";
+            echo 'text_glow_custom_color: ' . ( isset( $options['text_glow_custom_color'] ) ? $options['text_glow_custom_color'] : 'not set' ) . "\n";
             echo "\n";
-            echo 'circle_glow_enabled: ' . (isset($options['circle_glow_enabled']) ? $options['circle_glow_enabled'] : 'not set') . "\n";
-            echo 'circle_glow_color_mode: ' . (isset($options['circle_glow_color_mode']) ? $options['circle_glow_color_mode'] : 'not set') . "\n";
-            echo 'circle_glow_custom_color: ' . (isset($options['circle_glow_custom_color']) ? $options['circle_glow_custom_color'] : 'not set') . "\n";
+            echo 'circle_glow_enabled: ' . ( isset( $options['circle_glow_enabled'] ) ? $options['circle_glow_enabled'] : 'not set' ) . "\n";
+            echo 'circle_glow_color_mode: ' . ( isset( $options['circle_glow_color_mode'] ) ? $options['circle_glow_color_mode'] : 'not set' ) . "\n";
+            echo 'circle_glow_custom_color: ' . ( isset( $options['circle_glow_custom_color'] ) ? $options['circle_glow_custom_color'] : 'not set' ) . "\n";
             echo "\n";
-            echo 'color_low: ' . (isset($options['color_low']) ? $options['color_low'] : 'not set') . "\n";
-            echo 'color_mid: ' . (isset($options['color_mid']) ? $options['color_mid'] : 'not set') . "\n";
-            echo 'color_high: ' . (isset($options['color_high']) ? $options['color_high'] : 'not set') . "\n";
+            echo 'color_low: ' . ( isset( $options['color_low'] ) ? $options['color_low'] : 'not set' ) . "\n";
+            echo 'color_mid: ' . ( isset( $options['color_mid'] ) ? $options['color_mid'] : 'not set' ) . "\n";
+            echo 'color_high: ' . ( isset( $options['color_high'] ) ? $options['color_high'] : 'not set' ) . "\n";
             echo '</pre>';
             echo '</details>';
         }
     }
 
-    private function get_default_label($index) {
-        $defaults = ['Gameplay', 'Graphismes', 'Bande-son', 'Durée de vie', 'Scénario', 'Originalité'];
-        return $defaults[$index - 1] ?? 'Catégorie ' . $index;
+    private function get_default_label( $index ) {
+        $defaults = array( 'Gameplay', 'Graphismes', 'Bande-son', 'Durée de vie', 'Scénario', 'Originalité' );
+        return $defaults[ $index - 1 ] ?? 'Catégorie ' . $index;
     }
 }

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -1,14 +1,16 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Assets {
     private static $instance = null;
-    private $localizations = [];
-    private $text_domain = 'notation-jlg';
+    private $localizations   = array();
+    private $text_domain     = 'notation-jlg';
     private $languages_path;
 
     public static function get_instance() {
-        if (self::$instance === null) {
+        if ( self::$instance === null ) {
             self::$instance = new self();
         }
 
@@ -19,127 +21,147 @@ class JLG_Assets {
         $this->languages_path = JLG_NOTATION_PLUGIN_DIR . 'languages';
         $this->register_default_localizations();
 
-        add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
-        add_action('admin_enqueue_scripts', [$this, 'maybe_localize_scripts'], 20, 0);
-        add_action('wp_enqueue_scripts', [$this, 'maybe_localize_scripts'], 20, 0);
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'maybe_localize_scripts' ), 20, 0 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'maybe_localize_scripts' ), 20, 0 );
     }
 
-    public function enqueue_admin_assets($hook_suffix) {
-        if ($hook_suffix !== 'toplevel_page_notation_jlg_settings') {
+    public function enqueue_admin_assets( $hook_suffix ) {
+        if ( $hook_suffix !== 'toplevel_page_notation_jlg_settings' ) {
             return;
         }
 
-        $active_tab = isset($_GET['tab']) ? sanitize_key(wp_unslash($_GET['tab'])) : 'reglages';
-        if ($active_tab !== 'plateformes') {
+        $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'reglages';
+        if ( $active_tab !== 'plateformes' ) {
             return;
         }
 
-        wp_enqueue_script('jquery-ui-sortable');
+        wp_enqueue_script( 'jquery-ui-sortable' );
 
-        $handle = 'jlg-platforms-order';
-        $src = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-platforms-order.js';
-        $deps = ['jquery', 'jquery-ui-sortable'];
-        $version = defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : false;
+        $handle  = 'jlg-platforms-order';
+        $src     = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-platforms-order.js';
+        $deps    = array( 'jquery', 'jquery-ui-sortable' );
+        $version = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
 
-        wp_register_script($handle, $src, $deps, $version, true);
+        wp_register_script( $handle, $src, $deps, $version, true );
 
-        wp_localize_script($handle, 'jlgPlatformsOrder', [
-            'listSelector' => '#platforms-list',
-            'positionSelector' => '.jlg-platform-position',
-            'handleSelector' => '.jlg-sort-handle',
-            'rowSelector' => 'tr[data-key]',
-            'inputSelector' => 'input[name="platform_order[]"]',
-            'placeholderClass' => 'jlg-sortable-placeholder',
-        ]);
+        wp_localize_script(
+            $handle,
+            'jlgPlatformsOrder',
+            array(
+				'listSelector'     => '#platforms-list',
+				'positionSelector' => '.jlg-platform-position',
+				'handleSelector'   => '.jlg-sort-handle',
+				'rowSelector'      => 'tr[data-key]',
+				'inputSelector'    => 'input[name="platform_order[]"]',
+				'placeholderClass' => 'jlg-sortable-placeholder',
+			)
+        );
 
-        wp_localize_script($handle, 'jlgPlatformsOrderL10n', [
-            'confirmReset'  => esc_html__('Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?', 'notation-jlg'),
-            'confirmDelete' => esc_html__('Êtes-vous sûr de vouloir supprimer la plateforme "%s" ?', 'notation-jlg'),
-            'nonce'         => wp_create_nonce('jlg_platform_action'),
-            'nonceField'    => 'jlg_platform_nonce',
-            'actionField'   => 'jlg_platform_action',
-            'deleteAction'  => 'delete',
-        ]);
+        wp_localize_script(
+            $handle,
+            'jlgPlatformsOrderL10n',
+            array(
+				'confirmReset'  => esc_html__( 'Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?', 'notation-jlg' ),
+				'confirmDelete' => esc_html__( 'Êtes-vous sûr de vouloir supprimer la plateforme "%s" ?', 'notation-jlg' ),
+				'nonce'         => wp_create_nonce( 'jlg_platform_action' ),
+				'nonceField'    => 'jlg_platform_nonce',
+				'actionField'   => 'jlg_platform_action',
+				'deleteAction'  => 'delete',
+			)
+        );
 
-        wp_enqueue_script($handle);
+        wp_enqueue_script( $handle );
     }
 
-    public function register_localization($handle, $object_name, callable $data_callback, $text_domain = null) {
-        if (empty($handle) || empty($object_name)) {
+    public function register_localization( $handle, $object_name, callable $data_callback, $text_domain = null ) {
+        if ( empty( $handle ) || empty( $object_name ) ) {
             return;
         }
 
-        $this->localizations[$handle] = [
-            'object_name'  => $object_name,
+        $this->localizations[ $handle ] = array(
+            'object_name'   => $object_name,
             'data_callback' => $data_callback,
-            'text_domain'  => $text_domain ?: $this->text_domain,
-        ];
+            'text_domain'   => $text_domain ?: $this->text_domain,
+        );
     }
 
     public function maybe_localize_scripts() {
-        if (empty($this->localizations)) {
+        if ( empty( $this->localizations ) ) {
             return;
         }
 
-        foreach ($this->localizations as $handle => $config) {
-            if (!wp_script_is($handle, 'enqueued')) {
+        foreach ( $this->localizations as $handle => $config ) {
+            if ( ! wp_script_is( $handle, 'enqueued' ) ) {
                 continue;
             }
 
-            $data = [];
-            if (is_callable($config['data_callback'])) {
-                $data = call_user_func($config['data_callback']);
+            $data = array();
+            if ( is_callable( $config['data_callback'] ) ) {
+                $data = call_user_func( $config['data_callback'] );
             }
 
-            if (!empty($data)) {
-                wp_localize_script($handle, $config['object_name'], $data);
+            if ( ! empty( $data ) ) {
+                wp_localize_script( $handle, $config['object_name'], $data );
             }
 
-            if (function_exists('wp_set_script_translations') && is_dir($this->languages_path)) {
+            if ( function_exists( 'wp_set_script_translations' ) && is_dir( $this->languages_path ) ) {
                 $text_domain = $config['text_domain'] ?? $this->text_domain;
-                wp_set_script_translations($handle, $text_domain, $this->languages_path);
+                wp_set_script_translations( $handle, $text_domain, $this->languages_path );
             }
         }
     }
 
     private function register_default_localizations() {
-        $this->register_localization('jlg-user-rating', 'jlgUserRatingL10n', function() {
-            return [
-                'successMessage'      => __('Merci pour votre vote !', 'notation-jlg'),
-                'genericErrorMessage' => __('Erreur. Veuillez réessayer.', 'notation-jlg'),
-                'alreadyVotedMessage' => __('Vous avez déjà voté !', 'notation-jlg'),
-            ];
-        });
+        $this->register_localization(
+            'jlg-user-rating',
+            'jlgUserRatingL10n',
+            function () {
+				return array(
+					'successMessage'      => __( 'Merci pour votre vote !', 'notation-jlg' ),
+					'genericErrorMessage' => __( 'Erreur. Veuillez réessayer.', 'notation-jlg' ),
+					'alreadyVotedMessage' => __( 'Vous avez déjà voté !', 'notation-jlg' ),
+				);
+			}
+        );
 
-        $this->register_localization('jlg-admin-api', 'jlgAdminApiL10n', function() {
-            return [
-                'invalidAjaxConfig'   => __('Configuration AJAX invalide.', 'notation-jlg'),
-                'missingNonce'        => __('Nonce de sécurité manquant. Actualisez la page.', 'notation-jlg'),
-                'minCharsMessage'     => __('Veuillez entrer au moins 3 caractères.', 'notation-jlg'),
-                'searchingText'       => __('Recherche...', 'notation-jlg'),
-                'loadingText'         => __('Chargement...', 'notation-jlg'),
-                'searchButtonLabel'   => __('Rechercher', 'notation-jlg'),
-                'securityFailed'      => __('Vérification de sécurité échouée. Actualisez la page.', 'notation-jlg'),
-                'selectLabel'         => __('Choisir', 'notation-jlg'),
-                'communicationError'  => __('Erreur de communication.', 'notation-jlg'),
-                'filledMessage'       => __('Fiche technique remplie !', 'notation-jlg'),
-                'notAvailableLabel'   => __('N/A', 'notation-jlg'),
-            ];
-        });
+        $this->register_localization(
+            'jlg-admin-api',
+            'jlgAdminApiL10n',
+            function () {
+				return array(
+					'invalidAjaxConfig'  => __( 'Configuration AJAX invalide.', 'notation-jlg' ),
+					'missingNonce'       => __( 'Nonce de sécurité manquant. Actualisez la page.', 'notation-jlg' ),
+					'minCharsMessage'    => __( 'Veuillez entrer au moins 3 caractères.', 'notation-jlg' ),
+					'searchingText'      => __( 'Recherche...', 'notation-jlg' ),
+					'loadingText'        => __( 'Chargement...', 'notation-jlg' ),
+					'searchButtonLabel'  => __( 'Rechercher', 'notation-jlg' ),
+					'securityFailed'     => __( 'Vérification de sécurité échouée. Actualisez la page.', 'notation-jlg' ),
+					'selectLabel'        => __( 'Choisir', 'notation-jlg' ),
+					'communicationError' => __( 'Erreur de communication.', 'notation-jlg' ),
+					'filledMessage'      => __( 'Fiche technique remplie !', 'notation-jlg' ),
+					'notAvailableLabel'  => __( 'N/A', 'notation-jlg' ),
+				);
+			}
+        );
 
-        $this->register_localization('jlg-game-explorer', 'jlgGameExplorerL10n', function() {
-            return [
-                'ajaxUrl' => admin_url('admin-ajax.php'),
-                'nonce'   => wp_create_nonce('jlg_game_explorer'),
-                'strings' => [
-                    'loading'    => esc_html__('Chargement des jeux...', 'notation-jlg'),
-                    'noResults'  => esc_html__('Aucun jeu ne correspond à votre sélection.', 'notation-jlg'),
-                    'reset'      => esc_html__('Réinitialiser les filtres', 'notation-jlg'),
-                    'genericError' => esc_html__('Impossible de charger les jeux pour le moment.', 'notation-jlg'),
-                    'countSingular' => esc_html__('%d jeu', 'notation-jlg'),
-                    'countPlural'   => esc_html__('%d jeux', 'notation-jlg'),
-                ],
-            ];
-        });
+        $this->register_localization(
+            'jlg-game-explorer',
+            'jlgGameExplorerL10n',
+            function () {
+				return array(
+					'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+					'nonce'   => wp_create_nonce( 'jlg_game_explorer' ),
+					'strings' => array(
+						'loading'       => esc_html__( 'Chargement des jeux...', 'notation-jlg' ),
+						'noResults'     => esc_html__( 'Aucun jeu ne correspond à votre sélection.', 'notation-jlg' ),
+						'reset'         => esc_html__( 'Réinitialiser les filtres', 'notation-jlg' ),
+						'genericError'  => esc_html__( 'Impossible de charger les jeux pour le moment.', 'notation-jlg' ),
+						'countSingular' => esc_html__( '%d jeu', 'notation-jlg' ),
+						'countPlural'   => esc_html__( '%d jeux', 'notation-jlg' ),
+					),
+				);
+			}
+        );
     }
 }

--- a/plugin-notation-jeux_V4/includes/class-jlg-blocks.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-blocks.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -30,82 +30,82 @@ class JLG_Blocks {
      *
      * @var array<string, array<string, mixed>>
      */
-    private $blocks = [
-        'rating-block' => [
-            'name'            => 'notation-jlg/rating-block',
-            'shortcode'       => 'bloc_notation_jeu',
-            'script'          => 'notation-jlg-rating-block-editor',
-            'callback'        => 'render_rating_block',
-        ],
-        'pros-cons' => [
-            'name'            => 'notation-jlg/pros-cons',
-            'shortcode'       => 'jlg_points_forts_faibles',
-            'script'          => 'notation-jlg-pros-cons-editor',
-            'callback'        => 'render_pros_cons_block',
-        ],
-        'tagline' => [
-            'name'            => 'notation-jlg/tagline',
-            'shortcode'       => 'tagline_notation_jlg',
-            'script'          => 'notation-jlg-tagline-editor',
-            'callback'        => 'render_tagline_block',
-        ],
-        'game-info' => [
-            'name'            => 'notation-jlg/game-info',
-            'shortcode'       => 'jlg_fiche_technique',
-            'script'          => 'notation-jlg-game-info-editor',
-            'callback'        => 'render_game_info_block',
-        ],
-        'user-rating' => [
-            'name'            => 'notation-jlg/user-rating',
-            'shortcode'       => 'notation_utilisateurs_jlg',
-            'script'          => 'notation-jlg-user-rating-editor',
-            'callback'        => 'render_user_rating_block',
-        ],
-        'summary-display' => [
-            'name'            => 'notation-jlg/summary-display',
-            'shortcode'       => 'jlg_tableau_recap',
-            'script'          => 'notation-jlg-summary-display-editor',
-            'callback'        => 'render_summary_display_block',
-        ],
-        'all-in-one' => [
-            'name'            => 'notation-jlg/all-in-one',
-            'shortcode'       => 'jlg_bloc_complet',
-            'script'          => 'notation-jlg-all-in-one-editor',
-            'callback'        => 'render_all_in_one_block',
-        ],
-        'game-explorer' => [
-            'name'            => 'notation-jlg/game-explorer',
-            'shortcode'       => 'jlg_game_explorer',
-            'script'          => 'notation-jlg-game-explorer-editor',
-            'callback'        => 'render_game_explorer_block',
-        ],
-    ];
+    private $blocks = array(
+        'rating-block'    => array(
+            'name'      => 'notation-jlg/rating-block',
+            'shortcode' => 'bloc_notation_jeu',
+            'script'    => 'notation-jlg-rating-block-editor',
+            'callback'  => 'render_rating_block',
+        ),
+        'pros-cons'       => array(
+            'name'      => 'notation-jlg/pros-cons',
+            'shortcode' => 'jlg_points_forts_faibles',
+            'script'    => 'notation-jlg-pros-cons-editor',
+            'callback'  => 'render_pros_cons_block',
+        ),
+        'tagline'         => array(
+            'name'      => 'notation-jlg/tagline',
+            'shortcode' => 'tagline_notation_jlg',
+            'script'    => 'notation-jlg-tagline-editor',
+            'callback'  => 'render_tagline_block',
+        ),
+        'game-info'       => array(
+            'name'      => 'notation-jlg/game-info',
+            'shortcode' => 'jlg_fiche_technique',
+            'script'    => 'notation-jlg-game-info-editor',
+            'callback'  => 'render_game_info_block',
+        ),
+        'user-rating'     => array(
+            'name'      => 'notation-jlg/user-rating',
+            'shortcode' => 'notation_utilisateurs_jlg',
+            'script'    => 'notation-jlg-user-rating-editor',
+            'callback'  => 'render_user_rating_block',
+        ),
+        'summary-display' => array(
+            'name'      => 'notation-jlg/summary-display',
+            'shortcode' => 'jlg_tableau_recap',
+            'script'    => 'notation-jlg-summary-display-editor',
+            'callback'  => 'render_summary_display_block',
+        ),
+        'all-in-one'      => array(
+            'name'      => 'notation-jlg/all-in-one',
+            'shortcode' => 'jlg_bloc_complet',
+            'script'    => 'notation-jlg-all-in-one-editor',
+            'callback'  => 'render_all_in_one_block',
+        ),
+        'game-explorer'   => array(
+            'name'      => 'notation-jlg/game-explorer',
+            'shortcode' => 'jlg_game_explorer',
+            'script'    => 'notation-jlg-game-explorer-editor',
+            'callback'  => 'render_game_explorer_block',
+        ),
+    );
 
     public function __construct() {
-        $this->languages_path = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'languages';
+        $this->languages_path = trailingslashit( JLG_NOTATION_PLUGIN_DIR ) . 'languages';
 
-        add_action('init', [$this, 'register_block_editor_assets']);
-        add_action('init', [$this, 'register_blocks']);
+        add_action( 'init', array( $this, 'register_block_editor_assets' ) );
+        add_action( 'init', array( $this, 'register_blocks' ) );
     }
 
     public function register_block_editor_assets() {
-        $scripts_dir = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/js/blocks/';
-        $scripts_url = trailingslashit(JLG_NOTATION_PLUGIN_URL) . 'assets/js/blocks/';
-        $style_path  = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/css/blocks-editor.css';
-        $style_url   = trailingslashit(JLG_NOTATION_PLUGIN_URL) . 'assets/css/blocks-editor.css';
+        $scripts_dir = trailingslashit( JLG_NOTATION_PLUGIN_DIR ) . 'assets/js/blocks/';
+        $scripts_url = trailingslashit( JLG_NOTATION_PLUGIN_URL ) . 'assets/js/blocks/';
+        $style_path  = trailingslashit( JLG_NOTATION_PLUGIN_DIR ) . 'assets/css/blocks-editor.css';
+        $style_url   = trailingslashit( JLG_NOTATION_PLUGIN_URL ) . 'assets/css/blocks-editor.css';
 
-        if (file_exists($style_path)) {
+        if ( file_exists( $style_path ) ) {
             wp_register_style(
                 $this->editor_style_handle,
                 $style_url,
-                ['wp-edit-blocks'],
-                $this->get_file_version($style_path)
+                array( 'wp-edit-blocks' ),
+                $this->get_file_version( $style_path )
             );
         }
 
         $shared_script_path = $scripts_dir . 'shared.js';
-        if (file_exists($shared_script_path)) {
-            $shared_deps = [
+        if ( file_exists( $shared_script_path ) ) {
+            $shared_deps = array(
                 'wp-blocks',
                 'wp-components',
                 'wp-element',
@@ -115,372 +115,372 @@ class JLG_Blocks {
                 'wp-html-entities',
                 'wp-server-side-render',
                 'wp-compose',
-            ];
+            );
 
             wp_register_script(
                 $this->shared_script_handle,
                 $scripts_url . 'shared.js',
                 $shared_deps,
-                $this->get_file_version($shared_script_path),
+                $this->get_file_version( $shared_script_path ),
                 true
             );
 
-            $settings = [
-                'allowedPostTypes' => $this->get_allowed_post_types_for_editor(),
+            $settings = array(
+                'allowedPostTypes'  => $this->get_allowed_post_types_for_editor(),
                 'postsQueryPerPage' => 20,
-            ];
+            );
 
-            wp_localize_script($this->shared_script_handle, 'jlgBlockEditorSettings', $settings);
-            $this->set_script_translations($this->shared_script_handle);
+            wp_localize_script( $this->shared_script_handle, 'jlgBlockEditorSettings', $settings );
+            $this->set_script_translations( $this->shared_script_handle );
         }
 
-        foreach ($this->blocks as $slug => $config) {
-            $script_handle = isset($config['script']) ? $config['script'] : '';
+        foreach ( $this->blocks as $slug => $config ) {
+            $script_handle = isset( $config['script'] ) ? $config['script'] : '';
             $script_file   = $scripts_dir . $slug . '.js';
 
-            if ($script_handle === '' || !file_exists($script_file)) {
+            if ( $script_handle === '' || ! file_exists( $script_file ) ) {
                 continue;
             }
 
-            $deps = [$this->shared_script_handle];
+            $deps = array( $this->shared_script_handle );
             wp_register_script(
                 $script_handle,
                 $scripts_url . $slug . '.js',
                 $deps,
-                $this->get_file_version($script_file),
+                $this->get_file_version( $script_file ),
                 true
             );
 
-            $this->set_script_translations($script_handle);
+            $this->set_script_translations( $script_handle );
         }
     }
 
     public function register_blocks() {
-        if (!function_exists('register_block_type_from_metadata')) {
+        if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
             return;
         }
 
-        foreach ($this->blocks as $slug => $config) {
-            $metadata_path = trailingslashit(JLG_NOTATION_PLUGIN_DIR) . 'assets/blocks/' . $slug;
-            $callback      = isset($config['callback']) ? $config['callback'] : '';
+        foreach ( $this->blocks as $slug => $config ) {
+            $metadata_path = trailingslashit( JLG_NOTATION_PLUGIN_DIR ) . 'assets/blocks/' . $slug;
+            $callback      = isset( $config['callback'] ) ? $config['callback'] : '';
 
-            if (!is_dir($metadata_path) || !file_exists(trailingslashit($metadata_path) . 'block.json')) {
+            if ( ! is_dir( $metadata_path ) || ! file_exists( trailingslashit( $metadata_path ) . 'block.json' ) ) {
                 continue;
             }
 
-            $args = [];
-            if ($callback !== '' && method_exists($this, $callback)) {
-                $args['render_callback'] = [$this, $callback];
+            $args = array();
+            if ( $callback !== '' && method_exists( $this, $callback ) ) {
+                $args['render_callback'] = array( $this, $callback );
             }
 
-            register_block_type_from_metadata($metadata_path, $args);
+            register_block_type_from_metadata( $metadata_path, $args );
         }
     }
 
     private function get_allowed_post_types_for_editor() {
-        if (!class_exists('JLG_Helpers')) {
-            return [];
+        if ( ! class_exists( 'JLG_Helpers' ) ) {
+            return array();
         }
 
         $types = JLG_Helpers::get_allowed_post_types();
-        if (!is_array($types)) {
-            $types = [];
+        if ( ! is_array( $types ) ) {
+            $types = array();
         }
 
-        $types = array_map('sanitize_key', array_filter($types));
-        $types = array_values(array_unique($types));
-        $result = [];
+        $types  = array_map( 'sanitize_key', array_filter( $types ) );
+        $types  = array_values( array_unique( $types ) );
+        $result = array();
 
-        foreach ($types as $type) {
-            $object = get_post_type_object($type);
-            $label = $object && !empty($object->labels->singular_name)
+        foreach ( $types as $type ) {
+            $object = get_post_type_object( $type );
+            $label  = $object && ! empty( $object->labels->singular_name )
                 ? $object->labels->singular_name
-                : ucwords(str_replace(['-', '_'], ' ', $type));
+                : ucwords( str_replace( array( '-', '_' ), ' ', $type ) );
 
-            $result[] = [
+            $result[] = array(
                 'slug'  => $type,
                 'label' => $label,
-            ];
+            );
         }
 
-        if (empty($result)) {
-            $result[] = [
+        if ( empty( $result ) ) {
+            $result[] = array(
                 'slug'  => 'post',
-                'label' => __('Articles', 'notation-jlg'),
-            ];
+                'label' => __( 'Articles', 'notation-jlg' ),
+            );
         }
 
         return $result;
     }
 
-    private function set_script_translations($handle) {
-        if (!function_exists('wp_set_script_translations')) {
+    private function set_script_translations( $handle ) {
+        if ( ! function_exists( 'wp_set_script_translations' ) ) {
             return;
         }
 
-        if (!wp_script_is($handle, 'registered')) {
+        if ( ! wp_script_is( $handle, 'registered' ) ) {
             return;
         }
 
-        if (!is_dir($this->languages_path)) {
+        if ( ! is_dir( $this->languages_path ) ) {
             return;
         }
 
-        wp_set_script_translations($handle, 'notation-jlg', $this->languages_path);
+        wp_set_script_translations( $handle, 'notation-jlg', $this->languages_path );
     }
 
-    private function get_file_version($path) {
-        $mtime = file_exists($path) ? filemtime($path) : false;
+    private function get_file_version( $path ) {
+        $mtime = file_exists( $path ) ? filemtime( $path ) : false;
 
-        if ($mtime) {
+        if ( $mtime ) {
             return (string) $mtime;
         }
 
-        return defined('JLG_NOTATION_VERSION') ? JLG_NOTATION_VERSION : '1.0.0';
+        return defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : '1.0.0';
     }
 
-    private function render_shortcode($shortcode, array $atts = []) {
-        if (!shortcode_exists($shortcode)) {
+    private function render_shortcode( $shortcode, array $atts = array() ) {
+        if ( ! shortcode_exists( $shortcode ) ) {
             return '';
         }
 
-        if (class_exists('JLG_Frontend')) {
-            JLG_Frontend::mark_shortcode_rendered($shortcode);
+        if ( class_exists( 'JLG_Frontend' ) ) {
+            JLG_Frontend::mark_shortcode_rendered( $shortcode );
         }
 
         $attributes_string = '';
 
-        foreach ($atts as $key => $value) {
-            if ($value === null) {
+        foreach ( $atts as $key => $value ) {
+            if ( $value === null ) {
                 continue;
             }
 
-            if (is_bool($value)) {
+            if ( is_bool( $value ) ) {
                 $value = $value ? 'oui' : 'non';
-            } elseif (is_array($value)) {
-                $value = implode(',', array_filter(array_map('strval', $value)));
+            } elseif ( is_array( $value ) ) {
+                $value = implode( ',', array_filter( array_map( 'strval', $value ) ) );
             }
 
-            if ($value === '') {
+            if ( $value === '' ) {
                 continue;
             }
 
-            $attributes_string .= sprintf(' %s="%s"', sanitize_key($key), esc_attr($value));
+            $attributes_string .= sprintf( ' %s="%s"', sanitize_key( $key ), esc_attr( $value ) );
         }
 
-        return do_shortcode(sprintf('[%s%s]', sanitize_key($shortcode), $attributes_string));
+        return do_shortcode( sprintf( '[%s%s]', sanitize_key( $shortcode ), $attributes_string ) );
     }
 
-    public function render_rating_block($attributes) {
-        $post_id = isset($attributes['postId']) ? absint($attributes['postId']) : 0;
-        $atts = [];
+    public function render_rating_block( $attributes ) {
+        $post_id = isset( $attributes['postId'] ) ? absint( $attributes['postId'] ) : 0;
+        $atts    = array();
 
-        if ($post_id > 0) {
+        if ( $post_id > 0 ) {
             $atts['post_id'] = $post_id;
         }
 
-        return $this->render_shortcode('bloc_notation_jeu', $atts);
+        return $this->render_shortcode( 'bloc_notation_jeu', $atts );
     }
 
-    public function render_pros_cons_block($attributes) {
-        unset($attributes);
+    public function render_pros_cons_block( $attributes ) {
+        unset( $attributes );
 
-        return $this->render_shortcode('jlg_points_forts_faibles');
+        return $this->render_shortcode( 'jlg_points_forts_faibles' );
     }
 
-    public function render_tagline_block($attributes) {
-        unset($attributes);
+    public function render_tagline_block( $attributes ) {
+        unset( $attributes );
 
-        return $this->render_shortcode('tagline_notation_jlg');
+        return $this->render_shortcode( 'tagline_notation_jlg' );
     }
 
-    public function render_game_info_block($attributes) {
-        $atts = [];
+    public function render_game_info_block( $attributes ) {
+        $atts = array();
 
-        if (isset($attributes['postId'])) {
-            $post_id = absint($attributes['postId']);
-            if ($post_id > 0) {
+        if ( isset( $attributes['postId'] ) ) {
+            $post_id = absint( $attributes['postId'] );
+            if ( $post_id > 0 ) {
                 $atts['post_id'] = $post_id;
             }
         }
 
-        if (!empty($attributes['fields']) && is_array($attributes['fields'])) {
-            $fields = array_map('sanitize_key', array_filter($attributes['fields']));
-            if (!empty($fields)) {
-                $atts['champs'] = implode(',', $fields);
+        if ( ! empty( $attributes['fields'] ) && is_array( $attributes['fields'] ) ) {
+            $fields = array_map( 'sanitize_key', array_filter( $attributes['fields'] ) );
+            if ( ! empty( $fields ) ) {
+                $atts['champs'] = implode( ',', $fields );
             }
         }
 
-        if (!empty($attributes['title']) && is_string($attributes['title'])) {
-            $atts['titre'] = sanitize_text_field($attributes['title']);
+        if ( ! empty( $attributes['title'] ) && is_string( $attributes['title'] ) ) {
+            $atts['titre'] = sanitize_text_field( $attributes['title'] );
         }
 
-        return $this->render_shortcode('jlg_fiche_technique', $atts);
+        return $this->render_shortcode( 'jlg_fiche_technique', $atts );
     }
 
-    public function render_user_rating_block($attributes) {
-        unset($attributes);
+    public function render_user_rating_block( $attributes ) {
+        unset( $attributes );
 
-        return $this->render_shortcode('notation_utilisateurs_jlg');
+        return $this->render_shortcode( 'notation_utilisateurs_jlg' );
     }
 
-    public function render_summary_display_block($attributes) {
-        $atts = [];
+    public function render_summary_display_block( $attributes ) {
+        $atts = array();
 
-        if (isset($attributes['postsPerPage'])) {
-            $posts_per_page = max(1, absint($attributes['postsPerPage']));
+        if ( isset( $attributes['postsPerPage'] ) ) {
+            $posts_per_page         = max( 1, absint( $attributes['postsPerPage'] ) );
             $atts['posts_per_page'] = $posts_per_page;
         }
 
-        if (!empty($attributes['layout']) && is_string($attributes['layout'])) {
-            $layout = sanitize_key($attributes['layout']);
-            if (in_array($layout, ['table', 'grid'], true)) {
+        if ( ! empty( $attributes['layout'] ) && is_string( $attributes['layout'] ) ) {
+            $layout = sanitize_key( $attributes['layout'] );
+            if ( in_array( $layout, array( 'table', 'grid' ), true ) ) {
                 $atts['layout'] = $layout;
             }
         }
 
-        if (!empty($attributes['columns']) && is_array($attributes['columns'])) {
-            $columns = array_map('sanitize_key', array_filter($attributes['columns']));
-            if (!empty($columns)) {
-                $atts['colonnes'] = implode(',', $columns);
+        if ( ! empty( $attributes['columns'] ) && is_array( $attributes['columns'] ) ) {
+            $columns = array_map( 'sanitize_key', array_filter( $attributes['columns'] ) );
+            if ( ! empty( $columns ) ) {
+                $atts['colonnes'] = implode( ',', $columns );
             }
         }
 
-        if (!empty($attributes['category']) && is_string($attributes['category'])) {
-            $atts['categorie'] = sanitize_text_field($attributes['category']);
+        if ( ! empty( $attributes['category'] ) && is_string( $attributes['category'] ) ) {
+            $atts['categorie'] = sanitize_text_field( $attributes['category'] );
         }
 
-        if (!empty($attributes['letterFilter']) && is_string($attributes['letterFilter'])) {
-            $atts['letter_filter'] = sanitize_text_field($attributes['letterFilter']);
+        if ( ! empty( $attributes['letterFilter'] ) && is_string( $attributes['letterFilter'] ) ) {
+            $atts['letter_filter'] = sanitize_text_field( $attributes['letterFilter'] );
         }
 
-        if (!empty($attributes['genreFilter']) && is_string($attributes['genreFilter'])) {
-            $atts['genre_filter'] = sanitize_text_field($attributes['genreFilter']);
+        if ( ! empty( $attributes['genreFilter'] ) && is_string( $attributes['genreFilter'] ) ) {
+            $atts['genre_filter'] = sanitize_text_field( $attributes['genreFilter'] );
         }
 
-        return $this->render_shortcode('jlg_tableau_recap', $atts);
+        return $this->render_shortcode( 'jlg_tableau_recap', $atts );
     }
 
-    public function render_all_in_one_block($attributes) {
-        $atts = [];
+    public function render_all_in_one_block( $attributes ) {
+        $atts = array();
 
-        if (isset($attributes['postId'])) {
-            $post_id = absint($attributes['postId']);
-            if ($post_id > 0) {
+        if ( isset( $attributes['postId'] ) ) {
+            $post_id = absint( $attributes['postId'] );
+            if ( $post_id > 0 ) {
                 $atts['post_id'] = $post_id;
             }
         }
 
-        $bool_attributes = [
-            'showRating' => 'afficher_notation',
+        $bool_attributes = array(
+            'showRating'   => 'afficher_notation',
             'showProsCons' => 'afficher_points',
-            'showTagline' => 'afficher_tagline',
-        ];
+            'showTagline'  => 'afficher_tagline',
+        );
 
-        foreach ($bool_attributes as $attr_key => $shortcode_key) {
-            if (isset($attributes[$attr_key])) {
-                $atts[$shortcode_key] = (bool) $attributes[$attr_key];
+        foreach ( $bool_attributes as $attr_key => $shortcode_key ) {
+            if ( isset( $attributes[ $attr_key ] ) ) {
+                $atts[ $shortcode_key ] = (bool) $attributes[ $attr_key ];
             }
         }
 
-        if (!empty($attributes['style']) && is_string($attributes['style'])) {
-            $style = sanitize_key($attributes['style']);
-            if (in_array($style, ['moderne', 'classique', 'compact'], true)) {
+        if ( ! empty( $attributes['style'] ) && is_string( $attributes['style'] ) ) {
+            $style = sanitize_key( $attributes['style'] );
+            if ( in_array( $style, array( 'moderne', 'classique', 'compact' ), true ) ) {
                 $atts['style'] = $style;
             }
         }
 
-        if (!empty($attributes['accentColor']) && is_string($attributes['accentColor'])) {
-            $color = sanitize_hex_color($attributes['accentColor']);
-            if (!empty($color)) {
+        if ( ! empty( $attributes['accentColor'] ) && is_string( $attributes['accentColor'] ) ) {
+            $color = sanitize_hex_color( $attributes['accentColor'] );
+            if ( ! empty( $color ) ) {
                 $atts['couleur_accent'] = $color;
             }
         }
 
-        if (!empty($attributes['prosTitle']) && is_string($attributes['prosTitle'])) {
-            $atts['titre_points_forts'] = sanitize_text_field($attributes['prosTitle']);
+        if ( ! empty( $attributes['prosTitle'] ) && is_string( $attributes['prosTitle'] ) ) {
+            $atts['titre_points_forts'] = sanitize_text_field( $attributes['prosTitle'] );
         }
 
-        if (!empty($attributes['consTitle']) && is_string($attributes['consTitle'])) {
-            $atts['titre_points_faibles'] = sanitize_text_field($attributes['consTitle']);
+        if ( ! empty( $attributes['consTitle'] ) && is_string( $attributes['consTitle'] ) ) {
+            $atts['titre_points_faibles'] = sanitize_text_field( $attributes['consTitle'] );
         }
 
-        return $this->render_shortcode('jlg_bloc_complet', $atts);
+        return $this->render_shortcode( 'jlg_bloc_complet', $atts );
     }
 
-    public function render_game_explorer_block($attributes) {
-        $atts = [];
+    public function render_game_explorer_block( $attributes ) {
+        $atts = array();
 
-        if (isset($attributes['postsPerPage'])) {
-            $posts_per_page = max(1, absint($attributes['postsPerPage']));
+        if ( isset( $attributes['postsPerPage'] ) ) {
+            $posts_per_page         = max( 1, absint( $attributes['postsPerPage'] ) );
             $atts['posts_per_page'] = $posts_per_page;
         }
 
-        if (isset($attributes['columns'])) {
-            $columns = max(1, absint($attributes['columns']));
+        if ( isset( $attributes['columns'] ) ) {
+            $columns         = max( 1, absint( $attributes['columns'] ) );
             $atts['columns'] = $columns;
         }
 
-        if (!empty($attributes['filters']) && is_array($attributes['filters'])) {
-            $filters = array_map('sanitize_key', array_filter($attributes['filters']));
-            if (!empty($filters)) {
-                $atts['filters'] = implode(',', $filters);
+        if ( ! empty( $attributes['filters'] ) && is_array( $attributes['filters'] ) ) {
+            $filters = array_map( 'sanitize_key', array_filter( $attributes['filters'] ) );
+            if ( ! empty( $filters ) ) {
+                $atts['filters'] = implode( ',', $filters );
             }
         }
 
-        if (!empty($attributes['category']) && is_string($attributes['category'])) {
-            $atts['categorie'] = sanitize_text_field($attributes['category']);
+        if ( ! empty( $attributes['category'] ) && is_string( $attributes['category'] ) ) {
+            $atts['categorie'] = sanitize_text_field( $attributes['category'] );
         }
 
-        if (!empty($attributes['platform']) && is_string($attributes['platform'])) {
-            $atts['plateforme'] = sanitize_text_field($attributes['platform']);
+        if ( ! empty( $attributes['platform'] ) && is_string( $attributes['platform'] ) ) {
+            $atts['plateforme'] = sanitize_text_field( $attributes['platform'] );
         }
 
-        if (!empty($attributes['letter']) && is_string($attributes['letter'])) {
-            $atts['lettre'] = sanitize_text_field($attributes['letter']);
+        if ( ! empty( $attributes['letter'] ) && is_string( $attributes['letter'] ) ) {
+            $atts['lettre'] = sanitize_text_field( $attributes['letter'] );
         }
 
         $sort_override = null;
-        if (!empty($attributes['sort']) && is_string($attributes['sort'])) {
-            $sort = sanitize_text_field($attributes['sort']);
-            $parts = explode('|', $sort);
-            $orderby = isset($parts[0]) ? sanitize_key($parts[0]) : '';
-            $order = isset($parts[1]) ? strtoupper(sanitize_key($parts[1])) : '';
+        if ( ! empty( $attributes['sort'] ) && is_string( $attributes['sort'] ) ) {
+            $sort    = sanitize_text_field( $attributes['sort'] );
+            $parts   = explode( '|', $sort );
+            $orderby = isset( $parts[0] ) ? sanitize_key( $parts[0] ) : '';
+            $order   = isset( $parts[1] ) ? strtoupper( sanitize_key( $parts[1] ) ) : '';
 
-            if (in_array($orderby, ['date', 'score', 'title'], true)) {
-                if (!in_array($order, ['ASC', 'DESC'], true)) {
+            if ( in_array( $orderby, array( 'date', 'score', 'title' ), true ) ) {
+                if ( ! in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
                     $order = 'DESC';
                 }
 
-                $sort_override = [
+                $sort_override = array(
                     'orderby' => $orderby,
                     'order'   => $order,
-                ];
+                );
             }
         }
 
         $previous_orderby = null;
-        $previous_order = null;
+        $previous_order   = null;
 
-        if ($sort_override !== null) {
-            $previous_orderby = isset($_GET['orderby']) ? $_GET['orderby'] : null;
-            $previous_order = isset($_GET['order']) ? $_GET['order'] : null;
+        if ( $sort_override !== null ) {
+            $previous_orderby = isset( $_GET['orderby'] ) ? $_GET['orderby'] : null;
+            $previous_order   = isset( $_GET['order'] ) ? $_GET['order'] : null;
 
             $_GET['orderby'] = $sort_override['orderby'];
-            $_GET['order'] = $sort_override['order'];
+            $_GET['order']   = $sort_override['order'];
         }
 
-        $output = $this->render_shortcode('jlg_game_explorer', $atts);
+        $output = $this->render_shortcode( 'jlg_game_explorer', $atts );
 
-        if ($sort_override !== null) {
-            if ($previous_orderby === null) {
-                unset($_GET['orderby']);
+        if ( $sort_override !== null ) {
+            if ( $previous_orderby === null ) {
+                unset( $_GET['orderby'] );
             } else {
                 $_GET['orderby'] = $previous_orderby;
             }
 
-            if ($previous_order === null) {
-                unset($_GET['order']);
+            if ( $previous_order === null ) {
+                unset( $_GET['order'] );
             } else {
                 $_GET['order'] = $previous_order;
             }

--- a/plugin-notation-jeux_V4/includes/class-jlg-dynamic-css.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-dynamic-css.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -12,12 +12,12 @@ class JLG_Dynamic_CSS {
      * @param float|null $average_score
      * @return string
      */
-    public static function build_frontend_css($options, $palette, $average_score) {
+    public static function build_frontend_css( $options, $palette, $average_score ) {
         $builder = new self();
 
         return $builder->generate_css(
-            is_array($options) ? $options : [],
-            is_array($palette) ? $palette : [],
+            is_array( $options ) ? $options : array(),
+            is_array( $palette ) ? $palette : array(),
             $average_score
         );
     }
@@ -30,172 +30,187 @@ class JLG_Dynamic_CSS {
      * @param float|null $average_score
      * @return string
      */
-    private function generate_css(array $options, array $palette, $average_score) {
-        $palette_colors = $this->sanitize_color_options([
-            'bg_color',
-            'bg_color_secondary',
-            'border_color',
-            'main_text_color',
-            'secondary_text_color',
-            'bar_bg_color',
-            'tagline_bg_color',
-            'tagline_text_color',
-        ], $palette);
+    private function generate_css( array $options, array $palette, $average_score ) {
+        $palette_colors = $this->sanitize_color_options(
+            array(
+				'bg_color',
+				'bg_color_secondary',
+				'border_color',
+				'main_text_color',
+				'secondary_text_color',
+				'bar_bg_color',
+				'tagline_bg_color',
+				'tagline_text_color',
+            ),
+            $palette
+        );
 
-        $bg_color = $palette_colors['bg_color'] ?? '';
-        $bg_color_secondary = $palette_colors['bg_color_secondary'] ?? '';
-        $border_color = $palette_colors['border_color'] ?? '';
-        $main_text_color = $palette_colors['main_text_color'] ?? '';
+        $bg_color             = $palette_colors['bg_color'] ?? '';
+        $bg_color_secondary   = $palette_colors['bg_color_secondary'] ?? '';
+        $border_color         = $palette_colors['border_color'] ?? '';
+        $main_text_color      = $palette_colors['main_text_color'] ?? '';
         $secondary_text_color = $palette_colors['secondary_text_color'] ?? '';
-        $bar_bg_color = $palette_colors['bar_bg_color'] ?? '';
-        $tagline_bg_color = $palette_colors['tagline_bg_color'] ?? '';
-        $tagline_text_color = $palette_colors['tagline_text_color'] ?? '';
+        $bar_bg_color         = $palette_colors['bar_bg_color'] ?? '';
+        $tagline_bg_color     = $palette_colors['tagline_bg_color'] ?? '';
+        $tagline_text_color   = $palette_colors['tagline_text_color'] ?? '';
 
-        $option_colors = $this->sanitize_color_options([
-            'score_gradient_1',
-            'score_gradient_2',
-            'color_high',
-            'color_low',
-            'user_rating_text_color',
-            'user_rating_star_color',
-            'table_header_bg_color',
-            'table_header_text_color',
-            'table_row_bg_color' => ['allow_transparent' => true],
-            'table_row_text_color',
-            'table_zebra_bg_color' => ['allow_transparent' => true],
-            'circle_border_color',
-        ], $options);
+        $option_colors = $this->sanitize_color_options(
+            array(
+				'score_gradient_1',
+				'score_gradient_2',
+				'color_high',
+				'color_low',
+				'user_rating_text_color',
+				'user_rating_star_color',
+				'table_header_bg_color',
+				'table_header_text_color',
+				'table_row_bg_color'   => array( 'allow_transparent' => true ),
+				'table_row_text_color',
+				'table_zebra_bg_color' => array( 'allow_transparent' => true ),
+				'circle_border_color',
+            ),
+            $options
+        );
 
-        $score_gradient_1 = $option_colors['score_gradient_1'] ?? '';
-        $score_gradient_2 = $option_colors['score_gradient_2'] ?? '';
-        $color_high = $option_colors['color_high'] ?? '';
-        $color_low = $option_colors['color_low'] ?? '';
-        $user_rating_text_color = $option_colors['user_rating_text_color'] ?? '';
-        $user_rating_star_color = $option_colors['user_rating_star_color'] ?? '';
-        $table_header_bg_color = $option_colors['table_header_bg_color'] ?? '';
+        $score_gradient_1        = $option_colors['score_gradient_1'] ?? '';
+        $score_gradient_2        = $option_colors['score_gradient_2'] ?? '';
+        $color_high              = $option_colors['color_high'] ?? '';
+        $color_low               = $option_colors['color_low'] ?? '';
+        $user_rating_text_color  = $option_colors['user_rating_text_color'] ?? '';
+        $user_rating_star_color  = $option_colors['user_rating_star_color'] ?? '';
+        $table_header_bg_color   = $option_colors['table_header_bg_color'] ?? '';
         $table_header_text_color = $option_colors['table_header_text_color'] ?? '';
-        $table_row_bg_color = $option_colors['table_row_bg_color'] ?? '';
-        $table_row_text_color = $option_colors['table_row_text_color'] ?? '';
-        $table_zebra_bg_color = $option_colors['table_zebra_bg_color'] ?? '';
-        $circle_border_color = $option_colors['circle_border_color'] ?? '';
+        $table_row_bg_color      = $option_colors['table_row_bg_color'] ?? '';
+        $table_row_text_color    = $option_colors['table_row_text_color'] ?? '';
+        $table_zebra_bg_color    = $option_colors['table_zebra_bg_color'] ?? '';
+        $circle_border_color     = $option_colors['circle_border_color'] ?? '';
 
         $default_settings = JLG_Helpers::get_default_settings();
-        $default_colors = $this->sanitize_color_options([
-            'default_score_gradient_1' => 'score_gradient_1',
-            'default_score_gradient_2' => 'score_gradient_2',
-            'default_color_high' => 'color_high',
-            'default_color_low' => 'color_low',
-            'default_user_rating_text_color' => 'user_rating_text_color',
-            'default_user_rating_star_color' => 'user_rating_star_color',
-            'default_table_header_bg_color' => 'table_header_bg_color',
-            'default_table_header_text_color' => 'table_header_text_color',
-            'default_table_row_bg_color' => ['key' => 'table_row_bg_color', 'allow_transparent' => true],
-            'default_table_row_text_color' => 'table_row_text_color',
-            'default_table_zebra_bg_color' => ['key' => 'table_zebra_bg_color', 'allow_transparent' => true],
-            'default_circle_border_color' => 'circle_border_color',
-            'default_light_bg_color' => 'light_bg_color',
-            'default_light_bg_color_secondary' => 'light_bg_color_secondary',
-            'default_light_border_color' => 'light_border_color',
-            'default_light_text_color' => 'light_text_color',
-            'default_light_text_color_secondary' => 'light_text_color_secondary',
-            'default_dark_bg_color' => 'dark_bg_color',
-            'default_dark_bg_color_secondary' => 'dark_bg_color_secondary',
-            'default_dark_border_color' => 'dark_border_color',
-            'default_dark_text_color' => 'dark_text_color',
-            'default_dark_text_color_secondary' => 'dark_text_color_secondary',
-        ], $default_settings);
+        $default_colors   = $this->sanitize_color_options(
+            array(
+				'default_score_gradient_1'           => 'score_gradient_1',
+				'default_score_gradient_2'           => 'score_gradient_2',
+				'default_color_high'                 => 'color_high',
+				'default_color_low'                  => 'color_low',
+				'default_user_rating_text_color'     => 'user_rating_text_color',
+				'default_user_rating_star_color'     => 'user_rating_star_color',
+				'default_table_header_bg_color'      => 'table_header_bg_color',
+				'default_table_header_text_color'    => 'table_header_text_color',
+				'default_table_row_bg_color'         => array(
+					'key'               => 'table_row_bg_color',
+					'allow_transparent' => true,
+				),
+				'default_table_row_text_color'       => 'table_row_text_color',
+				'default_table_zebra_bg_color'       => array(
+					'key'               => 'table_zebra_bg_color',
+					'allow_transparent' => true,
+				),
+				'default_circle_border_color'        => 'circle_border_color',
+				'default_light_bg_color'             => 'light_bg_color',
+				'default_light_bg_color_secondary'   => 'light_bg_color_secondary',
+				'default_light_border_color'         => 'light_border_color',
+				'default_light_text_color'           => 'light_text_color',
+				'default_light_text_color_secondary' => 'light_text_color_secondary',
+				'default_dark_bg_color'              => 'dark_bg_color',
+				'default_dark_bg_color_secondary'    => 'dark_bg_color_secondary',
+				'default_dark_border_color'          => 'dark_border_color',
+				'default_dark_text_color'            => 'dark_text_color',
+				'default_dark_text_color_secondary'  => 'dark_text_color_secondary',
+            ),
+            $default_settings
+        );
 
-        $default_score_gradient_1 = $default_colors['default_score_gradient_1'] ?? '';
-        $default_score_gradient_2 = $default_colors['default_score_gradient_2'] ?? '';
-        $default_color_high = $default_colors['default_color_high'] ?? '';
-        $default_color_low = $default_colors['default_color_low'] ?? '';
-        $default_user_rating_text_color = $default_colors['default_user_rating_text_color'] ?? '';
-        $default_user_rating_star_color = $default_colors['default_user_rating_star_color'] ?? '';
-        $default_table_header_bg_color = $default_colors['default_table_header_bg_color'] ?? '';
-        $default_table_header_text_color = $default_colors['default_table_header_text_color'] ?? '';
-        $default_table_row_bg_color = $default_colors['default_table_row_bg_color'] ?? '';
-        $default_table_row_text_color = $default_colors['default_table_row_text_color'] ?? '';
-        $default_table_zebra_bg_color = $default_colors['default_table_zebra_bg_color'] ?? '';
-        $default_circle_border_color = $default_colors['default_circle_border_color'] ?? '';
-        $default_light_bg_color = $default_colors['default_light_bg_color'] ?? '';
-        $default_light_bg_color_secondary = $default_colors['default_light_bg_color_secondary'] ?? '';
-        $default_light_border_color = $default_colors['default_light_border_color'] ?? '';
-        $default_light_text_color = $default_colors['default_light_text_color'] ?? '';
+        $default_score_gradient_1           = $default_colors['default_score_gradient_1'] ?? '';
+        $default_score_gradient_2           = $default_colors['default_score_gradient_2'] ?? '';
+        $default_color_high                 = $default_colors['default_color_high'] ?? '';
+        $default_color_low                  = $default_colors['default_color_low'] ?? '';
+        $default_user_rating_text_color     = $default_colors['default_user_rating_text_color'] ?? '';
+        $default_user_rating_star_color     = $default_colors['default_user_rating_star_color'] ?? '';
+        $default_table_header_bg_color      = $default_colors['default_table_header_bg_color'] ?? '';
+        $default_table_header_text_color    = $default_colors['default_table_header_text_color'] ?? '';
+        $default_table_row_bg_color         = $default_colors['default_table_row_bg_color'] ?? '';
+        $default_table_row_text_color       = $default_colors['default_table_row_text_color'] ?? '';
+        $default_table_zebra_bg_color       = $default_colors['default_table_zebra_bg_color'] ?? '';
+        $default_circle_border_color        = $default_colors['default_circle_border_color'] ?? '';
+        $default_light_bg_color             = $default_colors['default_light_bg_color'] ?? '';
+        $default_light_bg_color_secondary   = $default_colors['default_light_bg_color_secondary'] ?? '';
+        $default_light_border_color         = $default_colors['default_light_border_color'] ?? '';
+        $default_light_text_color           = $default_colors['default_light_text_color'] ?? '';
         $default_light_text_color_secondary = $default_colors['default_light_text_color_secondary'] ?? '';
-        $default_dark_bg_color = $default_colors['default_dark_bg_color'] ?? '';
-        $default_dark_bg_color_secondary = $default_colors['default_dark_bg_color_secondary'] ?? '';
-        $default_dark_border_color = $default_colors['default_dark_border_color'] ?? '';
-        $default_dark_text_color = $default_colors['default_dark_text_color'] ?? '';
-        $default_dark_text_color_secondary = $default_colors['default_dark_text_color_secondary'] ?? '';
+        $default_dark_bg_color              = $default_colors['default_dark_bg_color'] ?? '';
+        $default_dark_bg_color_secondary    = $default_colors['default_dark_bg_color_secondary'] ?? '';
+        $default_dark_border_color          = $default_colors['default_dark_border_color'] ?? '';
+        $default_dark_text_color            = $default_colors['default_dark_text_color'] ?? '';
+        $default_dark_text_color_secondary  = $default_colors['default_dark_text_color_secondary'] ?? '';
 
         $default_score_gradient_1 = $default_score_gradient_1 !== '' ? $default_score_gradient_1 : '#000000';
         $default_score_gradient_2 = $default_score_gradient_2 !== '' ? $default_score_gradient_2 : '#000000';
 
         $theme = $options['visual_theme'] ?? 'dark';
-        if ($theme === 'light') {
-            $default_bg_color = $default_light_bg_color !== '' ? $default_light_bg_color : '#ffffff';
-            $default_bg_color_secondary = $default_light_bg_color_secondary !== '' ? $default_light_bg_color_secondary : '#f9fafb';
-            $default_border_color = $default_light_border_color !== '' ? $default_light_border_color : '#e5e7eb';
-            $default_text_color = $default_light_text_color !== '' ? $default_light_text_color : '#111827';
+        if ( $theme === 'light' ) {
+            $default_bg_color             = $default_light_bg_color !== '' ? $default_light_bg_color : '#ffffff';
+            $default_bg_color_secondary   = $default_light_bg_color_secondary !== '' ? $default_light_bg_color_secondary : '#f9fafb';
+            $default_border_color         = $default_light_border_color !== '' ? $default_light_border_color : '#e5e7eb';
+            $default_text_color           = $default_light_text_color !== '' ? $default_light_text_color : '#111827';
             $default_secondary_text_color = $default_light_text_color_secondary !== '' ? $default_light_text_color_secondary : '#6b7280';
         } else {
-            $default_bg_color = $default_dark_bg_color !== '' ? $default_dark_bg_color : '#18181b';
-            $default_bg_color_secondary = $default_dark_bg_color_secondary !== '' ? $default_dark_bg_color_secondary : '#27272a';
-            $default_border_color = $default_dark_border_color !== '' ? $default_dark_border_color : '#3f3f46';
-            $default_text_color = $default_dark_text_color !== '' ? $default_dark_text_color : '#fafafa';
+            $default_bg_color             = $default_dark_bg_color !== '' ? $default_dark_bg_color : '#18181b';
+            $default_bg_color_secondary   = $default_dark_bg_color_secondary !== '' ? $default_dark_bg_color_secondary : '#27272a';
+            $default_border_color         = $default_dark_border_color !== '' ? $default_dark_border_color : '#3f3f46';
+            $default_text_color           = $default_dark_text_color !== '' ? $default_dark_text_color : '#fafafa';
             $default_secondary_text_color = $default_dark_text_color_secondary !== '' ? $default_dark_text_color_secondary : '#a1a1aa';
         }
 
-        $default_color_high = $default_color_high !== '' ? $default_color_high : '#22c55e';
-        $default_color_low = $default_color_low !== '' ? $default_color_low : '#ef4444';
-        $default_user_rating_text_color = $default_user_rating_text_color !== '' ? $default_user_rating_text_color : '#a1a1aa';
-        $default_user_rating_star_color = $default_user_rating_star_color !== '' ? $default_user_rating_star_color : '#f59e0b';
-        $default_table_header_bg_color = $default_table_header_bg_color !== '' ? $default_table_header_bg_color : $default_bg_color_secondary;
+        $default_color_high              = $default_color_high !== '' ? $default_color_high : '#22c55e';
+        $default_color_low               = $default_color_low !== '' ? $default_color_low : '#ef4444';
+        $default_user_rating_text_color  = $default_user_rating_text_color !== '' ? $default_user_rating_text_color : '#a1a1aa';
+        $default_user_rating_star_color  = $default_user_rating_star_color !== '' ? $default_user_rating_star_color : '#f59e0b';
+        $default_table_header_bg_color   = $default_table_header_bg_color !== '' ? $default_table_header_bg_color : $default_bg_color_secondary;
         $default_table_header_text_color = $default_table_header_text_color !== '' ? $default_table_header_text_color : $default_text_color;
-        $default_table_row_bg_color = $default_table_row_bg_color !== '' ? $default_table_row_bg_color : 'transparent';
-        $default_table_row_text_color = $default_table_row_text_color !== '' ? $default_table_row_text_color : $default_secondary_text_color;
-        $default_table_zebra_bg_color = $default_table_zebra_bg_color !== '' ? $default_table_zebra_bg_color : 'transparent';
-        $default_circle_border_color = $default_circle_border_color !== '' ? $default_circle_border_color : 'transparent';
+        $default_table_row_bg_color      = $default_table_row_bg_color !== '' ? $default_table_row_bg_color : 'transparent';
+        $default_table_row_text_color    = $default_table_row_text_color !== '' ? $default_table_row_text_color : $default_secondary_text_color;
+        $default_table_zebra_bg_color    = $default_table_zebra_bg_color !== '' ? $default_table_zebra_bg_color : 'transparent';
+        $default_circle_border_color     = $default_circle_border_color !== '' ? $default_circle_border_color : 'transparent';
 
-        foreach ([
-            'score_gradient_1' => $default_score_gradient_1,
-            'score_gradient_2' => $default_score_gradient_2,
-            'bg_color' => $default_bg_color,
-            'bg_color_secondary' => $default_bg_color_secondary,
-            'border_color' => $default_border_color,
-            'main_text_color' => $default_text_color,
-            'secondary_text_color' => $default_secondary_text_color,
-            'color_high' => $default_color_high,
-            'color_low' => $default_color_low,
-            'user_rating_text_color' => $default_user_rating_text_color,
-            'user_rating_star_color' => $default_user_rating_star_color,
-            'table_header_bg_color' => $default_table_header_bg_color,
+        foreach ( array(
+            'score_gradient_1'        => $default_score_gradient_1,
+            'score_gradient_2'        => $default_score_gradient_2,
+            'bg_color'                => $default_bg_color,
+            'bg_color_secondary'      => $default_bg_color_secondary,
+            'border_color'            => $default_border_color,
+            'main_text_color'         => $default_text_color,
+            'secondary_text_color'    => $default_secondary_text_color,
+            'color_high'              => $default_color_high,
+            'color_low'               => $default_color_low,
+            'user_rating_text_color'  => $default_user_rating_text_color,
+            'user_rating_star_color'  => $default_user_rating_star_color,
+            'table_header_bg_color'   => $default_table_header_bg_color,
             'table_header_text_color' => $default_table_header_text_color,
-            'table_row_bg_color' => $default_table_row_bg_color,
-            'table_row_text_color' => $default_table_row_text_color,
-            'table_zebra_bg_color' => $default_table_zebra_bg_color,
-            'circle_border_color' => $default_circle_border_color,
-        ] as $variable => $fallback) {
-            if ($$variable === '') {
+            'table_row_bg_color'      => $default_table_row_bg_color,
+            'table_row_text_color'    => $default_table_row_text_color,
+            'table_zebra_bg_color'    => $default_table_zebra_bg_color,
+            'circle_border_color'     => $default_circle_border_color,
+        ) as $variable => $fallback ) {
+            if ( $$variable === '' ) {
                 $$variable = $fallback;
             }
         }
 
-        if ($bar_bg_color === '') {
+        if ( $bar_bg_color === '' ) {
             $bar_bg_color = $bg_color_secondary;
         }
-        if ($tagline_bg_color === '') {
+        if ( $tagline_bg_color === '' ) {
             $tagline_bg_color = $bg_color_secondary;
         }
-        if ($tagline_text_color === '') {
+        if ( $tagline_text_color === '' ) {
             $tagline_text_color = $secondary_text_color;
         }
 
-        $table_row_hover_color = $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($bg_color_secondary, 5));
-        $table_link_color = $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($table_row_text_color, 20));
-        $score_gradient_1_hover = $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($score_gradient_1, 20));
+        $table_row_hover_color  = $this->sanitize_color_value( JLG_Helpers::adjust_hex_brightness( $bg_color_secondary, 5 ) );
+        $table_link_color       = $this->sanitize_color_value( JLG_Helpers::adjust_hex_brightness( $table_row_text_color, 20 ) );
+        $score_gradient_1_hover = $this->sanitize_color_value( JLG_Helpers::adjust_hex_brightness( $score_gradient_1, 20 ) );
 
-        $inline_css  = ':root{'
+        $inline_css = ':root{'
             . '--jlg-bg-color:' . $bg_color . ';'
             . '--jlg-bg-color-secondary:' . $bg_color_secondary . ';'
             . '--jlg-border-color:' . $border_color . ';'
@@ -208,7 +223,7 @@ class JLG_Dynamic_CSS {
             . '--jlg-color-low:' . $color_low . ';'
             . '--jlg-tagline-bg-color:' . $tagline_bg_color . ';'
             . '--jlg-tagline-text-color:' . $tagline_text_color . ';'
-            . '--jlg-tagline-font-size:' . intval($options['tagline_font_size'] ?? 0) . 'px;'
+            . '--jlg-tagline-font-size:' . intval( $options['tagline_font_size'] ?? 0 ) . 'px;'
             . '--jlg-user-rating-text-color:' . $user_rating_text_color . ';'
             . '--jlg-user-rating-star-color:' . $user_rating_star_color . ';'
             . '--jlg-table-header-bg-color:' . $table_header_bg_color . ';'
@@ -221,8 +236,8 @@ class JLG_Dynamic_CSS {
             . '--jlg-table-zebra-bg-color:' . $table_zebra_bg_color . ';'
             . '}';
 
-        $inline_css .= $this->build_table_zebra_css($options, $table_zebra_bg_color);
-        $inline_css .= $this->build_table_border_css($options, $border_color);
+        $inline_css .= $this->build_table_zebra_css( $options, $table_zebra_bg_color );
+        $inline_css .= $this->build_table_border_css( $options, $border_color );
         $inline_css .= $this->build_score_circle_css(
             $options,
             $average_score,
@@ -232,8 +247,8 @@ class JLG_Dynamic_CSS {
             $default_score_gradient_2,
             $circle_border_color
         );
-        $inline_css .= $this->build_glow_css($options, $average_score);
-        $inline_css .= $this->build_custom_css($options);
+        $inline_css .= $this->build_glow_css( $options, $average_score );
+        $inline_css .= $this->build_custom_css( $options );
 
         return $inline_css;
     }
@@ -245,28 +260,28 @@ class JLG_Dynamic_CSS {
      * @param string $table_zebra_bg_color
      * @return string
      */
-    private function build_table_zebra_css(array $options, $table_zebra_bg_color) {
-        if (empty($options['table_zebra_striping'])) {
+    private function build_table_zebra_css( array $options, $table_zebra_bg_color ) {
+        if ( empty( $options['table_zebra_striping'] ) ) {
             return '';
         }
 
-        $zebra_base_color = $this->sanitize_color_value($table_zebra_bg_color, true);
+        $zebra_base_color = $this->sanitize_color_value( $table_zebra_bg_color, true );
 
-        if ($zebra_base_color === '') {
+        if ( $zebra_base_color === '' ) {
             return '';
         }
 
         $css = '.jlg-summary-table tbody tr:nth-child(even){background-color:var(--jlg-table-zebra-bg-color);}';
 
-        if ($zebra_base_color === 'transparent') {
+        if ( $zebra_base_color === 'transparent' ) {
             return $css;
         }
 
         $zebra_hover_color = $this->sanitize_color_value(
-            JLG_Helpers::adjust_hex_brightness($zebra_base_color, 5)
+            JLG_Helpers::adjust_hex_brightness( $zebra_base_color, 5 )
         );
 
-        if ($zebra_hover_color === '') {
+        if ( $zebra_hover_color === '' ) {
             return $css;
         }
 
@@ -280,16 +295,16 @@ class JLG_Dynamic_CSS {
      * @param string $border_color
      * @return string
      */
-    private function build_table_border_css(array $options, $border_color) {
-        $border_style = $options['table_border_style'] ?? '';
-        $border_width = intval($options['table_border_width'] ?? 0);
-        $sanitized_border_color = $this->sanitize_color_value($border_color, true);
+    private function build_table_border_css( array $options, $border_color ) {
+        $border_style           = $options['table_border_style'] ?? '';
+        $border_width           = intval( $options['table_border_width'] ?? 0 );
+        $sanitized_border_color = $this->sanitize_color_value( $border_color, true );
 
-        if ($sanitized_border_color === '') {
+        if ( $sanitized_border_color === '' ) {
             return '';
         }
 
-        switch ($border_style) {
+        switch ( $border_style ) {
             case 'horizontal':
                 return '.jlg-summary-table th,.jlg-summary-table td{border-bottom:' . $border_width . 'px solid ' . $sanitized_border_color . ';}';
             case 'full':
@@ -320,32 +335,32 @@ class JLG_Dynamic_CSS {
         $default_score_gradient_2,
         $circle_border_color
     ) {
-        if (($options['score_layout'] ?? '') !== 'circle') {
+        if ( ( $options['score_layout'] ?? '' ) !== 'circle' ) {
             return '';
         }
 
-        if (!empty($options['circle_dynamic_bg_enabled'])) {
-            $dynamic_color = $this->sanitize_color_value(JLG_Helpers::calculate_color_from_note($average_score, $options));
+        if ( ! empty( $options['circle_dynamic_bg_enabled'] ) ) {
+            $dynamic_color   = $this->sanitize_color_value( JLG_Helpers::calculate_color_from_note( $average_score, $options ) );
             $base_for_darker = $dynamic_color ?: $score_gradient_1;
-            $darker_color = $base_for_darker !== ''
-                ? $this->sanitize_color_value(JLG_Helpers::adjust_hex_brightness($base_for_darker, -30))
+            $darker_color    = $base_for_darker !== ''
+                ? $this->sanitize_color_value( JLG_Helpers::adjust_hex_brightness( $base_for_darker, -30 ) )
                 : '';
         } else {
             $dynamic_color = $score_gradient_1;
-            $darker_color = $score_gradient_2;
+            $darker_color  = $score_gradient_2;
         }
 
-        if ($dynamic_color === '') {
+        if ( $dynamic_color === '' ) {
             $dynamic_color = $default_score_gradient_1;
         }
-        if ($darker_color === '') {
+        if ( $darker_color === '' ) {
             $darker_color = $default_score_gradient_2;
         }
 
         $css = '.review-box-jlg .score-circle{background-image:linear-gradient(135deg,' . $dynamic_color . ',' . $darker_color . ');';
 
-        if (!empty($options['circle_border_enabled'])) {
-            $css .= 'border:' . intval($options['circle_border_width'] ?? 0) . 'px solid ' . $circle_border_color . ';';
+        if ( ! empty( $options['circle_border_enabled'] ) ) {
+            $css .= 'border:' . intval( $options['circle_border_width'] ?? 0 ) . 'px solid ' . $circle_border_color . ';';
         }
 
         return $css . '}';
@@ -358,15 +373,15 @@ class JLG_Dynamic_CSS {
      * @param float|null $average_score
      * @return string
      */
-    private function build_glow_css(array $options, $average_score) {
+    private function build_glow_css( array $options, $average_score ) {
         $layout = $options['score_layout'] ?? '';
 
-        if ($layout === 'text') {
-            return JLG_Helpers::get_glow_css('text', $average_score, $options);
+        if ( $layout === 'text' ) {
+            return JLG_Helpers::get_glow_css( 'text', $average_score, $options );
         }
 
-        if ($layout === 'circle') {
-            return JLG_Helpers::get_glow_css('circle', $average_score, $options);
+        if ( $layout === 'circle' ) {
+            return JLG_Helpers::get_glow_css( 'circle', $average_score, $options );
         }
 
         return '';
@@ -378,12 +393,12 @@ class JLG_Dynamic_CSS {
      * @param array $options
      * @return string
      */
-    private function build_custom_css(array $options) {
-        if (empty($options['custom_css'])) {
+    private function build_custom_css( array $options ) {
+        if ( empty( $options['custom_css'] ) ) {
             return '';
         }
 
-        return wp_strip_all_tags($options['custom_css']);
+        return wp_strip_all_tags( $options['custom_css'] );
     }
 
     /**
@@ -393,14 +408,14 @@ class JLG_Dynamic_CSS {
      * @param bool $allow_transparent
      * @return string
      */
-    private function sanitize_color_value($value, $allow_transparent = false) {
-        $sanitized = sanitize_hex_color($value);
+    private function sanitize_color_value( $value, $allow_transparent = false ) {
+        $sanitized = sanitize_hex_color( $value );
 
-        if (!empty($sanitized)) {
+        if ( ! empty( $sanitized ) ) {
             return $sanitized;
         }
 
-        if ($allow_transparent && is_string($value) && 'transparent' === strtolower(trim($value))) {
+        if ( $allow_transparent && is_string( $value ) && 'transparent' === strtolower( trim( $value ) ) ) {
             return 'transparent';
         }
 
@@ -414,28 +429,28 @@ class JLG_Dynamic_CSS {
      * @param array $source
      * @return array
      */
-    private function sanitize_color_options(array $definitions, array $source) {
-        $sanitized = [];
+    private function sanitize_color_options( array $definitions, array $source ) {
+        $sanitized = array();
 
-        foreach ($definitions as $target => $definition) {
+        foreach ( $definitions as $target => $definition ) {
             $allow_transparent = false;
 
-            if (is_int($target)) {
+            if ( is_int( $target ) ) {
                 $target_key = $definition;
                 $source_key = $definition;
-            } elseif (is_string($definition)) {
+            } elseif ( is_string( $definition ) ) {
                 $target_key = $target;
                 $source_key = $definition;
-            } elseif (is_array($definition)) {
-                $target_key = $target;
-                $source_key = isset($definition['key']) ? $definition['key'] : $target;
-                $allow_transparent = !empty($definition['allow_transparent']);
+            } elseif ( is_array( $definition ) ) {
+                $target_key        = $target;
+                $source_key        = isset( $definition['key'] ) ? $definition['key'] : $target;
+                $allow_transparent = ! empty( $definition['allow_transparent'] );
             } else {
                 continue;
             }
 
-            $value = isset($source[$source_key]) ? $source[$source_key] : '';
-            $sanitized[$target_key] = $this->sanitize_color_value($value, $allow_transparent);
+            $value                    = isset( $source[ $source_key ] ) ? $source[ $source_key ] : '';
+            $sanitized[ $target_key ] = $this->sanitize_color_value( $value, $allow_transparent );
         }
 
         return $sanitized;

--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1,16 +1,18 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Frontend {
 
     private const USER_RATING_MAX_STORED_VOTES = 250;
-    private const USER_RATING_RETENTION_DAYS = 180;
+    private const USER_RATING_RETENTION_DAYS   = 180;
 
     /**
      * Contiendra les erreurs de chargement des shortcodes pour affichage.
      * @var array
      */
-    private static $shortcode_errors = [];
+    private static $shortcode_errors = array();
 
     /**
      * Instance courante du frontend.
@@ -45,29 +47,29 @@ class JLG_Frontend {
      *
      * @var array<string, bool>
      */
-    private static $rendered_shortcodes = [];
+    private static $rendered_shortcodes = array();
 
     /**
      * Mémoïsation locale de la détection de métadonnées utilisées par le plugin.
      *
      * @var array<int, bool>
      */
-    private $metadata_usage_cache = [];
+    private $metadata_usage_cache = array();
 
     public function __construct() {
         self::$instance = $this;
         // On charge les shortcodes via le hook 'init' pour s'assurer que WordPress est prêt
-        add_action('init', [$this, 'initialize_shortcodes']);
+        add_action( 'init', array( $this, 'initialize_shortcodes' ) );
 
-        add_action('wp_enqueue_scripts', [$this, 'enqueue_jlg_scripts']);
-        add_filter('do_shortcode_tag', [$this, 'track_shortcode_usage'], 10, 4);
-        add_action('wp_ajax_jlg_rate_post', [$this, 'handle_user_rating']);
-        add_action('wp_ajax_nopriv_jlg_rate_post', [$this, 'handle_user_rating']);
-        add_action('wp_ajax_jlg_summary_sort', [$this, 'handle_summary_sort']);
-        add_action('wp_ajax_nopriv_jlg_summary_sort', [$this, 'handle_summary_sort']);
-        add_action('wp_ajax_jlg_game_explorer_sort', [$this, 'handle_game_explorer_sort']);
-        add_action('wp_ajax_nopriv_jlg_game_explorer_sort', [$this, 'handle_game_explorer_sort']);
-        add_action('wp_head', [$this, 'inject_review_schema']);
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_jlg_scripts' ) );
+        add_filter( 'do_shortcode_tag', array( $this, 'track_shortcode_usage' ), 10, 4 );
+        add_action( 'wp_ajax_jlg_rate_post', array( $this, 'handle_user_rating' ) );
+        add_action( 'wp_ajax_nopriv_jlg_rate_post', array( $this, 'handle_user_rating' ) );
+        add_action( 'wp_ajax_jlg_summary_sort', array( $this, 'handle_summary_sort' ) );
+        add_action( 'wp_ajax_nopriv_jlg_summary_sort', array( $this, 'handle_summary_sort' ) );
+        add_action( 'wp_ajax_jlg_game_explorer_sort', array( $this, 'handle_game_explorer_sort' ) );
+        add_action( 'wp_ajax_nopriv_jlg_game_explorer_sort', array( $this, 'handle_game_explorer_sort' ) );
+        add_action( 'wp_head', array( $this, 'inject_review_schema' ) );
     }
 
     /**
@@ -81,7 +83,7 @@ class JLG_Frontend {
      * Charge tous les shortcodes du plugin
      */
     private function load_shortcodes() {
-        $shortcodes = [
+        $shortcodes = array(
             'Rating_Block',
             'Pros_Cons',
             'Game_Info',
@@ -90,17 +92,17 @@ class JLG_Frontend {
             'Summary_Display',
             'All_In_One',  // NOUVEAU SHORTCODE AJOUTÉ ICI
             'Game_Explorer',
-        ];
-        
-        $errors = [];
+        );
 
-        foreach ($shortcodes as $shortcode) {
+        $errors = array();
+
+        foreach ( $shortcodes as $shortcode ) {
             $class_name = 'JLG_Shortcode_' . $shortcode;
-            $file_path = JLG_NOTATION_PLUGIN_DIR . 'includes/shortcodes/class-jlg-shortcode-' . strtolower(str_replace('_', '-', $shortcode)) . '.php';
-            
-            if (file_exists($file_path)) {
+            $file_path  = JLG_NOTATION_PLUGIN_DIR . 'includes/shortcodes/class-jlg-shortcode-' . strtolower( str_replace( '_', '-', $shortcode ) ) . '.php';
+
+            if ( file_exists( $file_path ) ) {
                 require_once $file_path;
-                if (!class_exists($class_name)) {
+                if ( ! class_exists( $class_name ) ) {
                     $errors[] = "Le fichier existe <code>{$file_path}</code>, mais la classe <code>{$class_name}</code> n'a pas été trouvée à l'intérieur.";
                 } else {
                     new $class_name();
@@ -111,10 +113,10 @@ class JLG_Frontend {
         }
 
         // On vérifie les erreurs et on les affiche seulement pour les admins
-        if (!empty($errors)) {
+        if ( ! empty( $errors ) ) {
             self::$shortcode_errors = $errors;
             // On diffère la vérification des capacités utilisateur
-            add_action('admin_notices', [$this, 'display_shortcode_errors']);
+            add_action( 'admin_notices', array( $this, 'display_shortcode_errors' ) );
         }
     }
 
@@ -123,10 +125,10 @@ class JLG_Frontend {
      */
     public function display_shortcode_errors() {
         // Maintenant on peut vérifier les capacités car WordPress est complètement chargé
-        if (!empty(self::$shortcode_errors) && current_user_can('manage_options')) {
+        if ( ! empty( self::$shortcode_errors ) && current_user_can( 'manage_options' ) ) {
             echo '<div class="notice notice-error"><p><strong>Plugin Notation - JLG : Erreur de chargement des shortcodes !</strong></p><ul>';
-            foreach (self::$shortcode_errors as $error) {
-                printf('<li>%s</li>', wp_kses_post($error));
+            foreach ( self::$shortcode_errors as $error ) {
+                printf( '<li>%s</li>', wp_kses_post( $error ) );
             }
             echo '</ul></div>';
         }
@@ -138,7 +140,7 @@ class JLG_Frontend {
      * @return array
      */
     private function get_plugin_shortcodes() {
-        return [
+        return array(
             'bloc_notation_jeu',
             'jlg_points_forts_faibles',
             'jlg_fiche_technique',
@@ -148,26 +150,26 @@ class JLG_Frontend {
             'jlg_bloc_complet',
             'bloc_notation_complet',
             'jlg_game_explorer',
-        ];
+        );
     }
 
     /**
      * Marque l'utilisation d'un shortcode du plugin.
      */
-    public static function mark_shortcode_rendered($shortcode = null) {
-        if (is_string($shortcode) && $shortcode !== '') {
-            self::$rendered_shortcodes[$shortcode] = true;
+    public static function mark_shortcode_rendered( $shortcode = null ) {
+        if ( is_string( $shortcode ) && $shortcode !== '' ) {
+            self::$rendered_shortcodes[ $shortcode ] = true;
         }
 
         self::$shortcode_rendered = true;
 
-        if (!self::$assets_enqueued && did_action('wp_enqueue_scripts') && self::$instance instanceof self) {
-            self::$instance->enqueue_jlg_scripts(true);
+        if ( ! self::$assets_enqueued && did_action( 'wp_enqueue_scripts' ) && self::$instance instanceof self ) {
+            self::$instance->enqueue_jlg_scripts( true );
 
-            if (did_action('wp_print_styles') && !wp_style_is('jlg-frontend', 'done')) {
-                if (!self::$deferred_styles_hooked) {
+            if ( did_action( 'wp_print_styles' ) && ! wp_style_is( 'jlg-frontend', 'done' ) ) {
+                if ( ! self::$deferred_styles_hooked ) {
                     self::$deferred_styles_hooked = true;
-                    add_action('wp_footer', [self::$instance, 'print_deferred_styles']);
+                    add_action( 'wp_footer', array( self::$instance, 'print_deferred_styles' ) );
                 }
             }
         }
@@ -179,24 +181,24 @@ class JLG_Frontend {
      * @param string $shortcode
      * @return bool
      */
-    public static function has_rendered_shortcode($shortcode) {
-        if ($shortcode === '') {
+    public static function has_rendered_shortcode( $shortcode ) {
+        if ( $shortcode === '' ) {
             return false;
         }
 
-        return isset(self::$rendered_shortcodes[$shortcode]);
+        return isset( self::$rendered_shortcodes[ $shortcode ] );
     }
 
     /**
      * Imprime la feuille de style frontend si elle n'a pas déjà été imprimée.
      */
     public function print_deferred_styles() {
-        if (!wp_style_is('jlg-frontend', 'done')) {
-            wp_print_styles('jlg-frontend');
+        if ( ! wp_style_is( 'jlg-frontend', 'done' ) ) {
+            wp_print_styles( 'jlg-frontend' );
         }
 
-        if (wp_style_is('jlg-frontend', 'done')) {
-            remove_action('wp_footer', [self::$instance, 'print_deferred_styles']);
+        if ( wp_style_is( 'jlg-frontend', 'done' ) ) {
+            remove_action( 'wp_footer', array( self::$instance, 'print_deferred_styles' ) );
             self::$deferred_styles_hooked = false;
         }
     }
@@ -204,9 +206,9 @@ class JLG_Frontend {
     /**
      * Détecte l'exécution des shortcodes du plugin lors de leur rendu.
      */
-    public function track_shortcode_usage($output, $tag, $attr, $m) {
-        if (in_array($tag, $this->get_plugin_shortcodes(), true)) {
-            self::mark_shortcode_rendered($tag);
+    public function track_shortcode_usage( $output, $tag, $attr, $m ) {
+        if ( in_array( $tag, $this->get_plugin_shortcodes(), true ) ) {
+            self::mark_shortcode_rendered( $tag );
         }
 
         return $output;
@@ -218,13 +220,13 @@ class JLG_Frontend {
      * @param string $content
      * @return bool
      */
-    private function content_has_plugin_shortcode($content) {
-        if (!is_string($content) || $content === '') {
+    private function content_has_plugin_shortcode( $content ) {
+        if ( ! is_string( $content ) || $content === '' ) {
             return false;
         }
 
-        foreach ($this->get_plugin_shortcodes() as $shortcode) {
-            if (has_shortcode($content, $shortcode)) {
+        foreach ( $this->get_plugin_shortcodes() as $shortcode ) {
+            if ( has_shortcode( $content, $shortcode ) ) {
                 return true;
             }
         }
@@ -238,18 +240,18 @@ class JLG_Frontend {
      * @param int $post_id
      * @return bool
      */
-    private function post_has_plugin_metadata($post_id) {
+    private function post_has_plugin_metadata( $post_id ) {
         $post_id = (int) $post_id;
 
-        if ($post_id <= 0) {
+        if ( $post_id <= 0 ) {
             return false;
         }
 
-        if (isset($this->metadata_usage_cache[$post_id])) {
-            return $this->metadata_usage_cache[$post_id];
+        if ( isset( $this->metadata_usage_cache[ $post_id ] ) ) {
+            return $this->metadata_usage_cache[ $post_id ];
         }
 
-        $meta_keys = [
+        $meta_keys = array(
             '_jlg_average_score',
             '_jlg_game_title',
             '_jlg_cover_image_url',
@@ -262,28 +264,28 @@ class JLG_Frontend {
             '_jlg_tagline_fr',
             '_jlg_tagline_en',
             '_jlg_user_rating_avg',
-        ];
+        );
 
-        foreach (array_keys(JLG_Helpers::get_rating_categories()) as $category_key) {
+        foreach ( array_keys( JLG_Helpers::get_rating_categories() ) as $category_key ) {
             $meta_keys[] = '_note_' . $category_key;
         }
 
         $has_metadata = false;
 
-        foreach ($meta_keys as $meta_key) {
-            if (!metadata_exists('post', $post_id, $meta_key)) {
+        foreach ( $meta_keys as $meta_key ) {
+            if ( ! metadata_exists( 'post', $post_id, $meta_key ) ) {
                 continue;
             }
 
-            $value = get_post_meta($post_id, $meta_key, true);
+            $value = get_post_meta( $post_id, $meta_key, true );
 
-            if ($this->is_meta_value_filled($value)) {
+            if ( $this->is_meta_value_filled( $value ) ) {
                 $has_metadata = true;
                 break;
             }
         }
 
-        $this->metadata_usage_cache[$post_id] = $has_metadata;
+        $this->metadata_usage_cache[ $post_id ] = $has_metadata;
 
         return $has_metadata;
     }
@@ -294,10 +296,10 @@ class JLG_Frontend {
      * @param mixed $value
      * @return bool
      */
-    private function is_meta_value_filled($value) {
-        if (is_array($value)) {
-            foreach ($value as $item) {
-                if ($this->is_meta_value_filled($item)) {
+    private function is_meta_value_filled( $value ) {
+        if ( is_array( $value ) ) {
+            foreach ( $value as $item ) {
+                if ( $this->is_meta_value_filled( $item ) ) {
                     return true;
                 }
             }
@@ -305,8 +307,8 @@ class JLG_Frontend {
             return false;
         }
 
-        if (is_string($value)) {
-            return trim($value) !== '';
+        if ( is_string( $value ) ) {
+            return trim( $value ) !== '';
         }
 
         return $value !== null && $value !== '';
@@ -315,195 +317,203 @@ class JLG_Frontend {
     /**
      * Charge les scripts JavaScript nécessaires
      */
-    public function enqueue_jlg_scripts($force = false) {
-        if (self::$assets_enqueued) {
+    public function enqueue_jlg_scripts( $force = false ) {
+        if ( self::$assets_enqueued ) {
             return;
         }
 
-        $summary_ajax = $this->is_summary_sort_ajax_context();
+        $summary_ajax       = $this->is_summary_sort_ajax_context();
         $game_explorer_ajax = $this->is_game_explorer_ajax_context();
-        $should_enqueue = $force || self::$shortcode_rendered;
+        $should_enqueue     = $force || self::$shortcode_rendered;
 
-        if (!$should_enqueue) {
+        if ( ! $should_enqueue ) {
             $queried_object = get_queried_object();
 
-            if ($queried_object instanceof WP_Post) {
-                if ($this->content_has_plugin_shortcode($queried_object->post_content ?? '')) {
+            if ( $queried_object instanceof WP_Post ) {
+                if ( $this->content_has_plugin_shortcode( $queried_object->post_content ?? '' ) ) {
                     $should_enqueue = true;
-                } elseif ($this->post_has_plugin_metadata($queried_object->ID)) {
+                } elseif ( $this->post_has_plugin_metadata( $queried_object->ID ) ) {
                     $should_enqueue = true;
                 }
             }
         }
 
-        if (!$should_enqueue) {
+        if ( ! $should_enqueue ) {
             return;
         }
 
-        self::$assets_enqueued = true;
+        self::$assets_enqueued    = true;
         self::$shortcode_rendered = true;
 
-        $options = JLG_Helpers::get_plugin_options();
-        $palette = JLG_Helpers::get_color_palette();
-        $post_id = get_queried_object_id();
-        $average_score = JLG_Helpers::get_average_score_for_post($post_id);
+        $options       = JLG_Helpers::get_plugin_options();
+        $palette       = JLG_Helpers::get_color_palette();
+        $post_id       = get_queried_object_id();
+        $average_score = JLG_Helpers::get_average_score_for_post( $post_id );
 
         // Feuille de styles principale
         wp_enqueue_style(
             'jlg-frontend',
             JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-frontend.css',
-            [],
+            array(),
             JLG_NOTATION_VERSION
         );
 
-        $inline_css = JLG_Dynamic_CSS::build_frontend_css($options, $palette, $average_score);
+        $inline_css = JLG_Dynamic_CSS::build_frontend_css( $options, $palette, $average_score );
 
-        wp_add_inline_style('jlg-frontend', $inline_css);
+        wp_add_inline_style( 'jlg-frontend', $inline_css );
 
-        if (!wp_style_is('jlg-game-explorer', 'registered')) {
+        if ( ! wp_style_is( 'jlg-game-explorer', 'registered' ) ) {
             wp_register_style(
                 'jlg-game-explorer',
                 JLG_NOTATION_PLUGIN_URL . 'assets/css/game-explorer.css',
-                ['jlg-frontend'],
+                array( 'jlg-frontend' ),
                 JLG_NOTATION_VERSION
             );
         }
 
-        $queried_object = isset($queried_object) ? $queried_object : get_queried_object();
-        $post_content = '';
+        $queried_object = isset( $queried_object ) ? $queried_object : get_queried_object();
+        $post_content   = '';
 
-        if ($queried_object instanceof WP_Post) {
+        if ( $queried_object instanceof WP_Post ) {
             $post_content = $queried_object->post_content ?? '';
         }
 
-        $summary_shortcode_used = self::has_rendered_shortcode('jlg_tableau_recap');
-        if (!$summary_shortcode_used) {
-            $summary_shortcode_used = $this->content_has_specific_shortcode($post_content, 'jlg_tableau_recap');
+        $summary_shortcode_used = self::has_rendered_shortcode( 'jlg_tableau_recap' );
+        if ( ! $summary_shortcode_used ) {
+            $summary_shortcode_used = $this->content_has_specific_shortcode( $post_content, 'jlg_tableau_recap' );
         }
 
-        $game_explorer_shortcode_used = self::has_rendered_shortcode('jlg_game_explorer');
-        if (!$game_explorer_shortcode_used) {
-            $game_explorer_shortcode_used = $this->content_has_specific_shortcode($post_content, 'jlg_game_explorer');
+        $game_explorer_shortcode_used = self::has_rendered_shortcode( 'jlg_game_explorer' );
+        if ( ! $game_explorer_shortcode_used ) {
+            $game_explorer_shortcode_used = $this->content_has_specific_shortcode( $post_content, 'jlg_game_explorer' );
         }
 
-        $should_enqueue_summary_script = $summary_shortcode_used || $summary_ajax;
+        $should_enqueue_summary_script       = $summary_shortcode_used || $summary_ajax;
         $should_enqueue_game_explorer_script = $game_explorer_shortcode_used || $game_explorer_ajax;
         $should_enqueue_game_explorer_assets = $should_enqueue_game_explorer_script || $game_explorer_ajax;
 
-        if ($should_enqueue_game_explorer_assets) {
-            wp_enqueue_style('jlg-game-explorer');
+        if ( $should_enqueue_game_explorer_assets ) {
+            wp_enqueue_style( 'jlg-game-explorer' );
 
-            if (wp_style_is('jlg-game-explorer', 'enqueued')) {
-                $game_explorer_css = $this->build_game_explorer_css($options, $palette);
+            if ( wp_style_is( 'jlg-game-explorer', 'enqueued' ) ) {
+                $game_explorer_css = $this->build_game_explorer_css( $options, $palette );
 
-                if (!empty($game_explorer_css)) {
-                    wp_add_inline_style('jlg-game-explorer', $game_explorer_css);
+                if ( ! empty( $game_explorer_css ) ) {
+                    wp_add_inline_style( 'jlg-game-explorer', $game_explorer_css );
                 }
             }
         }
 
         // Script pour la notation utilisateur
-        if (!empty($options['user_rating_enabled'])) {
+        if ( ! empty( $options['user_rating_enabled'] ) ) {
             wp_enqueue_script(
                 'jlg-user-rating',
                 JLG_NOTATION_PLUGIN_URL . 'assets/js/user-rating.js',
-                ['jquery'],
+                array( 'jquery' ),
                 JLG_NOTATION_VERSION,
                 true
             );
             $cookie_name = 'jlg_user_rating_token';
-            $token = self::get_user_rating_token_from_cookie();
+            $token       = self::get_user_rating_token_from_cookie();
 
-            if ($token === '') {
+            if ( $token === '' ) {
                 try {
-                    $token = bin2hex(random_bytes(32));
-                } catch (Exception $e) {
-                    $token = md5(uniqid('', true));
+                    $token = bin2hex( random_bytes( 32 ) );
+                } catch ( Exception $e ) {
+                    $token = md5( uniqid( '', true ) );
                 }
 
-                $cookie_options = [
+                $cookie_options = array(
                     'expires'  => time() + MONTH_IN_SECONDS,
-                    'path'     => defined('COOKIEPATH') ? COOKIEPATH : '/',
+                    'path'     => defined( 'COOKIEPATH' ) ? COOKIEPATH : '/',
                     'secure'   => is_ssl(),
                     'httponly' => true,
                     'samesite' => 'Lax',
-                ];
+                );
 
-                if (defined('COOKIE_DOMAIN') && COOKIE_DOMAIN) {
+                if ( defined( 'COOKIE_DOMAIN' ) && COOKIE_DOMAIN ) {
                     $cookie_options['domain'] = COOKIE_DOMAIN;
                 }
 
-                if (!headers_sent()) {
-                    setcookie($cookie_name, $token, $cookie_options);
+                if ( ! headers_sent() ) {
+                    setcookie( $cookie_name, $token, $cookie_options );
                 }
-                $_COOKIE[$cookie_name] = $token;
+                $_COOKIE[ $cookie_name ] = $token;
             }
 
-            $nonce = wp_create_nonce('jlg_user_rating_nonce_' . $token);
+            $nonce = wp_create_nonce( 'jlg_user_rating_nonce_' . $token );
 
-            wp_localize_script('jlg-user-rating', 'jlg_rating_ajax', [
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'nonce'    => $nonce,
-                'token'    => $token,
-            ]);
+            wp_localize_script(
+                'jlg-user-rating',
+                'jlg_rating_ajax',
+                array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => $nonce,
+					'token'    => $token,
+				)
+            );
         }
 
         // Script pour le changement de langue des taglines
-        if (!empty($options['tagline_enabled'])) {
+        if ( ! empty( $options['tagline_enabled'] ) ) {
             wp_enqueue_script(
                 'jlg-tagline-switcher',
                 JLG_NOTATION_PLUGIN_URL . 'assets/js/tagline-switcher.js',
-                ['jquery'],
+                array( 'jquery' ),
                 JLG_NOTATION_VERSION,
                 true
             );
         }
 
         // Script pour les animations
-        if (!empty($options['enable_animations'])) {
+        if ( ! empty( $options['enable_animations'] ) ) {
             wp_enqueue_script(
                 'jlg-animations',
                 JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-animations.js',
-                [],
+                array(),
                 JLG_NOTATION_VERSION,
                 true
             );
         }
 
-        if ($should_enqueue_summary_script) {
-            if (!wp_script_is('jlg-summary-table-sort', 'registered')) {
+        if ( $should_enqueue_summary_script ) {
+            if ( ! wp_script_is( 'jlg-summary-table-sort', 'registered' ) ) {
                 wp_register_script(
                     'jlg-summary-table-sort',
                     JLG_NOTATION_PLUGIN_URL . 'assets/js/summary-table-sort.js',
-                    ['jquery'],
+                    array( 'jquery' ),
                     JLG_NOTATION_VERSION,
                     true
                 );
             }
 
-            wp_enqueue_script('jlg-summary-table-sort');
+            wp_enqueue_script( 'jlg-summary-table-sort' );
 
-            wp_localize_script('jlg-summary-table-sort', 'jlgSummarySort', [
-                'ajax_url' => admin_url('admin-ajax.php'),
-                'nonce'    => wp_create_nonce('jlg_summary_sort'),
-                'strings'  => [
-                    'genericError' => esc_html__('Une erreur est survenue. Merci de réessayer plus tard.', 'notation-jlg'),
-                ],
-            ]);
+            wp_localize_script(
+                'jlg-summary-table-sort',
+                'jlgSummarySort',
+                array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'jlg_summary_sort' ),
+					'strings'  => array(
+						'genericError' => esc_html__( 'Une erreur est survenue. Merci de réessayer plus tard.', 'notation-jlg' ),
+					),
+				)
+            );
         }
 
-        if ($should_enqueue_game_explorer_script && !wp_script_is('jlg-game-explorer', 'enqueued')) {
-            if (!wp_script_is('jlg-game-explorer', 'registered')) {
+        if ( $should_enqueue_game_explorer_script && ! wp_script_is( 'jlg-game-explorer', 'enqueued' ) ) {
+            if ( ! wp_script_is( 'jlg-game-explorer', 'registered' ) ) {
                 wp_register_script(
                     'jlg-game-explorer',
                     JLG_NOTATION_PLUGIN_URL . 'assets/js/game-explorer.js',
-                    [],
+                    array(),
                     JLG_NOTATION_VERSION,
                     true
                 );
             }
 
-            wp_enqueue_script('jlg-game-explorer');
+            wp_enqueue_script( 'jlg-game-explorer' );
         }
     }
 
@@ -514,16 +524,16 @@ class JLG_Frontend {
      * @param string $shortcode
      * @return bool
      */
-    private function content_has_specific_shortcode($content, $shortcode) {
-        if (!is_string($content) || $content === '' || $shortcode === '') {
+    private function content_has_specific_shortcode( $content, $shortcode ) {
+        if ( ! is_string( $content ) || $content === '' || $shortcode === '' ) {
             return false;
         }
 
-        if (!function_exists('has_shortcode')) {
+        if ( ! function_exists( 'has_shortcode' ) ) {
             return false;
         }
 
-        return has_shortcode($content, $shortcode);
+        return has_shortcode( $content, $shortcode );
     }
 
     /**
@@ -532,9 +542,9 @@ class JLG_Frontend {
      * @return bool
      */
     private function is_summary_sort_ajax_context() {
-        $doing_ajax = function_exists('wp_doing_ajax') ? wp_doing_ajax() : (defined('DOING_AJAX') && DOING_AJAX);
+        $doing_ajax = function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : ( defined( 'DOING_AJAX' ) && DOING_AJAX );
 
-        return $doing_ajax && isset($_REQUEST['action']) && $_REQUEST['action'] === 'jlg_summary_sort';
+        return $doing_ajax && isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'jlg_summary_sort';
     }
 
     /**
@@ -543,24 +553,24 @@ class JLG_Frontend {
      * @return bool
      */
     private function is_game_explorer_ajax_context() {
-        $doing_ajax = function_exists('wp_doing_ajax') ? wp_doing_ajax() : (defined('DOING_AJAX') && DOING_AJAX);
+        $doing_ajax = function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : ( defined( 'DOING_AJAX' ) && DOING_AJAX );
 
-        return $doing_ajax && isset($_REQUEST['action']) && $_REQUEST['action'] === 'jlg_game_explorer_sort';
+        return $doing_ajax && isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'jlg_game_explorer_sort';
     }
 
-    private function build_game_explorer_css($options, $palette) {
-        $card_bg = $palette['bg_color_secondary'] ?? '#1f2937';
-        $border = $palette['border_color'] ?? '#3f3f46';
-        $text = $palette['text_color'] ?? '#fafafa';
-        $secondary = $palette['text_color_secondary'] ?? '#9ca3af';
-        $accent_primary = $options['score_gradient_1'] ?? '#60a5fa';
+    private function build_game_explorer_css( $options, $palette ) {
+        $card_bg          = $palette['bg_color_secondary'] ?? '#1f2937';
+        $border           = $palette['border_color'] ?? '#3f3f46';
+        $text             = $palette['text_color'] ?? '#fafafa';
+        $secondary        = $palette['text_color_secondary'] ?? '#9ca3af';
+        $accent_primary   = $options['score_gradient_1'] ?? '#60a5fa';
         $accent_secondary = $options['score_gradient_2'] ?? '#c084fc';
 
         $css = "
 .jlg-game-explorer{--jlg-ge-card-bg: {$card_bg};--jlg-ge-card-border: {$border};--jlg-ge-text: {$text};--jlg-ge-text-muted: {$secondary};--jlg-ge-accent: {$accent_primary};--jlg-ge-accent-alt: {$accent_secondary};}
 ";
 
-        return trim($css);
+        return trim( $css );
     }
 
     /**
@@ -571,24 +581,24 @@ class JLG_Frontend {
     private function get_request_ip_address() {
         $ip_address = '';
 
-        if (function_exists('rest_get_ip_address')) {
+        if ( function_exists( 'rest_get_ip_address' ) ) {
             $ip_address = rest_get_ip_address();
-        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
+        } elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
             $ip_address = $_SERVER['REMOTE_ADDR'];
         }
 
-        if (!is_string($ip_address)) {
+        if ( ! is_string( $ip_address ) ) {
             $ip_address = '';
         }
 
-        $ip_address = apply_filters('jlg_user_rating_request_ip', $ip_address);
+        $ip_address = apply_filters( 'jlg_user_rating_request_ip', $ip_address );
 
-        if (!is_string($ip_address)) {
+        if ( ! is_string( $ip_address ) ) {
             $ip_address = '';
         }
 
-        $ip_address = trim($ip_address);
-        $validated = $ip_address !== '' ? filter_var($ip_address, FILTER_VALIDATE_IP) : false;
+        $ip_address = trim( $ip_address );
+        $validated  = $ip_address !== '' ? filter_var( $ip_address, FILTER_VALIDATE_IP ) : false;
 
         return $validated ? $validated : '';
     }
@@ -598,116 +608,124 @@ class JLG_Frontend {
      */
     public function handle_user_rating() {
         $cookie_name = 'jlg_user_rating_token';
-        $token = '';
+        $token       = '';
 
-        if (isset($_POST['token'])) {
-            $token = self::normalize_user_rating_token(wp_unslash($_POST['token']));
+        if ( isset( $_POST['token'] ) ) {
+            $token = self::normalize_user_rating_token( wp_unslash( $_POST['token'] ) );
         }
 
-        if ($token === '' && isset($_COOKIE[$cookie_name])) {
-            $token = self::normalize_user_rating_token(wp_unslash($_COOKIE[$cookie_name]));
+        if ( $token === '' && isset( $_COOKIE[ $cookie_name ] ) ) {
+            $token = self::normalize_user_rating_token( wp_unslash( $_COOKIE[ $cookie_name ] ) );
         }
 
-        if ($token === '') {
-            wp_send_json_error(['message' => esc_html__('Jeton de sécurité manquant ou invalide.', 'notation-jlg')], 400);
+        if ( $token === '' ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Jeton de sécurité manquant ou invalide.', 'notation-jlg' ) ), 400 );
         }
 
-        if (!check_ajax_referer('jlg_user_rating_nonce_' . $token, 'nonce', false)) {
-            wp_send_json_error(['message' => esc_html__('La vérification de sécurité a échoué.', 'notation-jlg')], 403);
+        if ( ! check_ajax_referer( 'jlg_user_rating_nonce_' . $token, 'nonce', false ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'La vérification de sécurité a échoué.', 'notation-jlg' ) ), 403 );
         }
 
         $options = JLG_Helpers::get_plugin_options();
 
-        if (empty($options['user_rating_enabled'])) {
-            wp_send_json_error([
-                'message' => esc_html__('La notation des lecteurs est désactivée.', 'notation-jlg'),
-            ], 403);
+        if ( empty( $options['user_rating_enabled'] ) ) {
+            wp_send_json_error(
+                array(
+					'message' => esc_html__( 'La notation des lecteurs est désactivée.', 'notation-jlg' ),
+                ),
+                403
+            );
         }
 
-        $post_id = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
+        $post_id = isset( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : 0;
 
-        if (!$post_id) {
-            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')], 400);
+        if ( ! $post_id ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Données invalides.', 'notation-jlg' ) ), 400 );
         }
 
-        $post = get_post($post_id);
+        $post = get_post( $post_id );
 
-        if (!($post instanceof WP_Post) || 'trash' === $post->post_status || 'publish' !== $post->post_status) {
-            wp_send_json_error(['message' => esc_html__('Article introuvable ou non disponible pour la notation.', 'notation-jlg')], 404);
+        if ( ! ( $post instanceof WP_Post ) || 'trash' === $post->post_status || 'publish' !== $post->post_status ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Article introuvable ou non disponible pour la notation.', 'notation-jlg' ) ), 404 );
         }
 
         $allows_user_rating = apply_filters(
             'jlg_post_allows_user_rating',
-            $this->post_allows_user_rating($post, $options),
+            $this->post_allows_user_rating( $post, $options ),
             $post
         );
 
-        if (!$allows_user_rating) {
-            wp_send_json_error(['message' => esc_html__('La notation des lecteurs est désactivée pour ce contenu.', 'notation-jlg')], 403);
+        if ( ! $allows_user_rating ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'La notation des lecteurs est désactivée pour ce contenu.', 'notation-jlg' ) ), 403 );
         }
 
-        $rating = isset($_POST['rating']) ? intval($_POST['rating']) : 0;
+        $rating = isset( $_POST['rating'] ) ? intval( $_POST['rating'] ) : 0;
 
-        if ($rating < 1 || $rating > 5) {
-            wp_send_json_error(['message' => esc_html__('Données invalides.', 'notation-jlg')], 422);
+        if ( $rating < 1 || $rating > 5 ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Données invalides.', 'notation-jlg' ) ), 422 );
         }
 
-        $user_ip = $this->get_request_ip_address();
-        $user_ip_hash = $user_ip ? self::hash_user_ip($user_ip) : '';
-        $ip_log = [];
+        $user_ip      = $this->get_request_ip_address();
+        $user_ip_hash = $user_ip ? self::hash_user_ip( $user_ip ) : '';
+        $ip_log       = array();
 
-        if ($user_ip_hash !== '') {
-            $stored_ip_log = get_post_meta($post_id, '_jlg_user_rating_ips', true);
+        if ( $user_ip_hash !== '' ) {
+            $stored_ip_log = get_post_meta( $post_id, '_jlg_user_rating_ips', true );
 
-            if (is_array($stored_ip_log)) {
+            if ( is_array( $stored_ip_log ) ) {
                 $ip_log = $stored_ip_log;
             }
 
-            if (isset($ip_log[$user_ip_hash]) && (!is_array($ip_log[$user_ip_hash]) || empty($ip_log[$user_ip_hash]['legacy']))) {
-                wp_send_json_error([
-                    'message' => esc_html__('Un vote depuis cette adresse IP a déjà été enregistré.', 'notation-jlg'),
-                ], 409);
+            if ( isset( $ip_log[ $user_ip_hash ] ) && ( ! is_array( $ip_log[ $user_ip_hash ] ) || empty( $ip_log[ $user_ip_hash ]['legacy'] ) ) ) {
+                wp_send_json_error(
+                    array(
+						'message' => esc_html__( 'Un vote depuis cette adresse IP a déjà été enregistré.', 'notation-jlg' ),
+                    ),
+                    409
+                );
             }
         }
 
-        $token_hash = self::hash_user_rating_token($token);
+        $token_hash = self::hash_user_rating_token( $token );
 
-        $ratings_meta = [];
-        $ratings = self::get_post_user_rating_tokens($post_id, $ratings_meta);
+        $ratings_meta = array();
+        $ratings      = self::get_post_user_rating_tokens( $post_id, $ratings_meta );
 
-        if (isset($ratings[$token_hash])) {
-            wp_send_json_error(['message' => esc_html__('Vous avez déjà voté !', 'notation-jlg')], 409);
+        if ( isset( $ratings[ $token_hash ] ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Vous avez déjà voté !', 'notation-jlg' ) ), 409 );
         }
 
-        $ratings[$token_hash] = $rating;
-        $ratings_meta['timestamps'][$token_hash] = current_time('timestamp');
+        $ratings[ $token_hash ]                    = $rating;
+        $ratings_meta['timestamps'][ $token_hash ] = current_time( 'timestamp' );
 
-        self::store_post_user_rating_tokens($post_id, $ratings, $ratings_meta);
+        self::store_post_user_rating_tokens( $post_id, $ratings, $ratings_meta );
 
-        if ($user_ip_hash) {
-            self::update_user_rating_ip_log($post_id, $user_ip_hash, $token_hash, $rating);
+        if ( $user_ip_hash ) {
+            self::update_user_rating_ip_log( $post_id, $user_ip_hash, $token_hash, $rating );
         }
 
-        $fresh_ratings = self::get_post_user_rating_tokens($post_id);
-        list($new_average, $ratings_count) = self::calculate_user_rating_stats($fresh_ratings);
+        $fresh_ratings                     = self::get_post_user_rating_tokens( $post_id );
+        list($new_average, $ratings_count) = self::calculate_user_rating_stats( $fresh_ratings );
 
-        update_post_meta($post_id, '_jlg_user_rating_avg', $new_average);
-        update_post_meta($post_id, '_jlg_user_rating_count', $ratings_count);
+        update_post_meta( $post_id, '_jlg_user_rating_avg', $new_average );
+        update_post_meta( $post_id, '_jlg_user_rating_count', $ratings_count );
 
-        wp_send_json_success([
-            'new_average' => number_format_i18n($new_average, 2),
-            'new_count' => $ratings_count
-        ]);
+        wp_send_json_success(
+            array(
+				'new_average' => number_format_i18n( $new_average, 2 ),
+				'new_count'   => $ratings_count,
+            )
+        );
     }
 
-    private static function normalize_user_rating_token($token) {
-        if (!is_string($token)) {
+    private static function normalize_user_rating_token( $token ) {
+        if ( ! is_string( $token ) ) {
             return '';
         }
 
-        $token = sanitize_text_field($token);
+        $token = sanitize_text_field( $token );
 
-        if (!preg_match('/^[A-Fa-f0-9]{32,128}$/', $token)) {
+        if ( ! preg_match( '/^[A-Fa-f0-9]{32,128}$/', $token ) ) {
             return '';
         }
 
@@ -717,91 +735,91 @@ class JLG_Frontend {
     public static function get_user_rating_token_from_cookie() {
         $cookie_name = 'jlg_user_rating_token';
 
-        if (!isset($_COOKIE[$cookie_name])) {
+        if ( ! isset( $_COOKIE[ $cookie_name ] ) ) {
             return '';
         }
 
-        return self::normalize_user_rating_token(wp_unslash($_COOKIE[$cookie_name]));
+        return self::normalize_user_rating_token( wp_unslash( $_COOKIE[ $cookie_name ] ) );
     }
 
-    private static function hash_user_rating_token($token) {
-        $hashed = hash('sha256', (string) $token);
+    private static function hash_user_rating_token( $token ) {
+        $hashed = hash( 'sha256', (string) $token );
 
-        return is_string($hashed) ? $hashed : '';
+        return is_string( $hashed ) ? $hashed : '';
     }
 
-    private static function hash_user_ip($ip_address) {
-        $context = apply_filters('jlg_user_rating_ip_hash_context', site_url());
-        $context = is_string($context) ? $context : '';
+    private static function hash_user_ip( $ip_address ) {
+        $context = apply_filters( 'jlg_user_rating_ip_hash_context', site_url() );
+        $context = is_string( $context ) ? $context : '';
 
-        $hashed = hash('sha256', $ip_address . '|' . $context);
+        $hashed = hash( 'sha256', $ip_address . '|' . $context );
 
-        return is_string($hashed) ? $hashed : '';
+        return is_string( $hashed ) ? $hashed : '';
     }
 
-    private static function get_post_user_rating_tokens($post_id, &$meta = null) {
+    private static function get_post_user_rating_tokens( $post_id, &$meta = null ) {
         $meta_key = '_jlg_user_ratings';
-        $stored = get_post_meta($post_id, $meta_key, true);
+        $stored   = get_post_meta( $post_id, $meta_key, true );
 
-        if (!is_array($stored)) {
-            $stored = [];
+        if ( ! is_array( $stored ) ) {
+            $stored = array();
         }
 
-        $meta_data = [];
+        $meta_data = array();
 
-        if (isset($stored['__meta']) && is_array($stored['__meta'])) {
+        if ( isset( $stored['__meta'] ) && is_array( $stored['__meta'] ) ) {
             $meta_data = $stored['__meta'];
-            unset($stored['__meta']);
+            unset( $stored['__meta'] );
         }
 
-        $normalized = [];
-        $now = current_time('timestamp');
+        $normalized = array();
+        $now        = current_time( 'timestamp' );
 
-        $needs_meta_update = !isset($meta_data['version']) || (int) $meta_data['version'] < 2;
+        $needs_meta_update    = ! isset( $meta_data['version'] ) || (int) $meta_data['version'] < 2;
         $meta_data['version'] = 2;
 
-        if (!isset($meta_data['timestamps']) || !is_array($meta_data['timestamps'])) {
-            $meta_data['timestamps'] = [];
+        if ( ! isset( $meta_data['timestamps'] ) || ! is_array( $meta_data['timestamps'] ) ) {
+            $meta_data['timestamps'] = array();
         }
 
         $meta_changed = $needs_meta_update;
 
-        foreach ($stored as $key => $value) {
-            if (!is_string($key) || !preg_match('/^[A-Fa-f0-9]{32,128}$/', $key)) {
+        foreach ( $stored as $key => $value ) {
+            if ( ! is_string( $key ) || ! preg_match( '/^[A-Fa-f0-9]{32,128}$/', $key ) ) {
                 continue;
             }
 
-            if (!is_numeric($value)) {
+            if ( ! is_numeric( $value ) ) {
                 continue;
             }
 
-            $normalized[$key] = (float) $value;
+            $normalized[ $key ] = (float) $value;
 
-            if (!isset($meta_data['timestamps'][$key]) || !is_numeric($meta_data['timestamps'][$key])) {
-                $meta_data['timestamps'][$key] = $now;
+            if ( ! isset( $meta_data['timestamps'][ $key ] ) || ! is_numeric( $meta_data['timestamps'][ $key ] ) ) {
+                $meta_data['timestamps'][ $key ] = $now;
+                $meta_changed                    = true;
+            }
+        }
+
+        foreach ( array_keys( $meta_data['timestamps'] ) as $hash ) {
+            if ( ! isset( $normalized[ $hash ] ) ) {
+                unset( $meta_data['timestamps'][ $hash ] );
                 $meta_changed = true;
             }
         }
 
-        foreach (array_keys($meta_data['timestamps']) as $hash) {
-            if (!isset($normalized[$hash])) {
-                unset($meta_data['timestamps'][$hash]);
-                $meta_changed = true;
-            }
-        }
-
-        if ($meta !== null) {
+        if ( $meta !== null ) {
             $meta = $meta_data;
         }
 
-        if ($needs_meta_update) {
-            self::ensure_ip_log_for_legacy_votes($post_id, $normalized);
+        if ( $needs_meta_update ) {
+            self::ensure_ip_log_for_legacy_votes( $post_id, $normalized );
         }
 
-        if ($meta_changed) {
-            self::write_user_rating_store($post_id, $normalized, $meta_data, false);
+        if ( $meta_changed ) {
+            self::write_user_rating_store( $post_id, $normalized, $meta_data, false );
 
-            if ($meta !== null) {
+            if ( $meta !== null ) {
                 $meta = $meta_data;
             }
         }
@@ -809,287 +827,287 @@ class JLG_Frontend {
         return $normalized;
     }
 
-    private static function store_post_user_rating_tokens($post_id, array $ratings, array $meta = []) {
-        if (!isset($meta['version']) || (int) $meta['version'] < 2) {
+    private static function store_post_user_rating_tokens( $post_id, array $ratings, array $meta = array() ) {
+        if ( ! isset( $meta['version'] ) || (int) $meta['version'] < 2 ) {
             $meta['version'] = 2;
         }
 
-        if (!isset($meta['timestamps']) || !is_array($meta['timestamps'])) {
-            $meta['timestamps'] = [];
+        if ( ! isset( $meta['timestamps'] ) || ! is_array( $meta['timestamps'] ) ) {
+            $meta['timestamps'] = array();
         }
 
-        self::write_user_rating_store($post_id, $ratings, $meta, true);
+        self::write_user_rating_store( $post_id, $ratings, $meta, true );
     }
 
-    private static function write_user_rating_store($post_id, array $ratings, array $meta, $run_prune = true) {
-        if ($run_prune) {
-            self::prune_user_rating_store($post_id, $ratings, $meta);
+    private static function write_user_rating_store( $post_id, array $ratings, array $meta, $run_prune = true ) {
+        if ( $run_prune ) {
+            self::prune_user_rating_store( $post_id, $ratings, $meta );
         }
 
-        $data = $ratings;
+        $data           = $ratings;
         $data['__meta'] = $meta;
 
-        update_post_meta($post_id, '_jlg_user_ratings', $data);
+        update_post_meta( $post_id, '_jlg_user_ratings', $data );
     }
 
-    private static function prune_user_rating_store($post_id, array &$ratings, array &$meta) {
-        $timestamps = isset($meta['timestamps']) && is_array($meta['timestamps']) ? $meta['timestamps'] : [];
-        $now = current_time('timestamp');
-        $retention = self::get_user_rating_retention_window();
-        $removed_tokens = [];
+    private static function prune_user_rating_store( $post_id, array &$ratings, array &$meta ) {
+        $timestamps     = isset( $meta['timestamps'] ) && is_array( $meta['timestamps'] ) ? $meta['timestamps'] : array();
+        $now            = current_time( 'timestamp' );
+        $retention      = self::get_user_rating_retention_window();
+        $removed_tokens = array();
 
-        foreach ($timestamps as $hash => $timestamp) {
-            if (!isset($ratings[$hash])) {
-                unset($timestamps[$hash]);
+        foreach ( $timestamps as $hash => $timestamp ) {
+            if ( ! isset( $ratings[ $hash ] ) ) {
+                unset( $timestamps[ $hash ] );
                 continue;
             }
 
-            $timestamp = intval($timestamp);
+            $timestamp = intval( $timestamp );
 
-            if ($timestamp <= 0) {
-                $timestamps[$hash] = $now;
+            if ( $timestamp <= 0 ) {
+                $timestamps[ $hash ] = $now;
                 continue;
             }
 
-            if ($retention > 0 && ($now - $timestamp) > $retention) {
-                unset($ratings[$hash], $timestamps[$hash]);
+            if ( $retention > 0 && ( $now - $timestamp ) > $retention ) {
+                unset( $ratings[ $hash ], $timestamps[ $hash ] );
                 $removed_tokens[] = $hash;
             }
         }
 
-        $max_entries = intval(apply_filters('jlg_user_rating_max_entries', self::USER_RATING_MAX_STORED_VOTES, $post_id));
+        $max_entries = intval( apply_filters( 'jlg_user_rating_max_entries', self::USER_RATING_MAX_STORED_VOTES, $post_id ) );
 
-        if ($max_entries > 0 && count($ratings) > $max_entries) {
-            asort($timestamps);
+        if ( $max_entries > 0 && count( $ratings ) > $max_entries ) {
+            asort( $timestamps );
 
-            foreach ($timestamps as $hash => $timestamp) {
-                if (!isset($ratings[$hash])) {
+            foreach ( $timestamps as $hash => $timestamp ) {
+                if ( ! isset( $ratings[ $hash ] ) ) {
                     continue;
                 }
 
-                if (count($ratings) <= $max_entries) {
+                if ( count( $ratings ) <= $max_entries ) {
                     break;
                 }
 
-                unset($ratings[$hash], $timestamps[$hash]);
+                unset( $ratings[ $hash ], $timestamps[ $hash ] );
                 $removed_tokens[] = $hash;
             }
         }
 
         $meta['timestamps'] = $timestamps;
 
-        if (!empty($removed_tokens)) {
-            self::prune_user_rating_ip_tokens($post_id, $removed_tokens, true);
+        if ( ! empty( $removed_tokens ) ) {
+            self::prune_user_rating_ip_tokens( $post_id, $removed_tokens, true );
         } else {
-            self::prune_user_rating_ip_tokens($post_id, [], true);
+            self::prune_user_rating_ip_tokens( $post_id, array(), true );
         }
     }
 
     private static function get_user_rating_retention_window() {
-        $days = intval(apply_filters('jlg_user_rating_retention_days', self::USER_RATING_RETENTION_DAYS));
+        $days = intval( apply_filters( 'jlg_user_rating_retention_days', self::USER_RATING_RETENTION_DAYS ) );
 
-        if ($days <= 0) {
+        if ( $days <= 0 ) {
             return 0;
         }
 
-        $day_in_seconds = defined('DAY_IN_SECONDS') ? DAY_IN_SECONDS : 86400;
+        $day_in_seconds = defined( 'DAY_IN_SECONDS' ) ? DAY_IN_SECONDS : 86400;
 
         return $days * $day_in_seconds;
     }
 
-    private static function ensure_ip_log_for_legacy_votes($post_id, array $ratings) {
-        if (empty($ratings)) {
+    private static function ensure_ip_log_for_legacy_votes( $post_id, array $ratings ) {
+        if ( empty( $ratings ) ) {
             return;
         }
 
         $ip_meta_key = '_jlg_user_rating_ips';
-        $ip_log = get_post_meta($post_id, $ip_meta_key, true);
+        $ip_log      = get_post_meta( $post_id, $ip_meta_key, true );
 
-        if (!is_array($ip_log)) {
-            $ip_log = [];
+        if ( ! is_array( $ip_log ) ) {
+            $ip_log = array();
         }
 
-        $updated = false;
-        $timestamp = current_time('timestamp');
+        $updated   = false;
+        $timestamp = current_time( 'timestamp' );
 
-        foreach ($ratings as $hash => $value) {
-            if (!isset($ip_log[$hash]) || !is_array($ip_log[$hash])) {
-                $ip_log[$hash] = [
+        foreach ( $ratings as $hash => $value ) {
+            if ( ! isset( $ip_log[ $hash ] ) || ! is_array( $ip_log[ $hash ] ) ) {
+                $ip_log[ $hash ] = array(
                     'rating'    => (float) $value,
                     'votes'     => 1,
                     'last_vote' => $timestamp,
                     'legacy'    => true,
-                ];
-                $updated = true;
+                );
+                $updated         = true;
                 continue;
             }
 
-            $existing = $ip_log[$hash];
+            $existing = $ip_log[ $hash ];
 
-            if (!isset($existing['rating'])) {
+            if ( ! isset( $existing['rating'] ) ) {
                 $existing['rating'] = (float) $value;
             }
 
-            if (!isset($existing['votes'])) {
+            if ( ! isset( $existing['votes'] ) ) {
                 $existing['votes'] = 1;
             }
 
-            $existing['legacy'] = true;
-            $existing['last_vote'] = isset($existing['last_vote']) ? $existing['last_vote'] : $timestamp;
+            $existing['legacy']    = true;
+            $existing['last_vote'] = isset( $existing['last_vote'] ) ? $existing['last_vote'] : $timestamp;
 
-            $ip_log[$hash] = $existing;
-            $updated = true;
+            $ip_log[ $hash ] = $existing;
+            $updated         = true;
         }
 
-        if ($updated) {
-            update_post_meta($post_id, $ip_meta_key, $ip_log);
+        if ( $updated ) {
+            update_post_meta( $post_id, $ip_meta_key, $ip_log );
         }
     }
 
-    private static function update_user_rating_ip_log($post_id, $ip_hash, $token_hash, $rating) {
+    private static function update_user_rating_ip_log( $post_id, $ip_hash, $token_hash, $rating ) {
         $ip_meta_key = '_jlg_user_rating_ips';
-        $ip_log = get_post_meta($post_id, $ip_meta_key, true);
+        $ip_log      = get_post_meta( $post_id, $ip_meta_key, true );
 
-        if (!is_array($ip_log)) {
-            $ip_log = [];
+        if ( ! is_array( $ip_log ) ) {
+            $ip_log = array();
         }
 
-        $timestamp = current_time('timestamp');
-        $entry = isset($ip_log[$ip_hash]) && is_array($ip_log[$ip_hash]) ? $ip_log[$ip_hash] : [];
+        $timestamp = current_time( 'timestamp' );
+        $entry     = isset( $ip_log[ $ip_hash ] ) && is_array( $ip_log[ $ip_hash ] ) ? $ip_log[ $ip_hash ] : array();
 
-        $entry['rating'] = (float) $rating;
-        $entry['token'] = $token_hash;
+        $entry['rating']    = (float) $rating;
+        $entry['token']     = $token_hash;
         $entry['last_vote'] = $timestamp;
-        $entry['votes'] = isset($entry['votes']) ? (int) $entry['votes'] + 1 : 1;
+        $entry['votes']     = isset( $entry['votes'] ) ? (int) $entry['votes'] + 1 : 1;
 
-        unset($entry['legacy']);
+        unset( $entry['legacy'] );
 
-        $ip_log[$ip_hash] = $entry;
+        $ip_log[ $ip_hash ] = $entry;
 
-        update_post_meta($post_id, $ip_meta_key, $ip_log);
-        self::prune_user_rating_ip_tokens($post_id, [], true);
+        update_post_meta( $post_id, $ip_meta_key, $ip_log );
+        self::prune_user_rating_ip_tokens( $post_id, array(), true );
     }
 
-    private static function prune_user_rating_ip_tokens($post_id, array $token_hashes = [], $check_retention = true) {
+    private static function prune_user_rating_ip_tokens( $post_id, array $token_hashes = array(), $check_retention = true ) {
         $ip_meta_key = '_jlg_user_rating_ips';
-        $ip_log = get_post_meta($post_id, $ip_meta_key, true);
+        $ip_log      = get_post_meta( $post_id, $ip_meta_key, true );
 
-        if (!is_array($ip_log) || empty($ip_log)) {
+        if ( ! is_array( $ip_log ) || empty( $ip_log ) ) {
             return;
         }
 
-        $now = current_time('timestamp');
+        $now       = current_time( 'timestamp' );
         $retention = $check_retention ? self::get_user_rating_retention_window() : 0;
-        $threshold = ($retention > 0) ? $now - $retention : null;
-        $tokens = [];
+        $threshold = ( $retention > 0 ) ? $now - $retention : null;
+        $tokens    = array();
 
-        foreach ($token_hashes as $hash) {
-            $tokens[$hash] = true;
+        foreach ( $token_hashes as $hash ) {
+            $tokens[ $hash ] = true;
         }
 
         $updated = false;
 
-        foreach ($ip_log as $ip => $entry) {
-            if (!is_array($entry)) {
-                unset($ip_log[$ip]);
+        foreach ( $ip_log as $ip => $entry ) {
+            if ( ! is_array( $entry ) ) {
+                unset( $ip_log[ $ip ] );
                 $updated = true;
                 continue;
             }
 
-            if (!empty($tokens) && isset($entry['token']) && isset($tokens[$entry['token']])) {
-                unset($ip_log[$ip]);
+            if ( ! empty( $tokens ) && isset( $entry['token'] ) && isset( $tokens[ $entry['token'] ] ) ) {
+                unset( $ip_log[ $ip ] );
                 $updated = true;
                 continue;
             }
 
-            if ($threshold !== null && isset($entry['last_vote'])) {
-                $last_vote = intval($entry['last_vote']);
+            if ( $threshold !== null && isset( $entry['last_vote'] ) ) {
+                $last_vote = intval( $entry['last_vote'] );
 
-                if ($last_vote > 0 && $last_vote < $threshold) {
-                    unset($ip_log[$ip]);
+                if ( $last_vote > 0 && $last_vote < $threshold ) {
+                    unset( $ip_log[ $ip ] );
                     $updated = true;
                 }
             }
         }
 
-        if ($updated) {
-            update_post_meta($post_id, $ip_meta_key, $ip_log);
+        if ( $updated ) {
+            update_post_meta( $post_id, $ip_meta_key, $ip_log );
         }
     }
 
-    private static function calculate_user_rating_stats(array $ratings) {
-        $values = [];
+    private static function calculate_user_rating_stats( array $ratings ) {
+        $values = array();
 
-        foreach ($ratings as $value) {
-            if (is_numeric($value)) {
+        foreach ( $ratings as $value ) {
+            if ( is_numeric( $value ) ) {
                 $values[] = (float) $value;
             }
         }
 
-        $count = count($values);
+        $count = count( $values );
 
-        if ($count === 0) {
-            return [0.0, 0];
+        if ( $count === 0 ) {
+            return array( 0.0, 0 );
         }
 
-        $average = round(array_sum($values) / $count, 2);
+        $average = round( array_sum( $values ) / $count, 2 );
 
-        return [$average, $count];
+        return array( $average, $count );
     }
 
-    public static function get_user_vote_for_post($post_id, $token = '') {
-        $post_id = intval($post_id);
+    public static function get_user_vote_for_post( $post_id, $token = '' ) {
+        $post_id = intval( $post_id );
 
-        if ($post_id <= 0) {
-            return [false, 0];
+        if ( $post_id <= 0 ) {
+            return array( false, 0 );
         }
 
-        if ($token === '') {
+        if ( $token === '' ) {
             $token = self::get_user_rating_token_from_cookie();
         } else {
-            $token = self::normalize_user_rating_token($token);
+            $token = self::normalize_user_rating_token( $token );
         }
 
-        if ($token === '') {
-            return [false, 0];
+        if ( $token === '' ) {
+            return array( false, 0 );
         }
 
-        $token_hash = self::hash_user_rating_token($token);
-        $ratings = self::get_post_user_rating_tokens($post_id);
+        $token_hash = self::hash_user_rating_token( $token );
+        $ratings    = self::get_post_user_rating_tokens( $post_id );
 
-        if (isset($ratings[$token_hash])) {
-            return [true, $ratings[$token_hash]];
+        if ( isset( $ratings[ $token_hash ] ) ) {
+            return array( true, $ratings[ $token_hash ] );
         }
 
-        return [false, 0];
+        return array( false, 0 );
     }
 
     /**
      * Détermine si un article est éligible aux votes des lecteurs.
      */
-    private function post_allows_user_rating($post, $options = null) {
-        if (!($post instanceof WP_Post)) {
+    private function post_allows_user_rating( $post, $options = null ) {
+        if ( ! ( $post instanceof WP_Post ) ) {
             return false;
         }
 
         $allowed_post_types = JLG_Helpers::get_allowed_post_types();
 
-        if (!in_array($post->post_type, $allowed_post_types, true)) {
+        if ( ! in_array( $post->post_type, $allowed_post_types, true ) ) {
             return false;
         }
 
-        if (!is_array($options)) {
+        if ( ! is_array( $options ) ) {
             $options = JLG_Helpers::get_plugin_options();
         }
 
-        if (empty($options['user_rating_enabled'])) {
+        if ( empty( $options['user_rating_enabled'] ) ) {
             return false;
         }
 
         $content = $post->post_content ?? '';
 
-        foreach (['notation_utilisateurs_jlg', 'jlg_bloc_complet', 'bloc_notation_complet'] as $shortcode) {
-            if (has_shortcode($content, $shortcode) || self::has_rendered_shortcode($shortcode)) {
+        foreach ( array( 'notation_utilisateurs_jlg', 'jlg_bloc_complet', 'bloc_notation_complet' ) as $shortcode ) {
+            if ( has_shortcode( $content, $shortcode ) || self::has_rendered_shortcode( $shortcode ) ) {
                 return true;
             }
         }
@@ -1098,150 +1116,154 @@ class JLG_Frontend {
     }
 
     public function handle_summary_sort() {
-        if (!check_ajax_referer('jlg_summary_sort', 'nonce', false)) {
-            wp_send_json_error(['message' => esc_html__('La vérification de sécurité a échoué.', 'notation-jlg')], 403);
+        if ( ! check_ajax_referer( 'jlg_summary_sort', 'nonce', false ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'La vérification de sécurité a échoué.', 'notation-jlg' ) ), 403 );
         }
 
-        if (!class_exists('JLG_Shortcode_Summary_Display')) {
-            wp_send_json_error(['message' => esc_html__('Le shortcode requis est indisponible.', 'notation-jlg')], 500);
+        if ( ! class_exists( 'JLG_Shortcode_Summary_Display' ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Le shortcode requis est indisponible.', 'notation-jlg' ) ), 500 );
         }
 
-        $default_atts = JLG_Shortcode_Summary_Display::get_default_atts();
-        $default_posts_per_page = isset($default_atts['posts_per_page']) ? intval($default_atts['posts_per_page']) : 12;
-        if ($default_posts_per_page < 1) {
+        $default_atts           = JLG_Shortcode_Summary_Display::get_default_atts();
+        $default_posts_per_page = isset( $default_atts['posts_per_page'] ) ? intval( $default_atts['posts_per_page'] ) : 12;
+        if ( $default_posts_per_page < 1 ) {
             $default_posts_per_page = 1;
         }
 
-        $posts_per_page_input = isset($_POST['posts_per_page']) ? wp_unslash($_POST['posts_per_page']) : null;
-        $posts_per_page = null;
+        $posts_per_page_input = isset( $_POST['posts_per_page'] ) ? wp_unslash( $_POST['posts_per_page'] ) : null;
+        $posts_per_page       = null;
 
-        if ($posts_per_page_input !== null && !is_array($posts_per_page_input)) {
-            $posts_per_page = intval($posts_per_page_input);
+        if ( $posts_per_page_input !== null && ! is_array( $posts_per_page_input ) ) {
+            $posts_per_page = intval( $posts_per_page_input );
         }
 
-        if ($posts_per_page === null || $posts_per_page < 1) {
+        if ( $posts_per_page === null || $posts_per_page < 1 ) {
             $posts_per_page = $default_posts_per_page;
         }
 
-        $posts_per_page = max(1, min($posts_per_page, 50));
+        $posts_per_page = max( 1, min( $posts_per_page, 50 ) );
 
-        $atts = [
+        $atts = array(
             'posts_per_page' => $posts_per_page,
-            'layout'         => isset($_POST['layout']) ? sanitize_text_field(wp_unslash($_POST['layout'])) : 'table',
-            'categorie'      => isset($_POST['categorie']) ? sanitize_text_field(wp_unslash($_POST['categorie'])) : '',
-            'colonnes'       => isset($_POST['colonnes']) ? sanitize_text_field(wp_unslash($_POST['colonnes'])) : 'titre,date,note',
-            'id'             => isset($_POST['table_id']) ? sanitize_html_class(wp_unslash($_POST['table_id'])) : 'jlg-table-' . uniqid(),
+            'layout'         => isset( $_POST['layout'] ) ? sanitize_text_field( wp_unslash( $_POST['layout'] ) ) : 'table',
+            'categorie'      => isset( $_POST['categorie'] ) ? sanitize_text_field( wp_unslash( $_POST['categorie'] ) ) : '',
+            'colonnes'       => isset( $_POST['colonnes'] ) ? sanitize_text_field( wp_unslash( $_POST['colonnes'] ) ) : 'titre,date,note',
+            'id'             => isset( $_POST['table_id'] ) ? sanitize_html_class( wp_unslash( $_POST['table_id'] ) ) : 'jlg-table-' . uniqid(),
             'letter_filter'  => '',
             'genre_filter'   => '',
-        ];
+        );
 
-        $raw_request = isset($_POST) ? wp_unslash($_POST) : [];
-        if (!is_array($raw_request)) {
-            $raw_request = [];
+        $raw_request = isset( $_POST ) ? wp_unslash( $_POST ) : array();
+        if ( ! is_array( $raw_request ) ) {
+            $raw_request = array();
         }
 
-        $request_prefix = sanitize_title($atts['id']);
-        $letter_keys = [];
-        $genre_keys = [];
+        $request_prefix = sanitize_title( $atts['id'] );
+        $letter_keys    = array();
+        $genre_keys     = array();
 
-        if ($request_prefix !== '') {
+        if ( $request_prefix !== '' ) {
             $letter_keys[] = 'letter_filter__' . $request_prefix;
-            $genre_keys[] = 'genre_filter__' . $request_prefix;
+            $genre_keys[]  = 'genre_filter__' . $request_prefix;
         }
 
         $letter_keys[] = 'letter_filter';
-        $genre_keys[] = 'genre_filter';
+        $genre_keys[]  = 'genre_filter';
 
-        foreach ($letter_keys as $key) {
-            if (isset($raw_request[$key]) && !is_array($raw_request[$key])) {
-                $atts['letter_filter'] = JLG_Shortcode_Summary_Display::normalize_letter_filter($raw_request[$key]);
+        foreach ( $letter_keys as $key ) {
+            if ( isset( $raw_request[ $key ] ) && ! is_array( $raw_request[ $key ] ) ) {
+                $atts['letter_filter'] = JLG_Shortcode_Summary_Display::normalize_letter_filter( $raw_request[ $key ] );
                 break;
             }
         }
 
-        foreach ($genre_keys as $key) {
-            if (isset($raw_request[$key]) && !is_array($raw_request[$key])) {
-                $atts['genre_filter'] = sanitize_text_field($raw_request[$key]);
+        foreach ( $genre_keys as $key ) {
+            if ( isset( $raw_request[ $key ] ) && ! is_array( $raw_request[ $key ] ) ) {
+                $atts['genre_filter'] = sanitize_text_field( $raw_request[ $key ] );
                 break;
             }
         }
 
-        $current_url = isset($_POST['current_url']) ? wp_unslash($_POST['current_url']) : '';
-        $base_url = $this->sanitize_internal_url($current_url);
+        $current_url = isset( $_POST['current_url'] ) ? wp_unslash( $_POST['current_url'] ) : '';
+        $base_url    = $this->sanitize_internal_url( $current_url );
 
-        if ($base_url === '') {
-            $base_url = $this->sanitize_internal_url(wp_get_referer());
+        if ( $base_url === '' ) {
+            $base_url = $this->sanitize_internal_url( wp_get_referer() );
         }
 
-        $context = JLG_Shortcode_Summary_Display::get_render_context($atts, $raw_request, false);
+        $context             = JLG_Shortcode_Summary_Display::get_render_context( $atts, $raw_request, false );
         $context['base_url'] = $base_url;
 
-        $state = [
-            'orderby'    => $context['orderby'] ?? 'date',
-            'order'      => $context['order'] ?? 'DESC',
-            'paged'      => $context['paged'] ?? 1,
-            'cat_filter' => $context['cat_filter'] ?? 0,
+        $state = array(
+            'orderby'       => $context['orderby'] ?? 'date',
+            'order'         => $context['order'] ?? 'DESC',
+            'paged'         => $context['paged'] ?? 1,
+            'cat_filter'    => $context['cat_filter'] ?? 0,
             'letter_filter' => $context['letter_filter'] ?? '',
             'genre_filter'  => $context['genre_filter'] ?? '',
-            'total_pages' => 0,
-        ];
+            'total_pages'   => 0,
+        );
 
-        if (!empty($context['error']) && !empty($context['message'])) {
-            wp_send_json_success([
-                'html'  => $context['message'],
-                'state' => $state,
-            ]);
+        if ( ! empty( $context['error'] ) && ! empty( $context['message'] ) ) {
+            wp_send_json_success(
+                array(
+					'html'  => $context['message'],
+					'state' => $state,
+                )
+            );
         }
 
-        $html = JLG_Frontend::get_template_html('summary-table-fragment', $context);
+        $html = self::get_template_html( 'summary-table-fragment', $context );
 
-        if (isset($context['query']) && $context['query'] instanceof WP_Query) {
-            $state['total_pages'] = intval($context['query']->max_num_pages);
+        if ( isset( $context['query'] ) && $context['query'] instanceof WP_Query ) {
+            $state['total_pages'] = intval( $context['query']->max_num_pages );
         }
 
-        wp_send_json_success([
-            'html'  => $html,
-            'state' => $state,
-        ]);
+        wp_send_json_success(
+            array(
+				'html'  => $html,
+				'state' => $state,
+            )
+        );
     }
 
     public function handle_game_explorer_sort() {
-        if (!check_ajax_referer('jlg_game_explorer', 'nonce', false)) {
-            wp_send_json_error(['message' => esc_html__('La vérification de sécurité a échoué.', 'notation-jlg')], 403);
+        if ( ! check_ajax_referer( 'jlg_game_explorer', 'nonce', false ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'La vérification de sécurité a échoué.', 'notation-jlg' ) ), 403 );
         }
 
-        if (!class_exists('JLG_Shortcode_Game_Explorer')) {
-            wp_send_json_error(['message' => esc_html__('Le shortcode requis est indisponible.', 'notation-jlg')], 500);
+        if ( ! class_exists( 'JLG_Shortcode_Game_Explorer' ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'Le shortcode requis est indisponible.', 'notation-jlg' ) ), 500 );
         }
 
         $default_atts = JLG_Shortcode_Game_Explorer::get_default_atts();
 
-        $atts = [
-            'id'              => isset($_POST['container_id']) ? sanitize_html_class(wp_unslash($_POST['container_id'])) : ($default_atts['id'] ?? 'jlg-game-explorer-' . uniqid()),
-            'posts_per_page'  => isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : ($default_atts['posts_per_page'] ?? 12),
-            'columns'         => isset($_POST['columns']) ? intval(wp_unslash($_POST['columns'])) : ($default_atts['columns'] ?? 3),
-            'filters'         => isset($_POST['filters']) ? sanitize_text_field(wp_unslash($_POST['filters'])) : ($default_atts['filters'] ?? ''),
-            'categorie'       => isset($_POST['categorie']) ? sanitize_text_field(wp_unslash($_POST['categorie'])) : ($default_atts['categorie'] ?? ''),
-            'plateforme'      => isset($_POST['plateforme']) ? sanitize_text_field(wp_unslash($_POST['plateforme'])) : ($default_atts['plateforme'] ?? ''),
-            'lettre'          => isset($_POST['lettre']) ? sanitize_text_field(wp_unslash($_POST['lettre'])) : ($default_atts['lettre'] ?? ''),
-        ];
+        $atts = array(
+            'id'             => isset( $_POST['container_id'] ) ? sanitize_html_class( wp_unslash( $_POST['container_id'] ) ) : ( $default_atts['id'] ?? 'jlg-game-explorer-' . uniqid() ),
+            'posts_per_page' => isset( $_POST['posts_per_page'] ) ? intval( wp_unslash( $_POST['posts_per_page'] ) ) : ( $default_atts['posts_per_page'] ?? 12 ),
+            'columns'        => isset( $_POST['columns'] ) ? intval( wp_unslash( $_POST['columns'] ) ) : ( $default_atts['columns'] ?? 3 ),
+            'filters'        => isset( $_POST['filters'] ) ? sanitize_text_field( wp_unslash( $_POST['filters'] ) ) : ( $default_atts['filters'] ?? '' ),
+            'categorie'      => isset( $_POST['categorie'] ) ? sanitize_text_field( wp_unslash( $_POST['categorie'] ) ) : ( $default_atts['categorie'] ?? '' ),
+            'plateforme'     => isset( $_POST['plateforme'] ) ? sanitize_text_field( wp_unslash( $_POST['plateforme'] ) ) : ( $default_atts['plateforme'] ?? '' ),
+            'lettre'         => isset( $_POST['lettre'] ) ? sanitize_text_field( wp_unslash( $_POST['lettre'] ) ) : ( $default_atts['lettre'] ?? '' ),
+        );
 
-        if ($atts['posts_per_page'] < 1) {
+        if ( $atts['posts_per_page'] < 1 ) {
             $atts['posts_per_page'] = $default_atts['posts_per_page'] ?? 12;
         }
 
-        if ($atts['columns'] < 1) {
+        if ( $atts['columns'] < 1 ) {
             $atts['columns'] = $default_atts['columns'] ?? 3;
         }
 
-        $raw_request = isset($_POST) ? wp_unslash($_POST) : [];
-        if (!is_array($raw_request)) {
-            $raw_request = [];
+        $raw_request = isset( $_POST ) ? wp_unslash( $_POST ) : array();
+        if ( ! is_array( $raw_request ) ) {
+            $raw_request = array();
         }
 
-        $context = JLG_Shortcode_Game_Explorer::get_render_context($atts, $raw_request);
+        $context = JLG_Shortcode_Game_Explorer::get_render_context( $atts, $raw_request );
 
-        $state = [
+        $state = array(
             'orderby'      => $context['sort_key'] ?? 'date',
             'order'        => $context['sort_order'] ?? 'DESC',
             'letter'       => $context['current_filters']['letter'] ?? '',
@@ -1252,119 +1274,123 @@ class JLG_Frontend {
             'paged'        => $context['pagination']['current'] ?? 1,
             'total_pages'  => $context['pagination']['total'] ?? 0,
             'total_items'  => $context['total_items'] ?? 0,
-        ];
+        );
 
-        if (!empty($context['error']) && !empty($context['message'])) {
-            wp_send_json_success([
-                'html'  => $context['message'],
-                'state' => $state,
-            ]);
+        if ( ! empty( $context['error'] ) && ! empty( $context['message'] ) ) {
+            wp_send_json_success(
+                array(
+					'html'  => $context['message'],
+					'state' => $state,
+                )
+            );
         }
 
-        $html = JLG_Frontend::get_template_html('game-explorer-fragment', $context);
+        $html = self::get_template_html( 'game-explorer-fragment', $context );
 
-        wp_send_json_success([
-            'html'  => $html,
-            'state' => $state,
-        ]);
+        wp_send_json_success(
+            array(
+				'html'  => $html,
+				'state' => $state,
+            )
+        );
     }
 
-    private function sanitize_internal_url($url) {
-        $canonical_home = home_url('/');
+    private function sanitize_internal_url( $url ) {
+        $canonical_home = home_url( '/' );
 
-        if (!is_string($url)) {
+        if ( ! is_string( $url ) ) {
             return $canonical_home;
         }
 
-        $url = trim($url);
-        if ($url === '') {
+        $url = trim( $url );
+        if ( $url === '' ) {
             return $canonical_home;
         }
 
-        $sanitized_url = esc_url_raw($url);
-        if ($sanitized_url === '') {
+        $sanitized_url = esc_url_raw( $url );
+        if ( $sanitized_url === '' ) {
             return $canonical_home;
         }
 
-        $parsed_url = wp_parse_url($sanitized_url);
-        if ($parsed_url === false) {
+        $parsed_url = wp_parse_url( $sanitized_url );
+        if ( $parsed_url === false ) {
             return $canonical_home;
         }
 
-        if (!empty($parsed_url['scheme']) && !in_array($parsed_url['scheme'], ['http', 'https'], true)) {
+        if ( ! empty( $parsed_url['scheme'] ) && ! in_array( $parsed_url['scheme'], array( 'http', 'https' ), true ) ) {
             return $canonical_home;
         }
 
-        $site_url = wp_parse_url($canonical_home);
-        $site_host = is_array($site_url) && isset($site_url['host']) ? strtolower($site_url['host']) : '';
-        $site_scheme = is_array($site_url) && isset($site_url['scheme']) ? $site_url['scheme'] : '';
-        $site_port = is_array($site_url) && isset($site_url['port']) ? intval($site_url['port']) : null;
+        $site_url    = wp_parse_url( $canonical_home );
+        $site_host   = is_array( $site_url ) && isset( $site_url['host'] ) ? strtolower( $site_url['host'] ) : '';
+        $site_scheme = is_array( $site_url ) && isset( $site_url['scheme'] ) ? $site_url['scheme'] : '';
+        $site_port   = is_array( $site_url ) && isset( $site_url['port'] ) ? intval( $site_url['port'] ) : null;
 
-        $normalize_host = static function ($host) {
-            $host = strtolower((string) $host);
-            if ($host === '') {
+        $normalize_host = static function ( $host ) {
+            $host = strtolower( (string) $host );
+            if ( $host === '' ) {
                 return '';
             }
 
-            return preg_replace('/^www\./', '', $host);
+            return preg_replace( '/^www\./', '', $host );
         };
 
-        $target_host = isset($parsed_url['host']) ? strtolower($parsed_url['host']) : '';
+        $target_host = isset( $parsed_url['host'] ) ? strtolower( $parsed_url['host'] ) : '';
 
-        if ($target_host === '') {
+        if ( $target_host === '' ) {
             $target_host = $site_host;
         }
 
-        $normalized_site_host = $normalize_host($site_host);
-        $normalized_target_host = $normalize_host($target_host);
+        $normalized_site_host   = $normalize_host( $site_host );
+        $normalized_target_host = $normalize_host( $target_host );
 
-        if ($normalized_site_host === '' || $normalized_target_host === '') {
+        if ( $normalized_site_host === '' || $normalized_target_host === '' ) {
             return $canonical_home;
         }
 
-        if ($normalized_target_host !== $normalized_site_host) {
+        if ( $normalized_target_host !== $normalized_site_host ) {
             return $canonical_home;
         }
 
-        $scheme = $site_scheme !== '' ? $site_scheme : ($parsed_url['scheme'] ?? '');
-        if ($scheme === '' && isset($parsed_url['scheme'])) {
+        $scheme = $site_scheme !== '' ? $site_scheme : ( $parsed_url['scheme'] ?? '' );
+        if ( $scheme === '' && isset( $parsed_url['scheme'] ) ) {
             $scheme = $parsed_url['scheme'];
         }
 
         $path = $parsed_url['path'] ?? '';
-        if ($path === '') {
+        if ( $path === '' ) {
             $path = '/';
         } else {
-            $path = '/' . ltrim($path, '/');
-            $path = preg_replace('#/+#', '/', $path);
+            $path = '/' . ltrim( $path, '/' );
+            $path = preg_replace( '#/+#', '/', $path );
         }
 
         $normalized_url = '';
 
-        if ($scheme !== '') {
+        if ( $scheme !== '' ) {
             $normalized_url .= $scheme . '://';
         }
 
         $normalized_url .= $site_host;
 
         $target_port = null;
-        if (isset($parsed_url['port'])) {
-            $target_port = intval($parsed_url['port']);
-        } elseif ($site_port !== null) {
+        if ( isset( $parsed_url['port'] ) ) {
+            $target_port = intval( $parsed_url['port'] );
+        } elseif ( $site_port !== null ) {
             $target_port = $site_port;
         }
 
-        if ($target_port !== null) {
+        if ( $target_port !== null ) {
             $normalized_url .= ':' . $target_port;
         }
 
         $normalized_url .= $path;
 
-        if (!empty($parsed_url['query'])) {
+        if ( ! empty( $parsed_url['query'] ) ) {
             $normalized_url .= '?' . $parsed_url['query'];
         }
 
-        if (!empty($parsed_url['fragment'])) {
+        if ( ! empty( $parsed_url['fragment'] ) ) {
             $normalized_url .= '#' . $parsed_url['fragment'];
         }
 
@@ -1379,98 +1405,98 @@ class JLG_Frontend {
 
         $allowed_post_types = array_filter(
             JLG_Helpers::get_allowed_post_types(),
-            static function ($post_type) {
-                if (!is_string($post_type) || $post_type === '') {
+            static function ( $post_type ) {
+                if ( ! is_string( $post_type ) || $post_type === '' ) {
                     return false;
                 }
 
-                if (function_exists('post_type_exists')) {
-                    return post_type_exists($post_type);
+                if ( function_exists( 'post_type_exists' ) ) {
+                    return post_type_exists( $post_type );
                 }
 
                 return true;
             }
         );
 
-        if (empty($allowed_post_types)) {
-            $allowed_post_types = ['post'];
+        if ( empty( $allowed_post_types ) ) {
+            $allowed_post_types = array( 'post' );
         }
 
-        if (empty($options['seo_schema_enabled']) || !is_singular($allowed_post_types)) {
+        if ( empty( $options['seo_schema_enabled'] ) || ! is_singular( $allowed_post_types ) ) {
             return;
         }
 
-        $post_id = get_the_ID();
-        $score_data = JLG_Helpers::get_resolved_average_score($post_id);
-        $average_score = is_array($score_data) ? ($score_data['value'] ?? null) : null;
+        $post_id       = get_the_ID();
+        $score_data    = JLG_Helpers::get_resolved_average_score( $post_id );
+        $average_score = is_array( $score_data ) ? ( $score_data['value'] ?? null ) : null;
 
-        if ($average_score === null) {
+        if ( $average_score === null ) {
             return;
         }
-        
+
         $review_rating_bounds = apply_filters(
             'jlg_review_rating_bounds',
-            [
+            array(
                 'min' => 0,
                 'max' => 10,
-            ],
+            ),
             $post_id
         );
 
-        $review_best_rating  = isset($review_rating_bounds['max']) ? floatval($review_rating_bounds['max']) : 10;
-        $review_worst_rating = isset($review_rating_bounds['min']) ? floatval($review_rating_bounds['min']) : 0;
+        $review_best_rating  = isset( $review_rating_bounds['max'] ) ? floatval( $review_rating_bounds['max'] ) : 10;
+        $review_worst_rating = isset( $review_rating_bounds['min'] ) ? floatval( $review_rating_bounds['min'] ) : 0;
 
-        $schema = [
-            '@context'      => 'https://schema.org',
-            '@type'         => 'Game',
-            'name'          => JLG_Helpers::get_game_title($post_id),
-            'review'        => [
+        $schema = array(
+            '@context' => 'https://schema.org',
+            '@type'    => 'Game',
+            'name'     => JLG_Helpers::get_game_title( $post_id ),
+            'review'   => array(
                 '@type'         => 'Review',
-                'reviewRating'  => [
+                'reviewRating'  => array(
                     '@type'       => 'Rating',
                     'ratingValue' => $average_score,
                     'bestRating'  => $review_best_rating,
                     'worstRating' => $review_worst_rating,
-                ],
-                'author'        => [
+                ),
+                'author'        => array(
                     '@type' => 'Person',
-                    'name'  => get_the_author_meta('display_name', get_post_field('post_author', $post_id))
-                ],
-                'datePublished' => get_the_date('c', $post_id),
-            ],
-        ];
-        
-        $user_rating_count = (int) get_post_meta($post_id, '_jlg_user_rating_count', true);
-        
-        $user_rating_enabled = isset($options['user_rating_enabled'])
-            ? $options['user_rating_enabled']
-            : (JLG_Helpers::get_default_settings()['user_rating_enabled'] ?? 0);
+                    'name'  => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
+                ),
+                'datePublished' => get_the_date( 'c', $post_id ),
+            ),
+        );
 
-        if (!empty($user_rating_enabled) && $user_rating_count > 0) {
-            $aggregate_rating_value = (float) get_post_meta($post_id, '_jlg_user_rating_avg', true);
+        $user_rating_count = (int) get_post_meta( $post_id, '_jlg_user_rating_count', true );
+
+        $user_rating_enabled = isset( $options['user_rating_enabled'] )
+            ? $options['user_rating_enabled']
+            : ( JLG_Helpers::get_default_settings()['user_rating_enabled'] ?? 0 );
+
+        if ( ! empty( $user_rating_enabled ) && $user_rating_count > 0 ) {
+            $aggregate_rating_value = (float) get_post_meta( $post_id, '_jlg_user_rating_avg', true );
 
             $user_rating_bounds = apply_filters(
                 'jlg_user_rating_bounds',
-                [
+                array(
                     'min' => 1,
                     'max' => 5,
-                ],
+                ),
                 $post_id
             );
 
-            $aggregate_best_rating  = isset($user_rating_bounds['max']) ? floatval($user_rating_bounds['max']) : 5.0;
-            $aggregate_worst_rating = isset($user_rating_bounds['min']) ? floatval($user_rating_bounds['min']) : 1.0;
+            $aggregate_best_rating  = isset( $user_rating_bounds['max'] ) ? floatval( $user_rating_bounds['max'] ) : 5.0;
+            $aggregate_worst_rating = isset( $user_rating_bounds['min'] ) ? floatval( $user_rating_bounds['min'] ) : 1.0;
 
-            $schema['aggregateRating'] = [
+            $schema['aggregateRating'] = array(
                 '@type'       => 'AggregateRating',
                 'ratingValue' => $aggregate_rating_value,
                 'ratingCount' => $user_rating_count,
                 'bestRating'  => $aggregate_best_rating,
                 'worstRating' => $aggregate_worst_rating,
-            ];
+            );
         }
-        
-        echo '<script type="application/ld+json">' . wp_json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . '</script>';
+
+        echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</script>';
     }
 
     /**
@@ -1484,18 +1510,18 @@ class JLG_Frontend {
      * @param array $args Les variables à passer au template.
      * @return string Le contenu HTML du template.
      */
-    public static function get_template_html($template_name, $args = []) {
+    public static function get_template_html( $template_name, $args = array() ) {
         // S'assurer que $args est bien un tableau
-        if (!is_array($args)) {
-            $args = [];
+        if ( ! is_array( $args ) ) {
+            $args = array();
         }
 
         // Construire le chemin du template du plugin et rechercher une éventuelle surcharge dans le thème.
         $plugin_template_path = JLG_NOTATION_PLUGIN_DIR . 'templates/' . $template_name . '.php';
 
-        $template_candidates = [
+        $template_candidates = array(
             'notation-jlg/' . $template_name . '.php',
-        ];
+        );
 
         /**
          * Permet d'ajouter ou de modifier les chemins de surcharge cherchés dans le thème.
@@ -1504,18 +1530,18 @@ class JLG_Frontend {
          * @param string   $template_name        Nom du template demandé par le plugin.
          * @param array    $args                 Arguments transmis au rendu du template.
          */
-        $template_candidates = apply_filters('jlg_frontend_template_candidates', $template_candidates, $template_name, $args);
+        $template_candidates = apply_filters( 'jlg_frontend_template_candidates', $template_candidates, $template_name, $args );
 
-        if (!is_array($template_candidates)) {
+        if ( ! is_array( $template_candidates ) ) {
             $template_candidates = (array) $template_candidates;
         }
 
-        $template_candidates = array_values(array_filter(array_map('strval', $template_candidates)));
+        $template_candidates = array_values( array_filter( array_map( 'strval', $template_candidates ) ) );
 
         $located_template = '';
 
-        if (!empty($template_candidates) && function_exists('locate_template')) {
-            $located_template = locate_template($template_candidates);
+        if ( ! empty( $template_candidates ) && function_exists( 'locate_template' ) ) {
+            $located_template = locate_template( $template_candidates );
         }
 
         $template_path = $located_template !== '' ? $located_template : $plugin_template_path;
@@ -1529,71 +1555,74 @@ class JLG_Frontend {
          * @param string $located_template     Chemin localisé via locate_template() si une surcharge a été trouvée.
          * @param string $plugin_template_path Chemin par défaut fourni par le plugin.
          */
-        $template_path = (string) apply_filters('jlg_frontend_template_path', $template_path, $template_name, $args, $located_template, $plugin_template_path);
+        $template_path = (string) apply_filters( 'jlg_frontend_template_path', $template_path, $template_name, $args, $located_template, $plugin_template_path );
 
         // Démarrer la capture de sortie
         ob_start();
 
         // Inclure le template s'il existe
-        if (file_exists($template_path)) {
+        if ( file_exists( $template_path ) ) {
             // Valeurs par défaut pour les variables utilisées par les templates existants.
-            $template_defaults = [
-                'options'            => [],
-                'average_score'      => null,
-                'scores'             => [],
-                'categories'         => [],
-                'pros_list'          => [],
-                'cons_list'          => [],
-                'titre'              => '',
-                'champs_a_afficher'  => [],
-                'tagline_fr'         => '',
-                'tagline_en'         => '',
-                'query'              => null,
-                'atts'               => [],
-                'block_classes'      => '',
-                'css_variables'      => '',
-                'score_layout'       => 'text',
-                'animations_enabled' => false,
-                'paged'              => 1,
-                'orderby'            => '',
-                'order'              => '',
-                'colonnes'           => [],
-                'colonnes_disponibles' => [],
-                'error_message'      => '',
-                'cat_filter'         => 0,
-                'table_id'           => '',
-                'widget_args'        => [],
-                'title'              => '',
-                'latest_reviews'     => null,
-                'post_id'            => null,
-                'avg_rating'         => null,
-                'count'              => 0,
-                'has_voted'          => false,
-                'user_vote'          => 0,
-                'games'              => [],
-                'letters'            => [],
-                'filters'            => [],
-                'current_filters'    => [],
-                'pagination'         => ['current' => 1, 'total' => 0],
-                'sort_options'       => [],
-                'sort_key'           => 'date',
-                'sort_order'         => 'DESC',
-                'filters_enabled'    => [],
-                'categories_list'    => [],
-                'platforms_list'     => [],
-                'availability_options' => [],
-                'base_url'           => '',
-                'total_items'        => 0,
-                'config_payload'     => [],
-                'message'            => '',
-            ];
+            $template_defaults = array(
+                'options'              => array(),
+                'average_score'        => null,
+                'scores'               => array(),
+                'categories'           => array(),
+                'pros_list'            => array(),
+                'cons_list'            => array(),
+                'titre'                => '',
+                'champs_a_afficher'    => array(),
+                'tagline_fr'           => '',
+                'tagline_en'           => '',
+                'query'                => null,
+                'atts'                 => array(),
+                'block_classes'        => '',
+                'css_variables'        => '',
+                'score_layout'         => 'text',
+                'animations_enabled'   => false,
+                'paged'                => 1,
+                'orderby'              => '',
+                'order'                => '',
+                'colonnes'             => array(),
+                'colonnes_disponibles' => array(),
+                'error_message'        => '',
+                'cat_filter'           => 0,
+                'table_id'             => '',
+                'widget_args'          => array(),
+                'title'                => '',
+                'latest_reviews'       => null,
+                'post_id'              => null,
+                'avg_rating'           => null,
+                'count'                => 0,
+                'has_voted'            => false,
+                'user_vote'            => 0,
+                'games'                => array(),
+                'letters'              => array(),
+                'filters'              => array(),
+                'current_filters'      => array(),
+                'pagination'           => array(
+					'current' => 1,
+					'total'   => 0,
+				),
+                'sort_options'         => array(),
+                'sort_key'             => 'date',
+                'sort_order'           => 'DESC',
+                'filters_enabled'      => array(),
+                'categories_list'      => array(),
+                'platforms_list'       => array(),
+                'availability_options' => array(),
+                'base_url'             => '',
+                'total_items'          => 0,
+                'config_payload'       => array(),
+                'message'              => '',
+            );
 
             // Fusionner les arguments fournis avec les valeurs par défaut.
-            $prepared_args = array_merge($template_defaults, $args);
+            $prepared_args = array_merge( $template_defaults, $args );
 
             // Rendre chaque variable explicitement disponible pour le template.
-            foreach ($template_defaults as $var_name => $default_value) {
-                ${$var_name} = $prepared_args[$var_name];
+            foreach ( $template_defaults as $var_name => $default_value ) {
+                ${$var_name} = $prepared_args[ $var_name ];
             }
 
             // Permettre aux templates d'accéder directement au tableau complet si nécessaire.
@@ -1602,11 +1631,11 @@ class JLG_Frontend {
             include $template_path;
         } else {
             // Afficher un message d'erreur seulement pour les administrateurs
-            if (current_user_can('manage_options')) {
-                echo '<div class="notice notice-error"><p>Template manquant : <code>' . esc_html($template_path) . '</code></p></div>';
+            if ( current_user_can( 'manage_options' ) ) {
+                echo '<div class="notice notice-error"><p>Template manquant : <code>' . esc_html( $template_path ) . '</code></p></div>';
             }
         }
-        
+
         // Retourner le contenu capturé
         return ob_get_clean();
     }

--- a/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-helpers.php
@@ -4,21 +4,23 @@
  * Contient toutes les fonctions logiques réutilisables du plugin.
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Helpers {
 
-    private static $option_name = 'notation_jlg_settings';
-    private static $category_keys = ['cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6'];
-    private static $options_cache = null;
+    private static $option_name            = 'notation_jlg_settings';
+    private static $category_keys          = array( 'cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6' );
+    private static $options_cache          = null;
     private static $default_settings_cache = null;
 
     private static function get_rating_meta_keys() {
         static $meta_keys = null;
 
-        if ($meta_keys === null) {
+        if ( $meta_keys === null ) {
             $meta_keys = array_map(
-                static function ($key) {
+                static function ( $key ) {
                     return '_note_' . $key;
                 },
                 self::$category_keys
@@ -29,119 +31,140 @@ class JLG_Helpers {
     }
 
     private static function get_theme_defaults() {
-        return [
-            'light' => [
-                'bg_color'          => '#ffffff',
-                'bg_color_secondary'=> '#f9fafb',
-                'border_color'      => '#e5e7eb',
-                'text_color'        => '#111827',
+        return array(
+            'light' => array(
+                'bg_color'             => '#ffffff',
+                'bg_color_secondary'   => '#f9fafb',
+                'border_color'         => '#e5e7eb',
+                'text_color'           => '#111827',
                 'text_color_secondary' => '#6b7280',
-                'tagline_bg_color'  => '#f3f4f6',
-                'tagline_text_color'=> '#4b5563',
-            ],
-            'dark' => [
-                'bg_color'          => '#18181b',
-                'bg_color_secondary'=> '#27272a',
-                'border_color'      => '#3f3f46',
-                'text_color'        => '#fafafa',
+                'tagline_bg_color'     => '#f3f4f6',
+                'tagline_text_color'   => '#4b5563',
+            ),
+            'dark'  => array(
+                'bg_color'             => '#18181b',
+                'bg_color_secondary'   => '#27272a',
+                'border_color'         => '#3f3f46',
+                'text_color'           => '#fafafa',
                 'text_color_secondary' => '#a1a1aa',
-                'tagline_bg_color'  => '#1f2937',
-                'tagline_text_color'=> '#d1d5db',
-            ]
-        ];
+                'tagline_bg_color'     => '#1f2937',
+                'tagline_text_color'   => '#d1d5db',
+            ),
+        );
     }
 
     private static function get_default_platform_definitions() {
-        return [
-            'pc' => ['name' => 'PC', 'order' => 1],
-            'playstation-5' => ['name' => 'PlayStation 5', 'order' => 2],
-            'xbox-series-x' => ['name' => 'Xbox Series S/X', 'order' => 3],
-            'nintendo-switch' => ['name' => 'Nintendo Switch', 'order' => 4],
-            'playstation-4' => ['name' => 'PlayStation 4', 'order' => 5],
-            'xbox-one' => ['name' => 'Xbox One', 'order' => 6],
-            'steam-deck' => ['name' => 'Steam Deck', 'order' => 7],
-        ];
+        return array(
+            'pc'              => array(
+				'name'  => 'PC',
+				'order' => 1,
+			),
+            'playstation-5'   => array(
+				'name'  => 'PlayStation 5',
+				'order' => 2,
+			),
+            'xbox-series-x'   => array(
+				'name'  => 'Xbox Series S/X',
+				'order' => 3,
+			),
+            'nintendo-switch' => array(
+				'name'  => 'Nintendo Switch',
+				'order' => 4,
+			),
+            'playstation-4'   => array(
+				'name'  => 'PlayStation 4',
+				'order' => 5,
+			),
+            'xbox-one'        => array(
+				'name'  => 'Xbox One',
+				'order' => 6,
+			),
+            'steam-deck'      => array(
+				'name'  => 'Steam Deck',
+				'order' => 7,
+			),
+        );
     }
 
     public static function get_default_settings() {
-        if (is_array(self::$default_settings_cache)) {
+        if ( is_array( self::$default_settings_cache ) ) {
             return self::$default_settings_cache;
         }
 
-        $themes = self::get_theme_defaults();
-        $dark_defaults = $themes['dark'];
+        $themes         = self::get_theme_defaults();
+        $dark_defaults  = $themes['dark'];
         $light_defaults = $themes['light'];
 
-        self::$default_settings_cache = [
+        self::$default_settings_cache = array(
             // Options générales
-            'visual_theme'      => 'dark',
-            'score_layout'      => 'text',
-            'enable_animations' => 1,
-            'tagline_font_size' => 16,
-            
+            'visual_theme'                 => 'dark',
+            'score_layout'                 => 'text',
+            'enable_animations'            => 1,
+            'tagline_font_size'            => 16,
+
             // Couleurs de Thème Sombre personnalisables
-            'dark_bg_color'           => $dark_defaults['bg_color'],
-            'dark_bg_color_secondary' => $dark_defaults['bg_color_secondary'],
-            'dark_border_color'       => $dark_defaults['border_color'],
-            'dark_text_color'         => $dark_defaults['text_color'],
-            'dark_text_color_secondary' => $dark_defaults['text_color_secondary'],
-            'tagline_bg_color'        => $dark_defaults['tagline_bg_color'],
-            'tagline_text_color'      => $dark_defaults['tagline_text_color'],
+            'dark_bg_color'                => $dark_defaults['bg_color'],
+            'dark_bg_color_secondary'      => $dark_defaults['bg_color_secondary'],
+            'dark_border_color'            => $dark_defaults['border_color'],
+            'dark_text_color'              => $dark_defaults['text_color'],
+            'dark_text_color_secondary'    => $dark_defaults['text_color_secondary'],
+            'tagline_bg_color'             => $dark_defaults['tagline_bg_color'],
+            'tagline_text_color'           => $dark_defaults['tagline_text_color'],
 
             // Couleurs de Thème Clair personnalisables
-            'light_bg_color'           => $light_defaults['bg_color'],
-            'light_bg_color_secondary' => $light_defaults['bg_color_secondary'],
-            'light_border_color'       => $light_defaults['border_color'],
-            'light_text_color'         => $light_defaults['text_color'],
-            'light_text_color_secondary' => $light_defaults['text_color_secondary'],
+            'light_bg_color'               => $light_defaults['bg_color'],
+            'light_bg_color_secondary'     => $light_defaults['bg_color_secondary'],
+            'light_border_color'           => $light_defaults['border_color'],
+            'light_text_color'             => $light_defaults['text_color'],
+            'light_text_color_secondary'   => $light_defaults['text_color_secondary'],
 
             // Couleurs sémantiques et de marque
-            'score_gradient_1'      => '#60a5fa',
-            'score_gradient_2'      => '#c084fc',
-            'color_low'             => '#ef4444',
-            'color_mid'             => '#f97316',
-            'color_high'            => '#22c55e',
-            'user_rating_star_color'=> '#f59e0b',
-            'user_rating_text_color'=> '#a1a1aa',
-            'user_rating_title_color' => '#fafafa',
-            
+            'score_gradient_1'             => '#60a5fa',
+            'score_gradient_2'             => '#c084fc',
+            'color_low'                    => '#ef4444',
+            'color_mid'                    => '#f97316',
+            'color_high'                   => '#22c55e',
+            'user_rating_star_color'       => '#f59e0b',
+            'user_rating_text_color'       => '#a1a1aa',
+            'user_rating_title_color'      => '#fafafa',
+
             // Options cercle
-            'circle_dynamic_bg_enabled' => 0,
-            'circle_border_enabled' => 1,
-            'circle_border_width' => 5,
-            'circle_border_color' => '#60a5fa',
-            
+            'circle_dynamic_bg_enabled'    => 0,
+            'circle_border_enabled'        => 1,
+            'circle_border_width'          => 5,
+            'circle_border_color'          => '#60a5fa',
+
             // Options glow pour mode texte
-            'text_glow_enabled' => 0,
-            'text_glow_color_mode' => 'dynamic',
-            'text_glow_custom_color' => '#ffffff',
-            'text_glow_intensity' => 15,
-            'text_glow_pulse' => 0,
-            'text_glow_speed' => 2.5,
-            
+            'text_glow_enabled'            => 0,
+            'text_glow_color_mode'         => 'dynamic',
+            'text_glow_custom_color'       => '#ffffff',
+            'text_glow_intensity'          => 15,
+            'text_glow_pulse'              => 0,
+            'text_glow_speed'              => 2.5,
+
             // Options glow pour mode cercle
-            'circle_glow_enabled' => 0,
-            'circle_glow_color_mode' => 'dynamic',
-            'circle_glow_custom_color' => '#ffffff',
-            'circle_glow_intensity' => 15,
-            'circle_glow_pulse' => 0,
-            'circle_glow_speed' => 2.5,
-            
+            'circle_glow_enabled'          => 0,
+            'circle_glow_color_mode'       => 'dynamic',
+            'circle_glow_custom_color'     => '#ffffff',
+            'circle_glow_intensity'        => 15,
+            'circle_glow_pulse'            => 0,
+            'circle_glow_speed'            => 2.5,
+
             // Options des modules
-            'tagline_enabled'      => 1,
-            'user_rating_enabled'  => 1,
-            'table_zebra_striping' => 0,
-            'table_border_style'   => 'horizontal',
-            'table_border_width'   => 1,
-            'table_header_bg_color'   => '#3f3f46',
-            'table_header_text_color' => '#ffffff',
-            'table_row_bg_color'      => 'transparent', // Must remain literal "transparent" so CSS vars keep default transparency
-            'table_row_text_color'    => '#a1a1aa',
-            'table_zebra_bg_color'    => '#27272a',
-            'thumb_text_color'      => '#ffffff',
-            'thumb_font_size'       => 14,
-            'thumb_padding'         => 8,
-            'thumb_border_radius'   => 4,
+            'tagline_enabled'              => 1,
+            'user_rating_enabled'          => 1,
+            'table_zebra_striping'         => 0,
+            'table_border_style'           => 'horizontal',
+            'table_border_width'           => 1,
+            'table_header_bg_color'        => '#3f3f46',
+            'table_header_text_color'      => '#ffffff',
+            'table_row_bg_color'           => 'transparent', // Must remain literal "transparent" so CSS vars keep default transparency
+            'table_row_text_color'         => '#a1a1aa',
+            'table_zebra_bg_color'         => '#27272a',
+            'thumb_text_color'             => '#ffffff',
+            'thumb_font_size'              => 14,
+            'thumb_padding'                => 8,
+            'thumb_border_radius'          => 4,
 
             // Options Game Explorer
             'game_explorer_columns'        => 3,
@@ -149,31 +172,31 @@ class JLG_Helpers {
             'game_explorer_filters'        => 'letter,category,platform,availability',
 
             // Libellés
-            'label_cat1' => 'Gameplay',
-            'label_cat2' => 'Graphismes',
-            'label_cat3' => 'Bande-son',
-            'label_cat4' => 'Durée de vie',
-            'label_cat5' => 'Scénario',
-            'label_cat6' => 'Originalité',
+            'label_cat1'                   => 'Gameplay',
+            'label_cat2'                   => 'Graphismes',
+            'label_cat3'                   => 'Bande-son',
+            'label_cat4'                   => 'Durée de vie',
+            'label_cat5'                   => 'Scénario',
+            'label_cat6'                   => 'Originalité',
 
             // Options techniques et diverses
-            'custom_css' => '',
-            'seo_schema_enabled' => 1,
-            'debug_mode_enabled' => 0,
-            'rawg_api_key' => '',
-        ];
+            'custom_css'                   => '',
+            'seo_schema_enabled'           => 1,
+            'debug_mode_enabled'           => 0,
+            'rawg_api_key'                 => '',
+        );
 
         return self::$default_settings_cache;
     }
 
-    public static function get_plugin_options($force_refresh = false) {
-        if (!$force_refresh && is_array(self::$options_cache)) {
+    public static function get_plugin_options( $force_refresh = false ) {
+        if ( ! $force_refresh && is_array( self::$options_cache ) ) {
             return self::$options_cache;
         }
 
-        $defaults = self::get_default_settings();
-        $saved_options = get_option(self::$option_name, $defaults);
-        self::$options_cache = wp_parse_args($saved_options, $defaults);
+        $defaults            = self::get_default_settings();
+        $saved_options       = get_option( self::$option_name, $defaults );
+        self::$options_cache = wp_parse_args( $saved_options, $defaults );
 
         return self::$options_cache;
     }
@@ -184,19 +207,19 @@ class JLG_Helpers {
      * @return string[] List of sanitized post type identifiers.
      */
     public static function get_allowed_post_types() {
-        $post_types = apply_filters('jlg_rated_post_types', ['post']);
+        $post_types = apply_filters( 'jlg_rated_post_types', array( 'post' ) );
 
-        if (!is_array($post_types)) {
-            $post_types = ['post'];
+        if ( ! is_array( $post_types ) ) {
+            $post_types = array( 'post' );
         }
 
-        $post_types = array_values(array_filter(array_map('sanitize_key', $post_types)));
+        $post_types = array_values( array_filter( array_map( 'sanitize_key', $post_types ) ) );
 
-        if (empty($post_types)) {
-            $post_types = ['post'];
+        if ( empty( $post_types ) ) {
+            $post_types = array( 'post' );
         }
 
-        return array_values(array_unique($post_types));
+        return array_values( array_unique( $post_types ) );
     }
 
     public static function flush_plugin_options_cache() {
@@ -209,58 +232,58 @@ class JLG_Helpers {
      * @param int $post_id The post identifier.
      * @return string The stored game title if available, otherwise the WordPress post title.
      */
-    public static function get_game_title($post_id) {
+    public static function get_game_title( $post_id ) {
         $post_id = (int) $post_id;
 
-        if ($post_id <= 0) {
+        if ( $post_id <= 0 ) {
             return '';
         }
 
-        $raw_meta_title = get_post_meta($post_id, '_jlg_game_title', true);
+        $raw_meta_title = get_post_meta( $post_id, '_jlg_game_title', true );
         $resolved_title = '';
 
-        if (is_string($raw_meta_title)) {
-            $meta_title = sanitize_text_field($raw_meta_title);
-            if ($meta_title !== '') {
+        if ( is_string( $raw_meta_title ) ) {
+            $meta_title = sanitize_text_field( $raw_meta_title );
+            if ( $meta_title !== '' ) {
                 $resolved_title = $meta_title;
             }
         }
 
-        if ($resolved_title === '') {
-            $fallback_title = get_the_title($post_id);
-            if (is_string($fallback_title)) {
+        if ( $resolved_title === '' ) {
+            $fallback_title = get_the_title( $post_id );
+            if ( is_string( $fallback_title ) ) {
                 $resolved_title = $fallback_title;
             }
         }
 
-        return apply_filters('jlg_game_title', (string) $resolved_title, $post_id, $raw_meta_title);
+        return apply_filters( 'jlg_game_title', (string) $resolved_title, $post_id, $raw_meta_title );
     }
 
     public static function get_color_palette() {
-        $options = self::get_plugin_options();
-        $theme = $options['visual_theme'] ?? 'dark';
+        $options        = self::get_plugin_options();
+        $theme          = $options['visual_theme'] ?? 'dark';
         $theme_defaults = self::get_theme_defaults();
-        $palette = ($theme === 'light') ? $theme_defaults['light'] : $theme_defaults['dark'];
-        
-        if ($theme === 'light') {
-            $palette['bg_color']           = $options['light_bg_color'] ?? $theme_defaults['light']['bg_color'];
-            $palette['bg_color_secondary'] = $options['light_bg_color_secondary'] ?? $theme_defaults['light']['bg_color_secondary'];
-            $palette['border_color']       = $options['light_border_color'] ?? $theme_defaults['light']['border_color'];
-            $palette['text_color']         = $options['light_text_color'] ?? $theme_defaults['light']['text_color'];
+        $palette        = ( $theme === 'light' ) ? $theme_defaults['light'] : $theme_defaults['dark'];
+
+        if ( $theme === 'light' ) {
+            $palette['bg_color']             = $options['light_bg_color'] ?? $theme_defaults['light']['bg_color'];
+            $palette['bg_color_secondary']   = $options['light_bg_color_secondary'] ?? $theme_defaults['light']['bg_color_secondary'];
+            $palette['border_color']         = $options['light_border_color'] ?? $theme_defaults['light']['border_color'];
+            $palette['text_color']           = $options['light_text_color'] ?? $theme_defaults['light']['text_color'];
             $palette['text_color_secondary'] = $options['light_text_color_secondary'] ?? $theme_defaults['light']['text_color_secondary'];
         } else {
-            $palette['bg_color']           = $options['dark_bg_color'] ?? $theme_defaults['dark']['bg_color'];
-            $palette['bg_color_secondary'] = $options['dark_bg_color_secondary'] ?? $theme_defaults['dark']['bg_color_secondary'];
-            $palette['border_color']       = $options['dark_border_color'] ?? $theme_defaults['dark']['border_color'];
-            $palette['text_color']         = $options['dark_text_color'] ?? $theme_defaults['dark']['text_color'];
+            $palette['bg_color']             = $options['dark_bg_color'] ?? $theme_defaults['dark']['bg_color'];
+            $palette['bg_color_secondary']   = $options['dark_bg_color_secondary'] ?? $theme_defaults['dark']['bg_color_secondary'];
+            $palette['border_color']         = $options['dark_border_color'] ?? $theme_defaults['dark']['border_color'];
+            $palette['text_color']           = $options['dark_text_color'] ?? $theme_defaults['dark']['text_color'];
             $palette['text_color_secondary'] = $options['dark_text_color_secondary'] ?? $theme_defaults['dark']['text_color_secondary'];
         }
 
-        $tagline_bg_option = isset($options['tagline_bg_color']) ? (string) $options['tagline_bg_color'] : '';
-        $tagline_text_option = isset($options['tagline_text_color']) ? (string) $options['tagline_text_color'] : '';
+        $tagline_bg_option   = isset( $options['tagline_bg_color'] ) ? (string) $options['tagline_bg_color'] : '';
+        $tagline_text_option = isset( $options['tagline_text_color'] ) ? (string) $options['tagline_text_color'] : '';
 
-        $palette['tagline_bg_color']     = $tagline_bg_option !== '' ? $tagline_bg_option : ($theme === 'light' ? $theme_defaults['light']['tagline_bg_color'] : $theme_defaults['dark']['tagline_bg_color']);
-        $palette['tagline_text_color']   = $tagline_text_option !== '' ? $tagline_text_option : ($theme === 'light' ? $theme_defaults['light']['tagline_text_color'] : $theme_defaults['dark']['tagline_text_color']);
+        $palette['tagline_bg_color']     = $tagline_bg_option !== '' ? $tagline_bg_option : ( $theme === 'light' ? $theme_defaults['light']['tagline_bg_color'] : $theme_defaults['dark']['tagline_bg_color'] );
+        $palette['tagline_text_color']   = $tagline_text_option !== '' ? $tagline_text_option : ( $theme === 'light' ? $theme_defaults['light']['tagline_text_color'] : $theme_defaults['dark']['tagline_text_color'] );
         $palette['table_zebra_color']    = $palette['bg_color_secondary'];
         $palette['main_text_color']      = $palette['text_color'];
         $palette['secondary_text_color'] = $palette['text_color_secondary'];
@@ -269,19 +292,19 @@ class JLG_Helpers {
         return $palette;
     }
 
-    public static function get_average_score_for_post($post_id) {
+    public static function get_average_score_for_post( $post_id ) {
         $total_score = 0;
-        $count = 0;
+        $count       = 0;
 
-        foreach (self::$category_keys as $key) {
-            $score = get_post_meta($post_id, '_note_' . $key, true);
-            if ($score !== '' && is_numeric($score)) {
-                $total_score += floatval($score);
-                $count++;
+        foreach ( self::$category_keys as $key ) {
+            $score = get_post_meta( $post_id, '_note_' . $key, true );
+            if ( $score !== '' && is_numeric( $score ) ) {
+                $total_score += floatval( $score );
+                ++$count;
             }
         }
 
-        return ($count > 0) ? round($total_score / $count, 1) : null;
+        return ( $count > 0 ) ? round( $total_score / $count, 1 ) : null;
     }
 
     /**
@@ -290,146 +313,150 @@ class JLG_Helpers {
      * @param int $post_id The post ID.
      * @return array{value: float|null, formatted: string|null}
      */
-    public static function get_resolved_average_score($post_id) {
-        $stored_score = get_post_meta($post_id, '_jlg_average_score', true);
+    public static function get_resolved_average_score( $post_id ) {
+        $stored_score = get_post_meta( $post_id, '_jlg_average_score', true );
 
-        if ($stored_score !== '' && $stored_score !== null && is_numeric($stored_score)) {
+        if ( $stored_score !== '' && $stored_score !== null && is_numeric( $stored_score ) ) {
             $score_value = (float) $stored_score;
 
-            return [
-                'value' => $score_value,
-                'formatted' => number_format_i18n($score_value, 1),
-            ];
+            return array(
+                'value'     => $score_value,
+                'formatted' => number_format_i18n( $score_value, 1 ),
+            );
         }
 
-        $fallback_score = self::get_average_score_for_post($post_id);
+        $fallback_score = self::get_average_score_for_post( $post_id );
 
-        if ($fallback_score !== null && is_numeric($fallback_score)) {
-            update_post_meta($post_id, '_jlg_average_score', $fallback_score);
+        if ( $fallback_score !== null && is_numeric( $fallback_score ) ) {
+            update_post_meta( $post_id, '_jlg_average_score', $fallback_score );
             $fallback_value = (float) $fallback_score;
 
-            return [
-                'value' => $fallback_value,
-                'formatted' => number_format_i18n($fallback_value, 1),
-            ];
+            return array(
+                'value'     => $fallback_value,
+                'formatted' => number_format_i18n( $fallback_value, 1 ),
+            );
         }
 
-        return [
-            'value' => null,
+        return array(
+            'value'     => null,
             'formatted' => null,
-        ];
+        );
     }
 
     /**
      * Clear the cached average score when one of the rating metas is changed.
      */
-    public static function maybe_handle_rating_meta_change($meta_id, $post_id, $meta_key, $meta_value = null) {
-        unset($meta_id, $meta_value);
+    public static function maybe_handle_rating_meta_change( $meta_id, $post_id, $meta_key, $meta_value = null ) {
+        unset( $meta_id, $meta_value );
 
-        if (!is_string($meta_key) || !in_array($meta_key, self::get_rating_meta_keys(), true)) {
+        if ( ! is_string( $meta_key ) || ! in_array( $meta_key, self::get_rating_meta_keys(), true ) ) {
             return;
         }
 
-        self::invalidate_average_score_cache($post_id);
+        self::invalidate_average_score_cache( $post_id );
     }
 
     /**
      * Delete the stored average and queue a rebuild for the provided post.
      */
-    public static function invalidate_average_score_cache($post_id) {
+    public static function invalidate_average_score_cache( $post_id ) {
         $post_id = (int) $post_id;
 
-        if ($post_id <= 0) {
+        if ( $post_id <= 0 ) {
             return;
         }
 
-        delete_post_meta($post_id, '_jlg_average_score');
+        delete_post_meta( $post_id, '_jlg_average_score' );
         self::clear_rated_post_ids_cache();
-        self::queue_average_score_rebuild($post_id);
+        self::queue_average_score_rebuild( $post_id );
     }
 
     public static function get_rating_categories() {
-        $options = self::get_plugin_options();
-        $categories = [];
-        
-        foreach (self::$category_keys as $key) {
-            $label_key = 'label_' . $key;
-            $categories[$key] = !empty($options[$label_key]) ? $options[$label_key] : 'Catégorie';
+        $options    = self::get_plugin_options();
+        $categories = array();
+
+        foreach ( self::$category_keys as $key ) {
+            $label_key          = 'label_' . $key;
+            $categories[ $key ] = ! empty( $options[ $label_key ] ) ? $options[ $label_key ] : 'Catégorie';
         }
-        
+
         return $categories;
     }
-    
-    public static function get_rated_post_ids() {
-        $transient_key = 'jlg_rated_post_ids_v1';
-        $cached_post_ids = get_transient($transient_key);
 
-        if ($cached_post_ids !== false && is_array($cached_post_ids)) {
-            return array_map('intval', $cached_post_ids);
+    public static function get_rated_post_ids() {
+        $transient_key   = 'jlg_rated_post_ids_v1';
+        $cached_post_ids = get_transient( $transient_key );
+
+        if ( $cached_post_ids !== false && is_array( $cached_post_ids ) ) {
+            return array_map( 'intval', $cached_post_ids );
         }
 
         $post_ids = self::query_rated_post_ids();
 
-        $expiration = apply_filters('jlg_rated_post_ids_cache_ttl', 15 * (defined('MINUTE_IN_SECONDS') ? MINUTE_IN_SECONDS : 60));
+        $expiration = apply_filters( 'jlg_rated_post_ids_cache_ttl', 15 * ( defined( 'MINUTE_IN_SECONDS' ) ? MINUTE_IN_SECONDS : 60 ) );
 
-        if ($expiration > 0) {
-            set_transient($transient_key, $post_ids, $expiration);
+        if ( $expiration > 0 ) {
+            set_transient( $transient_key, $post_ids, $expiration );
         }
 
         return $post_ids;
     }
 
-    public static function get_rated_post_ids_batch($after_post_id = 0, $limit = 200) {
-        $after_post_id = max(0, (int) $after_post_id);
-        $limit = (int) $limit;
+    public static function get_rated_post_ids_batch( $after_post_id = 0, $limit = 200 ) {
+        $after_post_id = max( 0, (int) $after_post_id );
+        $limit         = (int) $limit;
 
-        if ($limit === 0) {
+        if ( $limit === 0 ) {
             $limit = 200;
         }
 
         global $wpdb;
 
-        $meta_keys = array_map(static function ($key) {
-            return '_note_' . $key;
-        }, self::$category_keys);
+        $meta_keys = array_map(
+            static function ( $key ) {
+				return '_note_' . $key;
+			},
+            self::$category_keys
+        );
 
         $post_types = self::get_allowed_post_types();
 
-        $post_statuses = apply_filters('jlg_rated_post_statuses', ['publish']);
-        if (!is_array($post_statuses) || empty($post_statuses)) {
-            $post_statuses = ['publish'];
+        $post_statuses = apply_filters( 'jlg_rated_post_statuses', array( 'publish' ) );
+        if ( ! is_array( $post_statuses ) || empty( $post_statuses ) ) {
+            $post_statuses = array( 'publish' );
         }
-        $post_statuses = array_values(array_filter(array_map('sanitize_key', $post_statuses)));
+        $post_statuses = array_values( array_filter( array_map( 'sanitize_key', $post_statuses ) ) );
 
-        $meta_placeholders = implode(', ', array_fill(0, count($meta_keys), '%s'));
-        $type_placeholders = implode(', ', array_fill(0, count($post_types), '%s'));
-        $status_clause = '';
-        $prepare_args = array_merge($meta_keys, $post_types);
+        $meta_placeholders = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
+        $type_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+        $status_clause     = '';
+        $prepare_args      = array_merge( $meta_keys, $post_types );
 
-        if (!empty($post_statuses)) {
-            $status_placeholders = implode(', ', array_fill(0, count($post_statuses), '%s'));
-            $status_clause = " AND p.post_status IN ($status_placeholders)";
-            $prepare_args = array_merge($prepare_args, $post_statuses);
+        if ( ! empty( $post_statuses ) ) {
+            $status_placeholders = implode( ', ', array_fill( 0, count( $post_statuses ), '%s' ) );
+            $status_clause       = " AND p.post_status IN ($status_placeholders)";
+            $prepare_args        = array_merge( $prepare_args, $post_statuses );
         }
 
-        $postmeta_table = isset($wpdb->postmeta) ? $wpdb->postmeta : (isset($wpdb->prefix) ? $wpdb->prefix . 'postmeta' : 'wp_postmeta');
-        $posts_table = isset($wpdb->posts) ? $wpdb->posts : (isset($wpdb->prefix) ? $wpdb->prefix . 'posts' : 'wp_posts');
+        $postmeta_table = isset( $wpdb->postmeta ) ? $wpdb->postmeta : ( isset( $wpdb->prefix ) ? $wpdb->prefix . 'postmeta' : 'wp_postmeta' );
+        $posts_table    = isset( $wpdb->posts ) ? $wpdb->posts : ( isset( $wpdb->prefix ) ? $wpdb->prefix . 'posts' : 'wp_posts' );
 
-        $postmeta_table = preg_match('/^[A-Za-z0-9_]+$/', (string) $postmeta_table) ? $postmeta_table : 'wp_postmeta';
-        $posts_table = preg_match('/^[A-Za-z0-9_]+$/', (string) $posts_table) ? $posts_table : 'wp_posts';
+        $postmeta_table = preg_match( '/^[A-Za-z0-9_]+$/', (string) $postmeta_table ) ? $postmeta_table : 'wp_postmeta';
+        $posts_table    = preg_match( '/^[A-Za-z0-9_]+$/', (string) $posts_table ) ? $posts_table : 'wp_posts';
 
         $after_clause = '';
-        if ($after_post_id > 0) {
+        if ( $after_post_id > 0 ) {
             $after_clause = 'AND pm.post_id > %d';
-            array_splice($prepare_args, count($meta_keys), 0, [$after_post_id]);
+            array_splice( $prepare_args, count( $meta_keys ), 0, array( $after_post_id ) );
         }
 
         $limit_clause = '';
-        if ($limit > 0 && $limit < PHP_INT_MAX) {
-            $limit_clause = 'LIMIT %d';
+        if ( $limit > 0 && $limit < PHP_INT_MAX ) {
+            $limit_clause   = 'LIMIT %d';
             $prepare_args[] = $limit;
         }
 
+        // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Table names are validated earlier.
         $query = "SELECT DISTINCT pm.post_id
             FROM {$postmeta_table} pm
             INNER JOIN {$posts_table} p ON p.ID = pm.post_id
@@ -441,40 +468,41 @@ class JLG_Helpers {
                 $status_clause
             ORDER BY pm.post_id ASC";
 
-        if ($limit_clause !== '') {
+        if ( $limit_clause !== '' ) {
             $query .= "\n            $limit_clause";
         }
 
-        $prepared = $wpdb->prepare($query, ...$prepare_args);
+        $prepared = $wpdb->prepare( $query, ...$prepare_args );
 
-        return array_map('intval', $wpdb->get_col($prepared));
+        return array_map( 'intval', $wpdb->get_col( $prepared ) );
+        // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
     }
 
     private static function query_rated_post_ids() {
-        return self::get_rated_post_ids_batch(0, -1);
+        return self::get_rated_post_ids_batch( 0, -1 );
     }
 
-    private static function resolve_post_id_from_mixed($post) {
-        if (is_object($post) && isset($post->ID)) {
+    private static function resolve_post_id_from_mixed( $post ) {
+        if ( is_object( $post ) && isset( $post->ID ) ) {
             return (int) $post->ID;
         }
 
-        if (is_array($post) && isset($post['ID'])) {
+        if ( is_array( $post ) && isset( $post['ID'] ) ) {
             return (int) $post['ID'];
         }
 
-        if (is_numeric($post)) {
+        if ( is_numeric( $post ) ) {
             return (int) $post;
         }
 
         return 0;
     }
 
-    private static function post_has_rating_values($post_id) {
-        foreach (self::get_rating_meta_keys() as $meta_key) {
-            $value = get_post_meta($post_id, $meta_key, true);
+    private static function post_has_rating_values( $post_id ) {
+        foreach ( self::get_rating_meta_keys() as $meta_key ) {
+            $value = get_post_meta( $post_id, $meta_key, true );
 
-            if ($value !== '' && $value !== null && $value !== false) {
+            if ( $value !== '' && $value !== null && $value !== false ) {
                 return true;
             }
         }
@@ -482,70 +510,70 @@ class JLG_Helpers {
         return false;
     }
 
-    public static function maybe_clear_rated_post_ids_cache_for_status_change($new_status, $old_status, $post) {
-        $new_status = is_string($new_status) ? strtolower($new_status) : '';
-        $old_status = is_string($old_status) ? strtolower($old_status) : '';
+    public static function maybe_clear_rated_post_ids_cache_for_status_change( $new_status, $old_status, $post ) {
+        $new_status = is_string( $new_status ) ? strtolower( $new_status ) : '';
+        $old_status = is_string( $old_status ) ? strtolower( $old_status ) : '';
 
-        if ($new_status === $old_status) {
+        if ( $new_status === $old_status ) {
             return;
         }
 
-        if ($new_status !== 'publish' && $old_status !== 'publish') {
+        if ( $new_status !== 'publish' && $old_status !== 'publish' ) {
             return;
         }
 
-        $post_id = self::resolve_post_id_from_mixed($post);
+        $post_id = self::resolve_post_id_from_mixed( $post );
 
-        if ($post_id <= 0) {
+        if ( $post_id <= 0 ) {
             return;
         }
 
         $post_type = null;
 
-        if (function_exists('get_post_type')) {
-            $post_type = get_post_type($post);
+        if ( function_exists( 'get_post_type' ) ) {
+            $post_type = get_post_type( $post );
         }
 
-        if (!is_string($post_type) || $post_type === '') {
-            if (is_object($post) && isset($post->post_type)) {
+        if ( ! is_string( $post_type ) || $post_type === '' ) {
+            if ( is_object( $post ) && isset( $post->post_type ) ) {
                 $post_type = (string) $post->post_type;
-            } elseif (is_array($post) && isset($post['post_type'])) {
+            } elseif ( is_array( $post ) && isset( $post['post_type'] ) ) {
                 $post_type = (string) $post['post_type'];
             }
         }
 
-        if (is_string($post_type) && $post_type !== '') {
+        if ( is_string( $post_type ) && $post_type !== '' ) {
             $allowed_types = self::get_allowed_post_types();
 
-            if (!in_array($post_type, $allowed_types, true)) {
+            if ( ! in_array( $post_type, $allowed_types, true ) ) {
                 return;
             }
         }
 
-        if (!self::post_has_rating_values($post_id)) {
+        if ( ! self::post_has_rating_values( $post_id ) ) {
             return;
         }
 
         self::clear_rated_post_ids_cache();
     }
 
-    public static function queue_average_score_rebuild($post_ids) {
-        if (empty($post_ids)) {
+    public static function queue_average_score_rebuild( $post_ids ) {
+        if ( empty( $post_ids ) ) {
             return;
         }
 
-        if (!is_array($post_ids)) {
-            $post_ids = [$post_ids];
+        if ( ! is_array( $post_ids ) ) {
+            $post_ids = array( $post_ids );
         }
 
         $post_ids = array_filter(
-            array_map('intval', $post_ids),
-            static function ($post_id) {
+            array_map( 'intval', $post_ids ),
+            static function ( $post_id ) {
                 return $post_id > 0;
             }
         );
 
-        if (empty($post_ids)) {
+        if ( empty( $post_ids ) ) {
             return;
         }
 
@@ -554,284 +582,292 @@ class JLG_Helpers {
          *
          * @param int[] $post_ids Liste des IDs d'articles.
          */
-        do_action('jlg_queue_average_rebuild', $post_ids);
+        do_action( 'jlg_queue_average_rebuild', $post_ids );
     }
 
     public static function clear_rated_post_ids_cache() {
-        delete_transient('jlg_rated_post_ids_v1');
-    }
-    
-    public static function adjust_hex_brightness($hex, $steps) {
-        $hex = str_replace('#', '', $hex);
-        
-        if (strlen($hex) == 3) {
-            $hex = str_repeat(substr($hex,0,1), 2) . 
-                   str_repeat(substr($hex,1,1), 2) . 
-                   str_repeat(substr($hex,2,1), 2);
-        }
-        
-        $r = max(0, min(255, hexdec(substr($hex,0,2)) + $steps));
-        $g = max(0, min(255, hexdec(substr($hex,2,2)) + $steps));
-        $b = max(0, min(255, hexdec(substr($hex,4,2)) + $steps));
-        
-        return '#' . str_pad(dechex($r), 2, '0', STR_PAD_LEFT) . 
-               str_pad(dechex($g), 2, '0', STR_PAD_LEFT) . 
-               str_pad(dechex($b), 2, '0', STR_PAD_LEFT);
+        delete_transient( 'jlg_rated_post_ids_v1' );
     }
 
-    public static function calculate_color_from_note($note, $options = null) {
-        if ($options === null) {
+    public static function adjust_hex_brightness( $hex, $steps ) {
+        $hex = str_replace( '#', '', $hex );
+
+        if ( strlen( $hex ) == 3 ) {
+            $hex = str_repeat( substr( $hex, 0, 1 ), 2 ) .
+                    str_repeat( substr( $hex, 1, 1 ), 2 ) .
+                    str_repeat( substr( $hex, 2, 1 ), 2 );
+        }
+
+        $r = max( 0, min( 255, hexdec( substr( $hex, 0, 2 ) ) + $steps ) );
+        $g = max( 0, min( 255, hexdec( substr( $hex, 2, 2 ) ) + $steps ) );
+        $b = max( 0, min( 255, hexdec( substr( $hex, 4, 2 ) ) + $steps ) );
+
+        return '#' . str_pad( dechex( $r ), 2, '0', STR_PAD_LEFT ) .
+                str_pad( dechex( $g ), 2, '0', STR_PAD_LEFT ) .
+                str_pad( dechex( $b ), 2, '0', STR_PAD_LEFT );
+    }
+
+    public static function calculate_color_from_note( $note, $options = null ) {
+        if ( $options === null ) {
             $options = self::get_plugin_options();
         }
-        
+
         // S'assurer que la note est un nombre
-        $note = floatval($note);
-        
+        $note = floatval( $note );
+
         // Récupérer les couleurs définies dans les options
-        $color_low = $options['color_low'] ?? '#ef4444';
-        $color_mid = $options['color_mid'] ?? '#f97316';
+        $color_low  = $options['color_low'] ?? '#ef4444';
+        $color_mid  = $options['color_mid'] ?? '#f97316';
         $color_high = $options['color_high'] ?? '#22c55e';
-        
+
         // Parser les couleurs hexadécimales
-        $parsed_low = sscanf($color_low, "#%02x%02x%02x");
-        $parsed_mid = sscanf($color_mid, "#%02x%02x%02x");
-        $parsed_high = sscanf($color_high, "#%02x%02x%02x");
-        
+        $parsed_low  = sscanf( $color_low, '#%02x%02x%02x' );
+        $parsed_mid  = sscanf( $color_mid, '#%02x%02x%02x' );
+        $parsed_high = sscanf( $color_high, '#%02x%02x%02x' );
+
         // Vérifier que le parsing a fonctionné
-        if (!$parsed_low || count($parsed_low) !== 3) $parsed_low = [239, 68, 68];
-        if (!$parsed_mid || count($parsed_mid) !== 3) $parsed_mid = [249, 115, 22];
-        if (!$parsed_high || count($parsed_high) !== 3) $parsed_high = [34, 197, 94];
-        
+        if ( ! $parsed_low || count( $parsed_low ) !== 3 ) {
+			$parsed_low = array( 239, 68, 68 );
+        }
+        if ( ! $parsed_mid || count( $parsed_mid ) !== 3 ) {
+			$parsed_mid = array( 249, 115, 22 );
+        }
+        if ( ! $parsed_high || count( $parsed_high ) !== 3 ) {
+			$parsed_high = array( 34, 197, 94 );
+        }
+
         // Calculer l'interpolation selon la note
-        if ($note <= 5) {
+        if ( $note <= 5 ) {
             // Entre 0 et 5 : interpolation entre low et mid
             $ratio = $note / 5.0;
-            $r = round($parsed_low[0] + ($parsed_mid[0] - $parsed_low[0]) * $ratio);
-            $g = round($parsed_low[1] + ($parsed_mid[1] - $parsed_low[1]) * $ratio);
-            $b = round($parsed_low[2] + ($parsed_mid[2] - $parsed_low[2]) * $ratio);
+            $r     = round( $parsed_low[0] + ( $parsed_mid[0] - $parsed_low[0] ) * $ratio );
+            $g     = round( $parsed_low[1] + ( $parsed_mid[1] - $parsed_low[1] ) * $ratio );
+            $b     = round( $parsed_low[2] + ( $parsed_mid[2] - $parsed_low[2] ) * $ratio );
         } else {
             // Entre 5 et 10 : interpolation entre mid et high
-            $ratio = ($note - 5.0) / 5.0;
-            $r = round($parsed_mid[0] + ($parsed_high[0] - $parsed_mid[0]) * $ratio);
-            $g = round($parsed_mid[1] + ($parsed_high[1] - $parsed_mid[1]) * $ratio);
-            $b = round($parsed_mid[2] + ($parsed_high[2] - $parsed_mid[2]) * $ratio);
+            $ratio = ( $note - 5.0 ) / 5.0;
+            $r     = round( $parsed_mid[0] + ( $parsed_high[0] - $parsed_mid[0] ) * $ratio );
+            $g     = round( $parsed_mid[1] + ( $parsed_high[1] - $parsed_mid[1] ) * $ratio );
+            $b     = round( $parsed_mid[2] + ( $parsed_high[2] - $parsed_mid[2] ) * $ratio );
         }
-        
+
         // S'assurer que les valeurs sont dans les limites
-        $r = max(0, min(255, $r));
-        $g = max(0, min(255, $g));
-        $b = max(0, min(255, $b));
-        
-        return sprintf("#%02x%02x%02x", $r, $g, $b);
+        $r = max( 0, min( 255, $r ) );
+        $g = max( 0, min( 255, $g ) );
+        $b = max( 0, min( 255, $b ) );
+
+        return sprintf( '#%02x%02x%02x', $r, $g, $b );
     }
 
-    public static function get_glow_css($type, $average_score, $options = null) {
-        if ($options === null) {
+    public static function get_glow_css( $type, $average_score, $options = null ) {
+        if ( $options === null ) {
             $options = self::get_plugin_options();
         }
-        
+
         // Vérifier si l'effet est activé pour ce type
         $enabled_key = "{$type}_glow_enabled";
-        if (empty($options[$enabled_key])) {
+        if ( empty( $options[ $enabled_key ] ) ) {
             return '';
         }
-        
+
         // Déterminer la couleur du glow
-        $color_mode_key = "{$type}_glow_color_mode";
+        $color_mode_key   = "{$type}_glow_color_mode";
         $custom_color_key = "{$type}_glow_custom_color";
-        
+
         // Vérifier explicitement si on est en mode dynamique
-        $is_dynamic = isset($options[$color_mode_key]) && $options[$color_mode_key] === 'dynamic';
-        
-        if ($is_dynamic) {
+        $is_dynamic = isset( $options[ $color_mode_key ] ) && $options[ $color_mode_key ] === 'dynamic';
+
+        if ( $is_dynamic ) {
             // Mode dynamique : calculer la couleur selon la note
-            $glow_color = self::calculate_color_from_note($average_score, $options);
+            $glow_color = self::calculate_color_from_note( $average_score, $options );
         } else {
             // Mode personnalisé : utiliser la couleur définie
-            $glow_color = $options[$custom_color_key] ?? '#ffffff';
+            $glow_color = $options[ $custom_color_key ] ?? '#ffffff';
         }
-        
+
         // Paramètres d'intensité et de vitesse
         $intensity_key = "{$type}_glow_intensity";
-        $pulse_key = "{$type}_glow_pulse";
-        $speed_key = "{$type}_glow_speed";
-        
-        $intensity = isset($options[$intensity_key]) ? intval($options[$intensity_key]) : 15;
-        $has_pulse = !empty($options[$pulse_key]);
-        $speed = isset($options[$speed_key]) ? floatval($options[$speed_key]) : 2.5;
-        
+        $pulse_key     = "{$type}_glow_pulse";
+        $speed_key     = "{$type}_glow_speed";
+
+        $intensity = isset( $options[ $intensity_key ] ) ? intval( $options[ $intensity_key ] ) : 15;
+        $has_pulse = ! empty( $options[ $pulse_key ] );
+        $speed     = isset( $options[ $speed_key ] ) ? floatval( $options[ $speed_key ] ) : 2.5;
+
         // Calculer les tailles de shadow
-        $s1 = round($intensity * 0.5);
+        $s1 = round( $intensity * 0.5 );
         $s2 = $intensity;
-        $s3 = round($intensity * 1.5);
-        
+        $s3 = round( $intensity * 1.5 );
+
         // Pour la pulsation
-        $ps1 = round($intensity * 0.7);
-        $ps2 = round($intensity * 1.5);
-        $ps3 = round($intensity * 2.5);
-        
+        $ps1 = round( $intensity * 0.7 );
+        $ps2 = round( $intensity * 1.5 );
+        $ps3 = round( $intensity * 2.5 );
+
         $css = '';
-        
-        if ($type === 'text') {
+
+        if ( $type === 'text' ) {
             // CSS pour le mode texte
-            $css .= ".review-box-jlg .score-value { ";
-            $css .= "text-shadow: ";
+            $css .= '.review-box-jlg .score-value { ';
+            $css .= 'text-shadow: ';
             $css .= "0 0 {$s1}px {$glow_color}, ";
             $css .= "0 0 {$s2}px {$glow_color}, ";
             $css .= "0 0 {$s3}px {$glow_color}";
-            $css .= " !important; "; // Force l'application
-            $css .= "} ";
-            
+            $css .= ' !important; '; // Force l'application
+            $css .= '} ';
+
             // Animation de pulsation si activée
-            if ($has_pulse) {
-                $css .= "@keyframes jlg-text-glow-pulse { ";
-                $css .= "0%, 100% { ";
+            if ( $has_pulse ) {
+                $css .= '@keyframes jlg-text-glow-pulse { ';
+                $css .= '0%, 100% { ';
                 $css .= "text-shadow: 0 0 {$s1}px {$glow_color}, 0 0 {$s2}px {$glow_color}, 0 0 {$s3}px {$glow_color}; ";
-                $css .= "} ";
-                $css .= "50% { ";
+                $css .= '} ';
+                $css .= '50% { ';
                 $css .= "text-shadow: 0 0 {$ps1}px {$glow_color}, 0 0 {$ps2}px {$glow_color}, 0 0 {$ps3}px {$glow_color}; ";
-                $css .= "} ";
-                $css .= "} ";
-                $css .= ".review-box-jlg .score-value { ";
+                $css .= '} ';
+                $css .= '} ';
+                $css .= '.review-box-jlg .score-value { ';
                 $css .= "animation: jlg-text-glow-pulse {$speed}s infinite ease-in-out !important; ";
-                $css .= "} ";
+                $css .= '} ';
             }
-            
-        } elseif ($type === 'circle') {
+		} elseif ( $type === 'circle' ) {
             // CSS pour le mode cercle
-            $css .= ".review-box-jlg .score-circle { ";
-            $css .= "box-shadow: ";
+            $css .= '.review-box-jlg .score-circle { ';
+            $css .= 'box-shadow: ';
             $css .= "0 0 {$s1}px {$glow_color}, ";
             $css .= "0 0 {$s2}px {$glow_color}, ";
             $css .= "0 0 {$s3}px {$glow_color}, ";
             $css .= "inset 0 0 {$s1}px rgba(255,255,255,0.1)";
-            $css .= " !important; "; // Force l'application
-            $css .= "} ";
-            
+            $css .= ' !important; '; // Force l'application
+            $css .= '} ';
+
             // Animation de pulsation si activée
-            if ($has_pulse) {
-                $css .= "@keyframes jlg-circle-glow-pulse { ";
-                $css .= "0%, 100% { ";
-                $css .= "box-shadow: ";
+            if ( $has_pulse ) {
+                $css .= '@keyframes jlg-circle-glow-pulse { ';
+                $css .= '0%, 100% { ';
+                $css .= 'box-shadow: ';
                 $css .= "0 0 {$s1}px {$glow_color}, ";
                 $css .= "0 0 {$s2}px {$glow_color}, ";
                 $css .= "0 0 {$s3}px {$glow_color}, ";
                 $css .= "inset 0 0 {$s1}px rgba(255,255,255,0.1); ";
-                $css .= "} ";
-                $css .= "50% { ";
-                $css .= "box-shadow: ";
+                $css .= '} ';
+                $css .= '50% { ';
+                $css .= 'box-shadow: ';
                 $css .= "0 0 {$ps1}px {$glow_color}, ";
                 $css .= "0 0 {$ps2}px {$glow_color}, ";
                 $css .= "0 0 {$ps3}px {$glow_color}, ";
                 $css .= "inset 0 0 {$ps1}px rgba(255,255,255,0.15); ";
-                $css .= "} ";
-                $css .= "} ";
-                $css .= ".review-box-jlg .score-circle { ";
+                $css .= '} ';
+                $css .= '} ';
+                $css .= '.review-box-jlg .score-circle { ';
                 $css .= "animation: jlg-circle-glow-pulse {$speed}s infinite ease-in-out !important; ";
-                $css .= "} ";
-            }
+                $css .= '} ';
+			}
         }
-        
+
         // Mode debug (optionnel) - décommentez pour voir les valeurs
-        if (!empty($options['debug_mode_enabled'])) {
-            $css .= "/* DEBUG GLOW: ";
+        if ( ! empty( $options['debug_mode_enabled'] ) ) {
+            $css .= '/* DEBUG GLOW: ';
             $css .= "Type: {$type}, ";
-            $css .= "Mode: " . ($is_dynamic ? 'dynamic' : 'custom') . ", ";
+            $css .= 'Mode: ' . ( $is_dynamic ? 'dynamic' : 'custom' ) . ', ';
             $css .= "Score: {$average_score}, ";
             $css .= "Color: {$glow_color}, ";
             $css .= "Intensity: {$intensity}, ";
-            $css .= "Pulse: " . ($has_pulse ? 'yes' : 'no');
-            $css .= " */ ";
+            $css .= 'Pulse: ' . ( $has_pulse ? 'yes' : 'no' );
+            $css .= ' */ ';
         }
-        
+
         return $css;
     }
-    
+
     public static function get_registered_platform_labels() {
-        $defaults = self::get_default_platform_definitions();
-        $stored = get_option('jlg_platforms_list', []);
+        $defaults  = self::get_default_platform_definitions();
+        $stored    = get_option( 'jlg_platforms_list', array() );
         $platforms = $defaults;
-        $order_map = [];
+        $order_map = array();
 
-        if (is_array($stored)) {
-            if (isset($stored['custom_platforms']) || isset($stored['order'])) {
-                $custom_platforms = isset($stored['custom_platforms']) && is_array($stored['custom_platforms'])
+        if ( is_array( $stored ) ) {
+            if ( isset( $stored['custom_platforms'] ) || isset( $stored['order'] ) ) {
+                $custom_platforms = isset( $stored['custom_platforms'] ) && is_array( $stored['custom_platforms'] )
                     ? $stored['custom_platforms']
-                    : [];
+                    : array();
 
-                foreach ($custom_platforms as $key => $platform) {
-                    if (!is_array($platform)) {
+                foreach ( $custom_platforms as $key => $platform ) {
+                    if ( ! is_array( $platform ) ) {
                         continue;
                     }
 
-                    $name = isset($platform['name']) ? sanitize_text_field($platform['name']) : '';
+                    $name = isset( $platform['name'] ) ? sanitize_text_field( $platform['name'] ) : '';
 
-                    if ($name === '') {
+                    if ( $name === '' ) {
                         continue;
                     }
 
-                    $platforms[$key] = [
+                    $platforms[ $key ] = array(
                         'name'  => $name,
-                        'order' => isset($platform['order']) ? (int) $platform['order'] : (int) (($platforms[$key]['order'] ?? count($platforms) + 1)),
-                    ];
+                        'order' => isset( $platform['order'] ) ? (int) $platform['order'] : (int) ( ( $platforms[ $key ]['order'] ?? count( $platforms ) + 1 ) ),
+                    );
                 }
 
-                if (isset($stored['order']) && is_array($stored['order'])) {
-                    $order_map = array_map('intval', $stored['order']);
+                if ( isset( $stored['order'] ) && is_array( $stored['order'] ) ) {
+                    $order_map = array_map( 'intval', $stored['order'] );
                 }
             } else {
-                foreach ($stored as $key => $platform) {
-                    if (!is_array($platform)) {
+                foreach ( $stored as $key => $platform ) {
+                    if ( ! is_array( $platform ) ) {
                         continue;
                     }
 
-                    $name = isset($platform['name']) ? sanitize_text_field($platform['name']) : '';
+                    $name = isset( $platform['name'] ) ? sanitize_text_field( $platform['name'] ) : '';
 
-                    if ($name === '') {
+                    if ( $name === '' ) {
                         continue;
                     }
 
-                    $platforms[$key] = [
+                    $platforms[ $key ] = array(
                         'name'  => $name,
-                        'order' => isset($platform['order']) ? (int) $platform['order'] : (int) (($defaults[$key]['order'] ?? count($platforms) + 1)),
-                    ];
+                        'order' => isset( $platform['order'] ) ? (int) $platform['order'] : (int) ( ( $defaults[ $key ]['order'] ?? count( $platforms ) + 1 ) ),
+                    );
 
-                    if (isset($platform['order'])) {
-                        $order_map[$key] = (int) $platform['order'];
+                    if ( isset( $platform['order'] ) ) {
+                        $order_map[ $key ] = (int) $platform['order'];
                     }
                 }
             }
         }
 
-        $keys = array_keys($platforms);
+        $keys = array_keys( $platforms );
 
-        usort($keys, function($a, $b) use ($order_map, $platforms) {
-            $order_a = isset($order_map[$a]) ? $order_map[$a] : (int) ($platforms[$a]['order'] ?? PHP_INT_MAX);
-            $order_b = isset($order_map[$b]) ? $order_map[$b] : (int) ($platforms[$b]['order'] ?? PHP_INT_MAX);
+        usort(
+            $keys,
+            function ( $a, $b ) use ( $order_map, $platforms ) {
+				$order_a = isset( $order_map[ $a ] ) ? $order_map[ $a ] : (int) ( $platforms[ $a ]['order'] ?? PHP_INT_MAX );
+				$order_b = isset( $order_map[ $b ] ) ? $order_map[ $b ] : (int) ( $platforms[ $b ]['order'] ?? PHP_INT_MAX );
 
-            if ($order_a === $order_b) {
-                return strcmp((string) $a, (string) $b);
-            }
+				if ( $order_a === $order_b ) {
+					return strcmp( (string) $a, (string) $b );
+				}
 
-            return $order_a <=> $order_b;
-        });
+				return $order_a <=> $order_b;
+			}
+        );
 
-        $labels = [];
+        $labels = array();
 
-        foreach ($keys as $key) {
-            $name = isset($platforms[$key]['name']) ? (string) $platforms[$key]['name'] : '';
+        foreach ( $keys as $key ) {
+            $name = isset( $platforms[ $key ]['name'] ) ? (string) $platforms[ $key ]['name'] : '';
 
-            if ($name === '') {
+            if ( $name === '' ) {
                 continue;
             }
 
-            $labels[$key] = $name;
+            $labels[ $key ] = $name;
         }
 
-        if (empty($labels)) {
-            foreach ($defaults as $key => $platform) {
-                if (isset($platform['name']) && $platform['name'] !== '') {
-                    $labels[$key] = $platform['name'];
+        if ( empty( $labels ) ) {
+            foreach ( $defaults as $key => $platform ) {
+                if ( isset( $platform['name'] ) && $platform['name'] !== '' ) {
+                    $labels[ $key ] = $platform['name'];
                 }
             }
         }
@@ -843,7 +879,7 @@ class JLG_Helpers {
      * Réinitialise toutes les options du plugin
      */
     public static function reset_all_settings() {
-        delete_option(self::$option_name);
+        delete_option( self::$option_name );
         return true;
     }
 }

--- a/plugin-notation-jeux_V4/includes/class-jlg-widget.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-widget.php
@@ -1,74 +1,79 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Latest_Reviews_Widget extends WP_Widget {
 
     public function __construct() {
         parent::__construct(
             'jlg_latest_reviews_widget',
-            __('Notation JLG : Derniers Tests', 'notation-jlg'),
-            ['description' => __('Affiche les derniers articles ayant reçu une note.', 'notation-jlg')]
+            __( 'Notation JLG : Derniers Tests', 'notation-jlg' ),
+            array( 'description' => __( 'Affiche les derniers articles ayant reçu une note.', 'notation-jlg' ) )
         );
     }
 
-    public function widget($args, $instance) {
-        $title = apply_filters('widget_title', $instance['title'] ?? __('Derniers Tests', 'notation-jlg'));
-        $number = (!empty($instance['number'])) ? absint($instance['number']) : 5;
+    public function widget( $args, $instance ) {
+        $title  = apply_filters( 'widget_title', $instance['title'] ?? __( 'Derniers Tests', 'notation-jlg' ) );
+        $number = ( ! empty( $instance['number'] ) ) ? absint( $instance['number'] ) : 5;
 
         $rated_post_ids = JLG_Helpers::get_rated_post_ids();
 
-        if (empty($rated_post_ids)) {
+        if ( empty( $rated_post_ids ) ) {
             echo $args['before_widget'];
-            if (!empty($title)) {
+            if ( ! empty( $title ) ) {
                 echo $args['before_title'] . $title . $args['after_title'];
             }
-            echo '<p>' . esc_html__('Aucun test trouvé.', 'notation-jlg') . '</p>';
+            echo '<p>' . esc_html__( 'Aucun test trouvé.', 'notation-jlg' ) . '</p>';
             echo $args['after_widget'];
             return;
         }
 
-        $query_args = [
-            'post_type' => JLG_Helpers::get_allowed_post_types(),
-            'posts_per_page' => $number,
-            'post__in' => $rated_post_ids,
-            'orderby' => 'date',
-            'order' => 'DESC',
-            'ignore_sticky_posts' => 1
-        ];
-        
-        $latest_reviews = new WP_Query($query_args);
+        $query_args = array(
+            'post_type'           => JLG_Helpers::get_allowed_post_types(),
+            'posts_per_page'      => $number,
+            'post__in'            => $rated_post_ids,
+            'orderby'             => 'date',
+            'order'               => 'DESC',
+            'ignore_sticky_posts' => 1,
+        );
+
+        $latest_reviews = new WP_Query( $query_args );
 
         // Utilisation d'un fichier template pour l'affichage
-        echo JLG_Frontend::get_template_html('widget-latest-reviews', [
-            'widget_args' => $args,
-            'title' => $title,
-            'latest_reviews' => $latest_reviews
-        ]);
+        echo JLG_Frontend::get_template_html(
+            'widget-latest-reviews',
+            array(
+				'widget_args'    => $args,
+				'title'          => $title,
+				'latest_reviews' => $latest_reviews,
+			)
+        );
     }
 
-    public function form($instance) {
-        $title = !empty($instance['title']) ? $instance['title'] : __('Derniers Tests', 'notation-jlg');
-        $number = isset($instance['number']) ? absint($instance['number']) : 5;
+    public function form( $instance ) {
+        $title  = ! empty( $instance['title'] ) ? $instance['title'] : __( 'Derniers Tests', 'notation-jlg' );
+        $number = isset( $instance['number'] ) ? absint( $instance['number'] ) : 5;
         ?>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('title')); ?>"><?php echo esc_html__('Titre :', 'notation-jlg'); ?></label>
-            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>"
-                   name="<?php echo esc_attr($this->get_field_name('title')); ?>"
-                   type="text" value="<?php echo esc_attr($title); ?>">
+            <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php echo esc_html__( 'Titre :', 'notation-jlg' ); ?></label>
+            <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+                    name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+                    type="text" value="<?php echo esc_attr( $title ); ?>">
         </p>
         <p>
-            <label for="<?php echo esc_attr($this->get_field_id('number')); ?>"><?php echo esc_html__('Nombre d\'articles à afficher :', 'notation-jlg'); ?></label>
-            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('number')); ?>"
-                   name="<?php echo esc_attr($this->get_field_name('number')); ?>"
-                   type="number" step="1" min="1" value="<?php echo esc_attr($number); ?>" size="3">
+            <label for="<?php echo esc_attr( $this->get_field_id( 'number' ) ); ?>"><?php echo esc_html__( 'Nombre d\'articles à afficher :', 'notation-jlg' ); ?></label>
+            <input class="tiny-text" id="<?php echo esc_attr( $this->get_field_id( 'number' ) ); ?>"
+                    name="<?php echo esc_attr( $this->get_field_name( 'number' ) ); ?>"
+                    type="number" step="1" min="1" value="<?php echo esc_attr( $number ); ?>" size="3">
         </p>
         <?php
     }
 
-    public function update($new_instance, $old_instance) {
-        $instance = [];
-        $instance['title'] = (!empty($new_instance['title'])) ? strip_tags($new_instance['title']) : '';
-        $instance['number'] = (!empty($new_instance['number'])) ? absint($new_instance['number']) : 5;
+    public function update( $new_instance, $old_instance ) {
+        $instance           = array();
+        $instance['title']  = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+        $instance['number'] = ( ! empty( $new_instance['number'] ) ) ? absint( $new_instance['number'] ) : 5;
         return $instance;
     }
 }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-all-in-one.php
@@ -7,7 +7,9 @@
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_All_In_One {
 
@@ -19,52 +21,55 @@ class JLG_Shortcode_All_In_One {
     private $style_handle = 'jlg-shortcode-all-in-one';
 
     public function __construct() {
-        add_shortcode('jlg_bloc_complet', [$this, 'render']);
-        add_shortcode('bloc_notation_complet', [$this, 'render']); // Alias
-        add_action('wp_enqueue_scripts', [$this, 'register_assets']);
+        add_shortcode( 'jlg_bloc_complet', array( $this, 'render' ) );
+        add_shortcode( 'bloc_notation_complet', array( $this, 'render' ) ); // Alias
+        add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
     }
 
     /**
      * Register assets used by the shortcode.
      */
     public function register_assets() {
-        if (!wp_style_is($this->style_handle, 'registered')) {
+        if ( ! wp_style_is( $this->style_handle, 'registered' ) ) {
             wp_register_style(
                 $this->style_handle,
                 JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-shortcode-all-in-one.css',
-                [],
+                array(),
                 JLG_NOTATION_VERSION
             );
         }
 
-        if (!wp_script_is('jlg-all-in-one', 'registered')) {
+        if ( ! wp_script_is( 'jlg-all-in-one', 'registered' ) ) {
             wp_register_script(
                 'jlg-all-in-one',
                 JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-all-in-one.js',
-                [],
+                array(),
                 JLG_NOTATION_VERSION,
                 true
             );
 
-            $script_settings = apply_filters('jlg_all_in_one_script_settings', [
-                'observerThreshold' => 0.2,
-                'visibleClass'      => 'is-visible',
-                'animationClass'    => 'animate-in',
-            ]);
+            $script_settings = apply_filters(
+                'jlg_all_in_one_script_settings',
+                array(
+					'observerThreshold' => 0.2,
+					'visibleClass'      => 'is-visible',
+					'animationClass'    => 'animate-in',
+				)
+            );
 
-            $inline_settings  = 'window.jlgAllInOneSettings = window.jlgAllInOneSettings || {};' . "\n";
+            $inline_settings = 'window.jlgAllInOneSettings = window.jlgAllInOneSettings || {};' . "\n";
 
-            foreach ($script_settings as $key => $value) {
-                if (!is_string($key) || $key === '') {
+            foreach ( $script_settings as $key => $value ) {
+                if ( ! is_string( $key ) || $key === '' ) {
                     continue;
                 }
 
-                $js_key = preg_replace('/[^A-Za-z0-9_]/', '', $key);
-                if ($js_key === '') {
+                $js_key = preg_replace( '/[^A-Za-z0-9_]/', '', $key );
+                if ( $js_key === '' ) {
                     continue;
                 }
 
-                $encoded_value = wp_json_encode($value);
+                $encoded_value    = wp_json_encode( $value );
                 $inline_settings .= sprintf(
                     'if (typeof window.jlgAllInOneSettings.%1$s === "undefined") { window.jlgAllInOneSettings.%1$s = %2$s; }' . "\n",
                     $js_key,
@@ -72,177 +77,181 @@ class JLG_Shortcode_All_In_One {
                 );
             }
 
-            wp_add_inline_script('jlg-all-in-one', $inline_settings, 'before');
+            wp_add_inline_script( 'jlg-all-in-one', $inline_settings, 'before' );
         }
     }
 
-    public function render($atts, $content = '', $shortcode_tag = '') {
+    public function render( $atts, $content = '', $shortcode_tag = '' ) {
         // Attributs du shortcode
-        $atts = shortcode_atts([
-            'post_id' => get_the_ID(),
-            'afficher_notation' => 'oui',
-            'afficher_points' => 'oui',
-            'afficher_tagline' => 'oui',
-            'titre_points_forts' => 'Points Forts',
-            'titre_points_faibles' => 'Points Faibles',
-            'style' => 'moderne', // moderne, classique, compact
-            'couleur_accent' => '', // Permet de surcharger la couleur d'accent
-        ], $atts, 'jlg_bloc_complet');
+        $atts = shortcode_atts(
+            array(
+				'post_id'              => get_the_ID(),
+				'afficher_notation'    => 'oui',
+				'afficher_points'      => 'oui',
+				'afficher_tagline'     => 'oui',
+				'titre_points_forts'   => 'Points Forts',
+				'titre_points_faibles' => 'Points Faibles',
+				'style'                => 'moderne', // moderne, classique, compact
+				'couleur_accent'       => '', // Permet de surcharger la couleur d'accent
+            ),
+            $atts,
+            'jlg_bloc_complet'
+        );
 
-        $post_id = intval($atts['post_id']);
-        $atts['afficher_notation'] = sanitize_text_field($atts['afficher_notation']);
-        $atts['afficher_points'] = sanitize_text_field($atts['afficher_points']);
-        $atts['afficher_tagline'] = sanitize_text_field($atts['afficher_tagline']);
-        $atts['titre_points_forts'] = sanitize_text_field($atts['titre_points_forts']);
-        $atts['titre_points_faibles'] = sanitize_text_field($atts['titre_points_faibles']);
-        $atts['style'] = sanitize_text_field($atts['style']);
-        $atts['couleur_accent'] = sanitize_hex_color($atts['couleur_accent']);
+        $post_id                      = intval( $atts['post_id'] );
+        $atts['afficher_notation']    = sanitize_text_field( $atts['afficher_notation'] );
+        $atts['afficher_points']      = sanitize_text_field( $atts['afficher_points'] );
+        $atts['afficher_tagline']     = sanitize_text_field( $atts['afficher_tagline'] );
+        $atts['titre_points_forts']   = sanitize_text_field( $atts['titre_points_forts'] );
+        $atts['titre_points_faibles'] = sanitize_text_field( $atts['titre_points_faibles'] );
+        $atts['style']                = sanitize_text_field( $atts['style'] );
+        $atts['couleur_accent']       = sanitize_hex_color( $atts['couleur_accent'] );
 
-        $allowed_styles = ['moderne', 'classique', 'compact'];
-        if (!in_array($atts['style'], $allowed_styles, true)) {
+        $allowed_styles = array( 'moderne', 'classique', 'compact' );
+        if ( ! in_array( $atts['style'], $allowed_styles, true ) ) {
             $atts['style'] = 'moderne';
         }
 
-        if (!$post_id) {
+        if ( ! $post_id ) {
             return '';
         }
 
-        $post = get_post($post_id);
+        $post          = get_post( $post_id );
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        if (!$post instanceof WP_Post || !in_array($post->post_type ?? '', $allowed_types, true)) {
+        if ( ! $post instanceof WP_Post || ! in_array( $post->post_type ?? '', $allowed_types, true ) ) {
             return '';
         }
 
-        if (($post->post_status ?? '') !== 'publish' && !current_user_can('read_post', $post_id)) {
+        if ( ( $post->post_status ?? '' ) !== 'publish' && ! current_user_can( 'read_post', $post_id ) ) {
             return '';
         }
 
         // Vérifier qu'il y a des données à afficher
-        $average_score = JLG_Helpers::get_average_score_for_post($post_id);
-        $tagline_fr = get_post_meta($post_id, '_jlg_tagline_fr', true);
-        $tagline_en = get_post_meta($post_id, '_jlg_tagline_en', true);
-        $pros = get_post_meta($post_id, '_jlg_points_forts', true);
-        $cons = get_post_meta($post_id, '_jlg_points_faibles', true);
+        $average_score = JLG_Helpers::get_average_score_for_post( $post_id );
+        $tagline_fr    = get_post_meta( $post_id, '_jlg_tagline_fr', true );
+        $tagline_en    = get_post_meta( $post_id, '_jlg_tagline_en', true );
+        $pros          = get_post_meta( $post_id, '_jlg_points_forts', true );
+        $cons          = get_post_meta( $post_id, '_jlg_points_faibles', true );
 
         // Si aucune donnée, ne rien afficher
-        if ($average_score === null && empty($tagline_fr) && empty($tagline_en) && empty($pros) && empty($cons)) {
+        if ( $average_score === null && empty( $tagline_fr ) && empty( $tagline_en ) && empty( $pros ) && empty( $cons ) ) {
             return '';
         }
 
         // Récupération des options et configuration
-        $options = JLG_Helpers::get_plugin_options();
-        $palette = JLG_Helpers::get_color_palette();
+        $options    = JLG_Helpers::get_plugin_options();
+        $palette    = JLG_Helpers::get_color_palette();
         $categories = JLG_Helpers::get_rating_categories();
-        $defaults = JLG_Helpers::get_default_settings();
+        $defaults   = JLG_Helpers::get_default_settings();
 
         // Couleur d'accent (utilise la couleur définie ou celle des options)
-        $accent_color = $atts['couleur_accent'] ?: ($options['score_gradient_1'] ?? '');
-        $accent_color = sanitize_hex_color($accent_color);
-        if (empty($accent_color)) {
-            $accent_color = sanitize_hex_color($defaults['score_gradient_1']);
+        $accent_color = $atts['couleur_accent'] ?: ( $options['score_gradient_1'] ?? '' );
+        $accent_color = sanitize_hex_color( $accent_color );
+        if ( empty( $accent_color ) ) {
+            $accent_color = sanitize_hex_color( $defaults['score_gradient_1'] );
         }
 
-        $score_gradient_1 = sanitize_hex_color($options['score_gradient_1'] ?? '');
-        if (empty($score_gradient_1)) {
-            $score_gradient_1 = sanitize_hex_color($defaults['score_gradient_1']);
+        $score_gradient_1 = sanitize_hex_color( $options['score_gradient_1'] ?? '' );
+        if ( empty( $score_gradient_1 ) ) {
+            $score_gradient_1 = sanitize_hex_color( $defaults['score_gradient_1'] );
         }
 
-        $score_gradient_2 = sanitize_hex_color($options['score_gradient_2'] ?? '');
-        if (empty($score_gradient_2)) {
-            $score_gradient_2 = sanitize_hex_color($defaults['score_gradient_2']);
+        $score_gradient_2 = sanitize_hex_color( $options['score_gradient_2'] ?? '' );
+        if ( empty( $score_gradient_2 ) ) {
+            $score_gradient_2 = sanitize_hex_color( $defaults['score_gradient_2'] );
         }
 
-        $color_high = sanitize_hex_color($options['color_high'] ?? '');
-        if (empty($color_high)) {
-            $color_high = sanitize_hex_color($defaults['color_high']);
+        $color_high = sanitize_hex_color( $options['color_high'] ?? '' );
+        if ( empty( $color_high ) ) {
+            $color_high = sanitize_hex_color( $defaults['color_high'] );
         }
 
-        $color_low = sanitize_hex_color($options['color_low'] ?? '');
-        if (empty($color_low)) {
-            $color_low = sanitize_hex_color($defaults['color_low']);
+        $color_low = sanitize_hex_color( $options['color_low'] ?? '' );
+        if ( empty( $color_low ) ) {
+            $color_low = sanitize_hex_color( $defaults['color_low'] );
         }
 
         // Récupérer les scores détaillés
-        $scores = [];
-        if ($average_score !== null) {
-            foreach (array_keys($categories) as $key) {
-                $score_value = get_post_meta($post_id, '_note_' . $key, true);
-                if ($score_value !== '' && is_numeric($score_value)) {
-                    $scores[$key] = floatval($score_value);
+        $scores = array();
+        if ( $average_score !== null ) {
+            foreach ( array_keys( $categories ) as $key ) {
+                $score_value = get_post_meta( $post_id, '_note_' . $key, true );
+                if ( $score_value !== '' && is_numeric( $score_value ) ) {
+                    $scores[ $key ] = floatval( $score_value );
                 }
             }
         }
 
         // Préparer les listes de points
-        $pros_list = !empty($pros) ? array_filter(array_map('trim', explode("\n", $pros))) : [];
-        $cons_list = !empty($cons) ? array_filter(array_map('trim', explode("\n", $cons))) : [];
+        $pros_list = ! empty( $pros ) ? array_filter( array_map( 'trim', explode( "\n", $pros ) ) ) : array();
+        $cons_list = ! empty( $cons ) ? array_filter( array_map( 'trim', explode( "\n", $cons ) ) ) : array();
 
         // Enregistrer/charger la feuille de style
-        if (!wp_style_is($this->style_handle, 'registered') || !wp_script_is('jlg-all-in-one', 'registered')) {
+        if ( ! wp_style_is( $this->style_handle, 'registered' ) || ! wp_script_is( 'jlg-all-in-one', 'registered' ) ) {
             $this->register_assets();
         }
-        wp_enqueue_style($this->style_handle);
-        wp_enqueue_script('jlg-all-in-one');
+        wp_enqueue_style( $this->style_handle );
+        wp_enqueue_script( 'jlg-all-in-one' );
 
-        $tagline_font_size = isset($options['tagline_font_size']) ? absint($options['tagline_font_size']) : 16;
-        if ($tagline_font_size <= 0) {
-            $tagline_font_size = absint($defaults['tagline_font_size']);
+        $tagline_font_size = isset( $options['tagline_font_size'] ) ? absint( $options['tagline_font_size'] ) : 16;
+        if ( $tagline_font_size <= 0 ) {
+            $tagline_font_size = absint( $defaults['tagline_font_size'] );
         }
 
         $score_layout = $options['score_layout'] ?? 'text';
 
-        $css_variables = [
-            '--jlg-aio-bg' => $palette['bg_color'] ?? '',
-            '--jlg-aio-bg-secondary' => $palette['bg_color_secondary'] ?? '',
-            '--jlg-aio-border-color' => $palette['border_color'] ?? '',
-            '--jlg-aio-text-color' => $palette['text_color'] ?? '',
-            '--jlg-aio-text-color-secondary' => $palette['text_color_secondary'] ?? '',
-            '--jlg-aio-header-bg' => $this->build_header_background($accent_color, $score_gradient_2 ?: $score_gradient_1),
-            '--jlg-aio-tagline-font-size' => $tagline_font_size . 'px',
-            '--jlg-aio-tagline-color' => $palette['text_color'] ?? '',
-            '--jlg-aio-score-gradient' => $this->build_score_gradient($accent_color, $score_gradient_2 ?: $score_gradient_1),
-            '--jlg-aio-score-label-color' => $palette['text_color_secondary'] ?? '',
-            '--jlg-aio-score-number-color' => $palette['text_color_secondary'] ?? '',
-            '--jlg-aio-bar-bg' => $palette['bg_color_secondary'] ?? '',
-            '--jlg-aio-points-divider' => $palette['border_color'] ?? '',
-            '--jlg-aio-points-bg' => $palette['bg_color'] ?? '',
-            '--jlg-aio-points-title-color' => $palette['text_color'] ?? '',
+        $css_variables = array(
+            '--jlg-aio-bg'                    => $palette['bg_color'] ?? '',
+            '--jlg-aio-bg-secondary'          => $palette['bg_color_secondary'] ?? '',
+            '--jlg-aio-border-color'          => $palette['border_color'] ?? '',
+            '--jlg-aio-text-color'            => $palette['text_color'] ?? '',
+            '--jlg-aio-text-color-secondary'  => $palette['text_color_secondary'] ?? '',
+            '--jlg-aio-header-bg'             => $this->build_header_background( $accent_color, $score_gradient_2 ?: $score_gradient_1 ),
+            '--jlg-aio-tagline-font-size'     => $tagline_font_size . 'px',
+            '--jlg-aio-tagline-color'         => $palette['text_color'] ?? '',
+            '--jlg-aio-score-gradient'        => $this->build_score_gradient( $accent_color, $score_gradient_2 ?: $score_gradient_1 ),
+            '--jlg-aio-score-label-color'     => $palette['text_color_secondary'] ?? '',
+            '--jlg-aio-score-number-color'    => $palette['text_color_secondary'] ?? '',
+            '--jlg-aio-bar-bg'                => $palette['bg_color_secondary'] ?? '',
+            '--jlg-aio-points-divider'        => $palette['border_color'] ?? '',
+            '--jlg-aio-points-bg'             => $palette['bg_color'] ?? '',
+            '--jlg-aio-points-title-color'    => $palette['text_color'] ?? '',
             '--jlg-aio-points-text-secondary' => $palette['text_color_secondary'] ?? '',
-            '--jlg-aio-pros-icon-bg' => $this->hex_to_rgba($color_high, 0.125),
-            '--jlg-aio-pros-icon-color' => $color_high,
-            '--jlg-aio-cons-icon-bg' => $this->hex_to_rgba($color_low, 0.125),
-            '--jlg-aio-cons-icon-color' => $color_low,
-            '--jlg-aio-circle-border' => 'none',
-            '--jlg-aio-circle-shadow' => $this->build_circle_shadow($accent_color),
-        ];
+            '--jlg-aio-pros-icon-bg'          => $this->hex_to_rgba( $color_high, 0.125 ),
+            '--jlg-aio-pros-icon-color'       => $color_high,
+            '--jlg-aio-cons-icon-bg'          => $this->hex_to_rgba( $color_low, 0.125 ),
+            '--jlg-aio-cons-icon-color'       => $color_low,
+            '--jlg-aio-circle-border'         => 'none',
+            '--jlg-aio-circle-shadow'         => $this->build_circle_shadow( $accent_color ),
+        );
 
-        if ($score_layout === 'circle') {
-            $css_variables['--jlg-aio-circle-bg'] = $this->build_circle_background($options, $accent_color, $average_score, $score_gradient_2 ?: $score_gradient_1);
-            $css_variables['--jlg-aio-circle-border'] = $this->build_circle_border($options, $defaults);
+        if ( $score_layout === 'circle' ) {
+            $css_variables['--jlg-aio-circle-bg']     = $this->build_circle_background( $options, $accent_color, $average_score, $score_gradient_2 ?: $score_gradient_1 );
+            $css_variables['--jlg-aio-circle-border'] = $this->build_circle_border( $options, $defaults );
         }
 
         // Effet Glow/Neon
-        if ($score_layout !== 'circle' && !empty($options['text_glow_enabled'])) {
-            $glow_mode = isset($options['text_glow_color_mode']) ? $options['text_glow_color_mode'] : 'dynamic';
+        if ( $score_layout !== 'circle' && ! empty( $options['text_glow_enabled'] ) ) {
+            $glow_mode = isset( $options['text_glow_color_mode'] ) ? $options['text_glow_color_mode'] : 'dynamic';
 
-            if ($glow_mode === 'dynamic' && $average_score !== null) {
-                $glow_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
+            if ( $glow_mode === 'dynamic' && $average_score !== null ) {
+                $glow_color = JLG_Helpers::calculate_color_from_note( $average_score, $options );
             } else {
-                $glow_color = isset($options['text_glow_custom_color']) ? $options['text_glow_custom_color'] : '#60a5fa';
+                $glow_color = isset( $options['text_glow_custom_color'] ) ? $options['text_glow_custom_color'] : '#60a5fa';
             }
 
-            if (!preg_match('/^#[0-9A-Fa-f]{6}$/', (string) $glow_color)) {
+            if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', (string) $glow_color ) ) {
                 $glow_color = '#60a5fa';
             }
 
-            $intensity = isset($options['text_glow_intensity']) ? max(0, intval($options['text_glow_intensity'])) : 15;
-            $has_pulse = !empty($options['text_glow_pulse']);
-            $speed = isset($options['text_glow_speed']) ? floatval($options['text_glow_speed']) : 2.5;
+            $intensity = isset( $options['text_glow_intensity'] ) ? max( 0, intval( $options['text_glow_intensity'] ) ) : 15;
+            $has_pulse = ! empty( $options['text_glow_pulse'] );
+            $speed     = isset( $options['text_glow_speed'] ) ? floatval( $options['text_glow_speed'] ) : 2.5;
 
-            $s1 = round($intensity * 0.5);
+            $s1 = round( $intensity * 0.5 );
             $s2 = $intensity;
-            $s3 = round($intensity * 1.5);
+            $s3 = round( $intensity * 1.5 );
 
             $css_variables['--jlg-aio-text-shadow'] = sprintf(
                 '0 0 %1$spx %4$s, 0 0 %2$spx %4$s, 0 0 %3$spx %4$s',
@@ -252,40 +261,40 @@ class JLG_Shortcode_All_In_One {
                 $glow_color
             );
 
-            if ($has_pulse) {
-                $ps1 = round($intensity * 0.7);
-                $ps2 = round($intensity * 1.5);
-                $ps3 = round($intensity * 2.5);
+            if ( $has_pulse ) {
+                $ps1 = round( $intensity * 0.7 );
+                $ps2 = round( $intensity * 1.5 );
+                $ps3 = round( $intensity * 2.5 );
 
                 $css_variables['--jlg-aio-text-glow-color'] = $glow_color;
-                $css_variables['--jlg-aio-text-glow-s1'] = $s1 . 'px';
-                $css_variables['--jlg-aio-text-glow-s2'] = $s2 . 'px';
-                $css_variables['--jlg-aio-text-glow-s3'] = $s3 . 'px';
-                $css_variables['--jlg-aio-text-glow-ps1'] = $ps1 . 'px';
-                $css_variables['--jlg-aio-text-glow-ps2'] = $ps2 . 'px';
-                $css_variables['--jlg-aio-text-glow-ps3'] = $ps3 . 'px';
-                $css_variables['--jlg-aio-text-animation'] = 'jlg-aio-text-glow-pulse ' . $speed . 's infinite ease-in-out';
+                $css_variables['--jlg-aio-text-glow-s1']    = $s1 . 'px';
+                $css_variables['--jlg-aio-text-glow-s2']    = $s2 . 'px';
+                $css_variables['--jlg-aio-text-glow-s3']    = $s3 . 'px';
+                $css_variables['--jlg-aio-text-glow-ps1']   = $ps1 . 'px';
+                $css_variables['--jlg-aio-text-glow-ps2']   = $ps2 . 'px';
+                $css_variables['--jlg-aio-text-glow-ps3']   = $ps3 . 'px';
+                $css_variables['--jlg-aio-text-animation']  = 'jlg-aio-text-glow-pulse ' . $speed . 's infinite ease-in-out';
             }
-        } elseif ($score_layout === 'circle' && !empty($options['circle_glow_enabled'])) {
-            $glow_mode = isset($options['circle_glow_color_mode']) ? $options['circle_glow_color_mode'] : 'dynamic';
+        } elseif ( $score_layout === 'circle' && ! empty( $options['circle_glow_enabled'] ) ) {
+            $glow_mode = isset( $options['circle_glow_color_mode'] ) ? $options['circle_glow_color_mode'] : 'dynamic';
 
-            if ($glow_mode === 'dynamic' && $average_score !== null) {
-                $glow_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
+            if ( $glow_mode === 'dynamic' && $average_score !== null ) {
+                $glow_color = JLG_Helpers::calculate_color_from_note( $average_score, $options );
             } else {
-                $glow_color = isset($options['circle_glow_custom_color']) ? $options['circle_glow_custom_color'] : '#60a5fa';
+                $glow_color = isset( $options['circle_glow_custom_color'] ) ? $options['circle_glow_custom_color'] : '#60a5fa';
             }
 
-            if (!preg_match('/^#[0-9A-Fa-f]{6}$/', (string) $glow_color)) {
+            if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', (string) $glow_color ) ) {
                 $glow_color = '#60a5fa';
             }
 
-            $intensity = isset($options['circle_glow_intensity']) ? max(0, intval($options['circle_glow_intensity'])) : 15;
-            $has_pulse = !empty($options['circle_glow_pulse']);
-            $speed = isset($options['circle_glow_speed']) ? floatval($options['circle_glow_speed']) : 2.5;
+            $intensity = isset( $options['circle_glow_intensity'] ) ? max( 0, intval( $options['circle_glow_intensity'] ) ) : 15;
+            $has_pulse = ! empty( $options['circle_glow_pulse'] );
+            $speed     = isset( $options['circle_glow_speed'] ) ? floatval( $options['circle_glow_speed'] ) : 2.5;
 
-            $s1 = round($intensity * 0.5);
+            $s1 = round( $intensity * 0.5 );
             $s2 = $intensity;
-            $s3 = round($intensity * 1.5);
+            $s3 = round( $intensity * 1.5 );
 
             $css_variables['--jlg-aio-circle-shadow'] = sprintf(
                 '0 0 %1$spx %4$s, 0 0 %2$spx %4$s, 0 0 %3$spx %4$s, inset 0 0 %1$spx rgba(255,255,255,0.1)',
@@ -295,171 +304,174 @@ class JLG_Shortcode_All_In_One {
                 $glow_color
             );
 
-            if ($has_pulse) {
-                $ps1 = round($intensity * 0.7);
-                $ps2 = round($intensity * 1.5);
-                $ps3 = round($intensity * 2.5);
+            if ( $has_pulse ) {
+                $ps1 = round( $intensity * 0.7 );
+                $ps2 = round( $intensity * 1.5 );
+                $ps3 = round( $intensity * 2.5 );
 
                 $css_variables['--jlg-aio-circle-glow-color'] = $glow_color;
-                $css_variables['--jlg-aio-circle-glow-s1'] = $s1 . 'px';
-                $css_variables['--jlg-aio-circle-glow-s2'] = $s2 . 'px';
-                $css_variables['--jlg-aio-circle-glow-s3'] = $s3 . 'px';
-                $css_variables['--jlg-aio-circle-glow-ps1'] = $ps1 . 'px';
-                $css_variables['--jlg-aio-circle-glow-ps2'] = $ps2 . 'px';
-                $css_variables['--jlg-aio-circle-glow-ps3'] = $ps3 . 'px';
-                $css_variables['--jlg-aio-circle-animation'] = 'jlg-aio-circle-glow-pulse ' . $speed . 's infinite ease-in-out';
+                $css_variables['--jlg-aio-circle-glow-s1']    = $s1 . 'px';
+                $css_variables['--jlg-aio-circle-glow-s2']    = $s2 . 'px';
+                $css_variables['--jlg-aio-circle-glow-s3']    = $s3 . 'px';
+                $css_variables['--jlg-aio-circle-glow-ps1']   = $ps1 . 'px';
+                $css_variables['--jlg-aio-circle-glow-ps2']   = $ps2 . 'px';
+                $css_variables['--jlg-aio-circle-glow-ps3']   = $ps3 . 'px';
+                $css_variables['--jlg-aio-circle-animation']  = 'jlg-aio-circle-glow-pulse ' . $speed . 's infinite ease-in-out';
             }
         }
 
-        $block_classes = [
+        $block_classes = array(
             'jlg-all-in-one-block',
             'style-' . $atts['style'],
-        ];
+        );
 
-        if (!empty($options['enable_animations'])) {
+        if ( ! empty( $options['enable_animations'] ) ) {
             $block_classes[] = 'animate-in';
         }
 
-        $block_classes = implode(' ', array_map('sanitize_html_class', array_filter($block_classes)));
+        $block_classes = implode( ' ', array_map( 'sanitize_html_class', array_filter( $block_classes ) ) );
 
-        $css_variables_string = $this->format_css_variables($css_variables);
+        $css_variables_string = $this->format_css_variables( $css_variables );
 
         $tag = $shortcode_tag !== '' ? $shortcode_tag : 'jlg_bloc_complet';
-        JLG_Frontend::mark_shortcode_rendered($tag);
+        JLG_Frontend::mark_shortcode_rendered( $tag );
 
-        return JLG_Frontend::get_template_html('shortcode-all-in-one', [
-            'options' => $options,
-            'average_score' => $average_score,
-            'scores' => $scores,
-            'categories' => $categories,
-            'pros_list' => $pros_list,
-            'cons_list' => $cons_list,
-            'tagline_fr' => $tagline_fr,
-            'tagline_en' => $tagline_en,
-            'atts' => $atts,
-            'block_classes' => $block_classes,
-            'css_variables' => $css_variables_string,
-            'score_layout' => $score_layout,
-            'animations_enabled' => !empty($options['enable_animations']),
-        ]);
+        return JLG_Frontend::get_template_html(
+            'shortcode-all-in-one',
+            array(
+				'options'            => $options,
+				'average_score'      => $average_score,
+				'scores'             => $scores,
+				'categories'         => $categories,
+				'pros_list'          => $pros_list,
+				'cons_list'          => $cons_list,
+				'tagline_fr'         => $tagline_fr,
+				'tagline_en'         => $tagline_en,
+				'atts'               => $atts,
+				'block_classes'      => $block_classes,
+				'css_variables'      => $css_variables_string,
+				'score_layout'       => $score_layout,
+				'animations_enabled' => ! empty( $options['enable_animations'] ),
+			)
+        );
     }
 
     /**
      * Convert an hex color to rgba string with alpha.
      */
-    private function hex_to_rgba($hex, $alpha) {
-        $hex = sanitize_hex_color($hex);
-        if (empty($hex)) {
+    private function hex_to_rgba( $hex, $alpha ) {
+        $hex = sanitize_hex_color( $hex );
+        if ( empty( $hex ) ) {
             return '';
         }
 
-        $alpha = max(0, min(1, floatval($alpha)));
+        $alpha = max( 0, min( 1, floatval( $alpha ) ) );
 
-        $hex = ltrim($hex, '#');
-        if (strlen($hex) === 3) {
-            $hex = substr($hex, 0, 1) . substr($hex, 0, 1)
-                 . substr($hex, 1, 1) . substr($hex, 1, 1)
-                 . substr($hex, 2, 1) . substr($hex, 2, 1);
+        $hex = ltrim( $hex, '#' );
+        if ( strlen( $hex ) === 3 ) {
+            $hex = substr( $hex, 0, 1 ) . substr( $hex, 0, 1 )
+                . substr( $hex, 1, 1 ) . substr( $hex, 1, 1 )
+                . substr( $hex, 2, 1 ) . substr( $hex, 2, 1 );
         }
 
-        if (strlen($hex) !== 6) {
+        if ( strlen( $hex ) !== 6 ) {
             return '';
         }
 
-        $r = hexdec(substr($hex, 0, 2));
-        $g = hexdec(substr($hex, 2, 2));
-        $b = hexdec(substr($hex, 4, 2));
+        $r = hexdec( substr( $hex, 0, 2 ) );
+        $g = hexdec( substr( $hex, 2, 2 ) );
+        $b = hexdec( substr( $hex, 4, 2 ) );
 
-        return sprintf('rgba(%d, %d, %d, %s)', $r, $g, $b, $alpha);
+        return sprintf( 'rgba(%d, %d, %d, %s)', $r, $g, $b, $alpha );
     }
 
-    private function build_header_background($accent_color, $secondary_color) {
-        $start = $this->hex_to_rgba($accent_color, 0.08);
-        $end = $this->hex_to_rgba($secondary_color, 0.06);
+    private function build_header_background( $accent_color, $secondary_color ) {
+        $start = $this->hex_to_rgba( $accent_color, 0.08 );
+        $end   = $this->hex_to_rgba( $secondary_color, 0.06 );
 
-        if ($start && $end) {
+        if ( $start && $end ) {
             return 'linear-gradient(135deg, ' . $start . ' 0%, ' . $end . ' 100%)';
         }
 
         return '';
     }
 
-    private function build_score_gradient($from_color, $to_color) {
-        $from_color = sanitize_hex_color($from_color);
-        $to_color = sanitize_hex_color($to_color);
+    private function build_score_gradient( $from_color, $to_color ) {
+        $from_color = sanitize_hex_color( $from_color );
+        $to_color   = sanitize_hex_color( $to_color );
 
-        if ($from_color && $to_color) {
+        if ( $from_color && $to_color ) {
             return 'linear-gradient(135deg, ' . $from_color . ', ' . $to_color . ')';
         }
 
         return '';
     }
 
-    private function build_circle_background($options, $accent_color, $average_score, $fallback_color) {
-        if (($options['score_layout'] ?? 'text') !== 'circle') {
+    private function build_circle_background( $options, $accent_color, $average_score, $fallback_color ) {
+        if ( ( $options['score_layout'] ?? 'text' ) !== 'circle' ) {
             return '';
         }
 
-        if (!empty($options['circle_dynamic_bg_enabled']) && $average_score !== null) {
-            $dynamic_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
-            $dynamic_color = sanitize_hex_color($dynamic_color);
-            $darker_color = $dynamic_color ? JLG_Helpers::adjust_hex_brightness($dynamic_color, -30) : '';
-            $darker_color = sanitize_hex_color($darker_color);
+        if ( ! empty( $options['circle_dynamic_bg_enabled'] ) && $average_score !== null ) {
+            $dynamic_color = JLG_Helpers::calculate_color_from_note( $average_score, $options );
+            $dynamic_color = sanitize_hex_color( $dynamic_color );
+            $darker_color  = $dynamic_color ? JLG_Helpers::adjust_hex_brightness( $dynamic_color, -30 ) : '';
+            $darker_color  = sanitize_hex_color( $darker_color );
 
-            if ($dynamic_color && $darker_color) {
+            if ( $dynamic_color && $darker_color ) {
                 return 'linear-gradient(135deg, ' . $dynamic_color . ', ' . $darker_color . ')';
             }
         }
 
-        $accent = sanitize_hex_color($accent_color);
-        $fallback = sanitize_hex_color($fallback_color);
+        $accent   = sanitize_hex_color( $accent_color );
+        $fallback = sanitize_hex_color( $fallback_color );
 
-        if ($accent && $fallback) {
+        if ( $accent && $fallback ) {
             return 'linear-gradient(135deg, ' . $accent . ', ' . $fallback . ')';
         }
 
         return '';
     }
 
-    private function build_circle_shadow($accent_color) {
-        $rgba = $this->hex_to_rgba($accent_color, 0.25);
-        if ($rgba) {
+    private function build_circle_shadow( $accent_color ) {
+        $rgba = $this->hex_to_rgba( $accent_color, 0.25 );
+        if ( $rgba ) {
             return '0 10px 25px -5px ' . $rgba;
         }
 
         return 'none';
     }
 
-    private function build_circle_border($options, $defaults) {
-        if (empty($options['circle_border_enabled'])) {
+    private function build_circle_border( $options, $defaults ) {
+        if ( empty( $options['circle_border_enabled'] ) ) {
             return 'none';
         }
 
-        $width = isset($options['circle_border_width']) ? absint($options['circle_border_width']) : absint($defaults['circle_border_width']);
-        $color = sanitize_hex_color($options['circle_border_color'] ?? '');
-        if (empty($color)) {
-            $color = sanitize_hex_color($defaults['circle_border_color']);
+        $width = isset( $options['circle_border_width'] ) ? absint( $options['circle_border_width'] ) : absint( $defaults['circle_border_width'] );
+        $color = sanitize_hex_color( $options['circle_border_color'] ?? '' );
+        if ( empty( $color ) ) {
+            $color = sanitize_hex_color( $defaults['circle_border_color'] );
         }
 
-        if ($width > 0 && $color) {
+        if ( $width > 0 && $color ) {
             return $width . 'px solid ' . $color;
         }
 
         return 'none';
     }
 
-    private function format_css_variables(array $variables) {
-        $declarations = [];
+    private function format_css_variables( array $variables ) {
+        $declarations = array();
 
-        foreach ($variables as $name => $value) {
-            if ($value === null || $value === '') {
+        foreach ( $variables as $name => $value ) {
+            if ( $value === null || $value === '' ) {
                 continue;
             }
 
             $declarations[] = $name . ': ' . $value;
         }
 
-        return implode('; ', $declarations);
+        return implode( '; ', $declarations );
     }
 }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -1,18 +1,20 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Game_Explorer {
 
-    private const SNAPSHOT_TRANSIENT_KEY = 'jlg_game_explorer_snapshot_v1';
-    private const SNAPSHOT_RELEVANT_META_KEYS = [
+    private const SNAPSHOT_TRANSIENT_KEY      = 'jlg_game_explorer_snapshot_v1';
+    private const SNAPSHOT_RELEVANT_META_KEYS = array(
         '_jlg_game_title',
         '_jlg_developpeur',
         '_jlg_editeur',
         '_jlg_plateformes',
         '_jlg_date_sortie',
-    ];
+    );
 
-    private const REQUEST_KEYS = [
+    private const REQUEST_KEYS = array(
         'orderby',
         'order',
         'letter',
@@ -21,158 +23,158 @@ class JLG_Shortcode_Game_Explorer {
         'availability',
         'search',
         'paged',
-    ];
+    );
 
     /** @var array<string, mixed>|null */
     private static $filters_snapshot = null;
 
     public static function clear_filters_snapshot() {
-        delete_transient(self::SNAPSHOT_TRANSIENT_KEY);
+        delete_transient( self::SNAPSHOT_TRANSIENT_KEY );
         self::$filters_snapshot = null;
     }
 
-    public static function maybe_clear_filters_snapshot_for_meta($meta_id, $post_id, $meta_key, $meta_value = null) {
-        unset($meta_id, $meta_value);
+    public static function maybe_clear_filters_snapshot_for_meta( $meta_id, $post_id, $meta_key, $meta_value = null ) {
+        unset( $meta_id, $meta_value );
 
-        if (!is_string($meta_key) || $meta_key === '') {
+        if ( ! is_string( $meta_key ) || $meta_key === '' ) {
             return;
         }
 
-        if (!self::is_snapshot_relevant_meta_key($meta_key)) {
+        if ( ! self::is_snapshot_relevant_meta_key( $meta_key ) ) {
             return;
         }
 
-        $post = self::resolve_post($post_id);
-        if (!self::should_invalidate_for_post($post)) {
-            return;
-        }
-
-        self::clear_filters_snapshot();
-    }
-
-    public static function maybe_clear_filters_snapshot_for_post($post_id, $post, $update) {
-        unset($post_id, $update);
-
-        if (!self::should_invalidate_for_post($post)) {
-            return;
-        }
-
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-            return;
-        }
-
-        if (function_exists('wp_is_post_autosave') && wp_is_post_autosave($post->ID ?? 0)) {
-            return;
-        }
-
-        if (function_exists('wp_is_post_revision') && wp_is_post_revision($post->ID ?? 0)) {
+        $post = self::resolve_post( $post_id );
+        if ( ! self::should_invalidate_for_post( $post ) ) {
             return;
         }
 
         self::clear_filters_snapshot();
     }
 
-    public static function maybe_clear_filters_snapshot_for_status_change($new_status, $old_status, $post) {
-        if (!self::is_snapshot_supported_post($post)) {
+    public static function maybe_clear_filters_snapshot_for_post( $post_id, $post, $update ) {
+        unset( $post_id, $update );
+
+        if ( ! self::should_invalidate_for_post( $post ) ) {
             return;
         }
 
-        if ($new_status === $old_status) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
             return;
         }
 
-        if ($new_status === 'publish' || $old_status === 'publish') {
+        if ( function_exists( 'wp_is_post_autosave' ) && wp_is_post_autosave( $post->ID ?? 0 ) ) {
+            return;
+        }
+
+        if ( function_exists( 'wp_is_post_revision' ) && wp_is_post_revision( $post->ID ?? 0 ) ) {
+            return;
+        }
+
+        self::clear_filters_snapshot();
+    }
+
+    public static function maybe_clear_filters_snapshot_for_status_change( $new_status, $old_status, $post ) {
+        if ( ! self::is_snapshot_supported_post( $post ) ) {
+            return;
+        }
+
+        if ( $new_status === $old_status ) {
+            return;
+        }
+
+        if ( $new_status === 'publish' || $old_status === 'publish' ) {
             self::clear_filters_snapshot();
         }
     }
 
-    public static function maybe_clear_filters_snapshot_for_terms($object_id, $terms, $tt_ids, $taxonomy) {
-        unset($terms, $tt_ids);
+    public static function maybe_clear_filters_snapshot_for_terms( $object_id, $terms, $tt_ids, $taxonomy ) {
+        unset( $terms, $tt_ids );
 
-        if (!is_string($taxonomy) || $taxonomy !== 'category') {
+        if ( ! is_string( $taxonomy ) || $taxonomy !== 'category' ) {
             return;
         }
 
-        $post = self::resolve_post($object_id);
-        if (!self::should_invalidate_for_post($post)) {
-            return;
-        }
-
-        self::clear_filters_snapshot();
-    }
-
-    public static function maybe_clear_filters_snapshot_for_term_event($term, $tt_id = null, $taxonomy = '', $deleted_term = null) {
-        unset($tt_id, $deleted_term);
-
-        $resolved_taxonomy = self::resolve_taxonomy_from_term_event($term, $taxonomy, $deleted_term);
-
-        if ($resolved_taxonomy !== 'category') {
+        $post = self::resolve_post( $object_id );
+        if ( ! self::should_invalidate_for_post( $post ) ) {
             return;
         }
 
         self::clear_filters_snapshot();
     }
 
-    private static function is_snapshot_relevant_meta_key($meta_key) {
-        return in_array($meta_key, self::SNAPSHOT_RELEVANT_META_KEYS, true);
+    public static function maybe_clear_filters_snapshot_for_term_event( $term, $tt_id = null, $taxonomy = '', $deleted_term = null ) {
+        unset( $tt_id, $deleted_term );
+
+        $resolved_taxonomy = self::resolve_taxonomy_from_term_event( $term, $taxonomy, $deleted_term );
+
+        if ( $resolved_taxonomy !== 'category' ) {
+            return;
+        }
+
+        self::clear_filters_snapshot();
     }
 
-    private static function resolve_post($post) {
-        if ($post instanceof WP_Post) {
+    private static function is_snapshot_relevant_meta_key( $meta_key ) {
+        return in_array( $meta_key, self::SNAPSHOT_RELEVANT_META_KEYS, true );
+    }
+
+    private static function resolve_post( $post ) {
+        if ( $post instanceof WP_Post ) {
             return $post;
         }
 
-        $post_id = is_numeric($post) ? (int) $post : 0;
-        if ($post_id <= 0) {
+        $post_id = is_numeric( $post ) ? (int) $post : 0;
+        if ( $post_id <= 0 ) {
             return null;
         }
 
-        $resolved = get_post($post_id);
+        $resolved = get_post( $post_id );
 
         return $resolved instanceof WP_Post ? $resolved : null;
     }
 
-    private static function should_invalidate_for_post($post) {
-        if (!$post instanceof WP_Post) {
+    private static function should_invalidate_for_post( $post ) {
+        if ( ! $post instanceof WP_Post ) {
             return false;
         }
 
-        if (!self::is_snapshot_supported_post($post)) {
+        if ( ! self::is_snapshot_supported_post( $post ) ) {
             return false;
         }
 
-        return ($post->post_status ?? '') === 'publish';
+        return ( $post->post_status ?? '' ) === 'publish';
     }
 
-    private static function is_snapshot_supported_post($post) {
-        if (!$post instanceof WP_Post) {
+    private static function is_snapshot_supported_post( $post ) {
+        if ( ! $post instanceof WP_Post ) {
             return false;
         }
 
-        $post_type = isset($post->post_type) ? (string) $post->post_type : '';
-        if ($post_type === '') {
+        $post_type = isset( $post->post_type ) ? (string) $post->post_type : '';
+        if ( $post_type === '' ) {
             return false;
         }
 
-        if (!class_exists('JLG_Helpers')) {
+        if ( ! class_exists( 'JLG_Helpers' ) ) {
             return false;
         }
 
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        return in_array($post_type, $allowed_types, true);
+        return in_array( $post_type, $allowed_types, true );
     }
 
-    private static function resolve_taxonomy_from_term_event($term, $taxonomy, $deleted_term) {
-        if (is_object($term) && isset($term->taxonomy)) {
+    private static function resolve_taxonomy_from_term_event( $term, $taxonomy, $deleted_term ) {
+        if ( is_object( $term ) && isset( $term->taxonomy ) ) {
             return (string) $term->taxonomy;
         }
 
-        if (is_object($deleted_term) && isset($deleted_term->taxonomy)) {
+        if ( is_object( $deleted_term ) && isset( $deleted_term->taxonomy ) ) {
             return (string) $deleted_term->taxonomy;
         }
 
-        if (is_string($taxonomy) && $taxonomy !== '') {
+        if ( is_string( $taxonomy ) && $taxonomy !== '' ) {
             return $taxonomy;
         }
 
@@ -180,36 +182,36 @@ class JLG_Shortcode_Game_Explorer {
     }
 
     public function __construct() {
-        add_shortcode('jlg_game_explorer', [$this, 'render']);
+        add_shortcode( 'jlg_game_explorer', array( $this, 'render' ) );
     }
 
-    public function render($atts, $content = '', $shortcode_tag = '') {
-        $context = self::get_render_context($atts, $_GET);
+    public function render( $atts, $content = '', $shortcode_tag = '' ) {
+        $context = self::get_render_context( $atts, $_GET );
 
-        if (!empty($context['error']) && !empty($context['message'])) {
+        if ( ! empty( $context['error'] ) && ! empty( $context['message'] ) ) {
             return $context['message'];
         }
 
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_game_explorer');
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'jlg_game_explorer' );
 
-        return JLG_Frontend::get_template_html('shortcode-game-explorer', $context);
+        return JLG_Frontend::get_template_html( 'shortcode-game-explorer', $context );
     }
 
     public static function get_default_atts() {
-        $options = JLG_Helpers::get_plugin_options();
-        $posts_per_page = isset($options['game_explorer_posts_per_page']) ? (int) $options['game_explorer_posts_per_page'] : 12;
-        if ($posts_per_page < 1) {
+        $options        = JLG_Helpers::get_plugin_options();
+        $posts_per_page = isset( $options['game_explorer_posts_per_page'] ) ? (int) $options['game_explorer_posts_per_page'] : 12;
+        if ( $posts_per_page < 1 ) {
             $posts_per_page = 12;
         }
 
-        $columns = isset($options['game_explorer_columns']) ? (int) $options['game_explorer_columns'] : 3;
-        if ($columns < 1) {
+        $columns = isset( $options['game_explorer_columns'] ) ? (int) $options['game_explorer_columns'] : 3;
+        if ( $columns < 1 ) {
             $columns = 3;
         }
 
-        $filters = isset($options['game_explorer_filters']) ? $options['game_explorer_filters'] : 'letter,category,platform,availability';
+        $filters = isset( $options['game_explorer_filters'] ) ? $options['game_explorer_filters'] : 'letter,category,platform,availability';
 
-        return [
+        return array(
             'id'             => 'jlg-game-explorer-' . uniqid(),
             'posts_per_page' => $posts_per_page,
             'columns'        => $columns,
@@ -217,330 +219,330 @@ class JLG_Shortcode_Game_Explorer {
             'categorie'      => '',
             'plateforme'     => '',
             'lettre'         => '',
-        ];
+        );
     }
 
     protected static function get_sort_options() {
-        return [
-            [
+        return array(
+            array(
                 'value'   => 'date|DESC',
                 'orderby' => 'date',
                 'order'   => 'DESC',
-                'label'   => esc_html__('Plus récents', 'notation-jlg'),
-            ],
-            [
+                'label'   => esc_html__( 'Plus récents', 'notation-jlg' ),
+            ),
+            array(
                 'value'   => 'date|ASC',
                 'orderby' => 'date',
                 'order'   => 'ASC',
-                'label'   => esc_html__('Plus anciens', 'notation-jlg'),
-            ],
-            [
+                'label'   => esc_html__( 'Plus anciens', 'notation-jlg' ),
+            ),
+            array(
                 'value'   => 'score|DESC',
                 'orderby' => 'score',
                 'order'   => 'DESC',
-                'label'   => esc_html__('Meilleures notes', 'notation-jlg'),
-            ],
-            [
+                'label'   => esc_html__( 'Meilleures notes', 'notation-jlg' ),
+            ),
+            array(
                 'value'   => 'score|ASC',
                 'orderby' => 'score',
                 'order'   => 'ASC',
-                'label'   => esc_html__('Notes les plus basses', 'notation-jlg'),
-            ],
-            [
+                'label'   => esc_html__( 'Notes les plus basses', 'notation-jlg' ),
+            ),
+            array(
                 'value'   => 'title|ASC',
                 'orderby' => 'title',
                 'order'   => 'ASC',
-                'label'   => esc_html__('Titre (A-Z)', 'notation-jlg'),
-            ],
-            [
+                'label'   => esc_html__( 'Titre (A-Z)', 'notation-jlg' ),
+            ),
+            array(
                 'value'   => 'title|DESC',
                 'orderby' => 'title',
                 'order'   => 'DESC',
-                'label'   => esc_html__('Titre (Z-A)', 'notation-jlg'),
-            ],
-        ];
+                'label'   => esc_html__( 'Titre (Z-A)', 'notation-jlg' ),
+            ),
+        );
     }
 
     public static function get_allowed_sort_keys() {
         $options = self::get_sort_options();
-        $keys = [];
+        $keys    = array();
 
-        foreach ($options as $option) {
-            if (isset($option['orderby'])) {
-                $keys[] = sanitize_key($option['orderby']);
+        foreach ( $options as $option ) {
+            if ( isset( $option['orderby'] ) ) {
+                $keys[] = sanitize_key( $option['orderby'] );
             }
         }
 
-        return array_values(array_unique(array_filter($keys)));
+        return array_values( array_unique( array_filter( $keys ) ) );
     }
 
-    protected static function normalize_filters($filters_string) {
-        $allowed = ['letter', 'category', 'platform', 'availability', 'search'];
-        $normalized = [];
+    protected static function normalize_filters( $filters_string ) {
+        $allowed    = array( 'letter', 'category', 'platform', 'availability', 'search' );
+        $normalized = array();
 
-        if (is_string($filters_string)) {
-            $parts = array_filter(array_map('trim', explode(',', strtolower($filters_string))));
-            foreach ($parts as $part) {
-                if (in_array($part, $allowed, true)) {
-                    $normalized[$part] = true;
+        if ( is_string( $filters_string ) ) {
+            $parts = array_filter( array_map( 'trim', explode( ',', strtolower( $filters_string ) ) ) );
+            foreach ( $parts as $part ) {
+                if ( in_array( $part, $allowed, true ) ) {
+                    $normalized[ $part ] = true;
                 }
             }
         }
 
-        if (empty($normalized)) {
-            $normalized = array_fill_keys(['letter', 'category', 'platform', 'availability'], true);
+        if ( empty( $normalized ) ) {
+            $normalized = array_fill_keys( array( 'letter', 'category', 'platform', 'availability' ), true );
         }
 
         return $normalized;
     }
 
-    protected static function normalize_letter($value) {
-        if (!is_string($value)) {
+    protected static function normalize_letter( $value ) {
+        if ( ! is_string( $value ) ) {
             return '';
         }
 
-        $value = trim($value);
-        if ($value === '') {
+        $value = trim( $value );
+        if ( $value === '' ) {
             return '';
         }
 
-        $value = remove_accents($value);
+        $value = remove_accents( $value );
 
-        $first = self::substr_unicode($value, 0, 1);
+        $first = self::substr_unicode( $value, 0, 1 );
 
-        $first_upper = self::strtoupper_unicode($first);
+        $first_upper = self::strtoupper_unicode( $first );
 
-        if (preg_match('/[A-Z]/u', $first_upper)) {
+        if ( preg_match( '/[A-Z]/u', $first_upper ) ) {
             return $first_upper;
         }
 
-        if (preg_match('/[0-9]/u', $first_upper)) {
+        if ( preg_match( '/[0-9]/u', $first_upper ) ) {
             return '#';
         }
 
         return '#';
     }
 
-    private static function substr_unicode($string, $start, $length = null, $encoding = 'UTF-8') {
+    private static function substr_unicode( $string, $start, $length = null, $encoding = 'UTF-8' ) {
         $string = (string) $string;
 
-        if (function_exists('mb_substr')) {
+        if ( function_exists( 'mb_substr' ) ) {
             $result = $length === null
-                ? mb_substr($string, $start, null, $encoding)
-                : mb_substr($string, $start, $length, $encoding);
+                ? mb_substr( $string, $start, null, $encoding )
+                : mb_substr( $string, $start, $length, $encoding );
 
             return $result === false ? '' : $result;
         }
 
-        if (function_exists('iconv_substr')) {
-            if ($length === null) {
+        if ( function_exists( 'iconv_substr' ) ) {
+            if ( $length === null ) {
                 $iconv_length = null;
-                if (function_exists('iconv_strlen')) {
-                    $computed_length = iconv_strlen($string, $encoding);
-                    if ($computed_length !== false) {
+                if ( function_exists( 'iconv_strlen' ) ) {
+                    $computed_length = iconv_strlen( $string, $encoding );
+                    if ( $computed_length !== false ) {
                         $iconv_length = $computed_length;
                     }
                 }
                 $result = $iconv_length === null
-                    ? iconv_substr($string, $start, strlen($string), $encoding)
-                    : iconv_substr($string, $start, $iconv_length, $encoding);
+                    ? iconv_substr( $string, $start, strlen( $string ), $encoding )
+                    : iconv_substr( $string, $start, $iconv_length, $encoding );
             } else {
-                $result = iconv_substr($string, $start, $length, $encoding);
+                $result = iconv_substr( $string, $start, $length, $encoding );
             }
 
-            if ($result !== false && $result !== null) {
+            if ( $result !== false && $result !== null ) {
                 return $result;
             }
         }
 
-        if ($string === '') {
+        if ( $string === '' ) {
             return '';
         }
 
-        if (function_exists('wp_strlen')) {
-            $chars = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
-            if (is_array($chars)) {
-                $slice = $length === null ? array_slice($chars, $start) : array_slice($chars, $start, $length);
-                return implode('', $slice);
+        if ( function_exists( 'wp_strlen' ) ) {
+            $chars = preg_split( '//u', $string, -1, PREG_SPLIT_NO_EMPTY );
+            if ( is_array( $chars ) ) {
+                $slice = $length === null ? array_slice( $chars, $start ) : array_slice( $chars, $start, $length );
+                return implode( '', $slice );
             }
         }
 
-        if ($length === null) {
-            return substr($string, $start);
+        if ( $length === null ) {
+            return substr( $string, $start );
         }
 
-        return substr($string, $start, $length);
+        return substr( $string, $start, $length );
     }
 
-    private static function strtoupper_unicode($string, $encoding = 'UTF-8') {
+    private static function strtoupper_unicode( $string, $encoding = 'UTF-8' ) {
         $string = (string) $string;
 
-        if (function_exists('mb_strtoupper')) {
-            return mb_strtoupper($string, $encoding);
+        if ( function_exists( 'mb_strtoupper' ) ) {
+            return mb_strtoupper( $string, $encoding );
         }
 
-        if (function_exists('wp_strtoupper')) {
-            return wp_strtoupper($string);
+        if ( function_exists( 'wp_strtoupper' ) ) {
+            return wp_strtoupper( $string );
         }
 
-        if (function_exists('iconv')) {
-            $converted = @iconv($encoding, 'UTF-8//TRANSLIT', $string);
-            if ($converted !== false) {
+        if ( function_exists( 'iconv' ) ) {
+            $converted = @iconv( $encoding, 'UTF-8//TRANSLIT', $string );
+            if ( $converted !== false ) {
                 $string = $converted;
             }
         }
 
-        return strtoupper($string);
+        return strtoupper( $string );
     }
 
-    protected static function resolve_category_id($value) {
-        if ($value === null || $value === '') {
+    protected static function resolve_category_id( $value ) {
+        if ( $value === null || $value === '' ) {
             return 0;
         }
 
-        if (is_numeric($value)) {
+        if ( is_numeric( $value ) ) {
             $id = (int) $value;
             return $id > 0 ? $id : 0;
         }
 
-        $slug = sanitize_title($value);
-        if ($slug === '') {
+        $slug = sanitize_title( $value );
+        if ( $slug === '' ) {
             return 0;
         }
 
-        $term = get_category_by_slug($slug);
-        if ($term && !is_wp_error($term)) {
+        $term = get_category_by_slug( $slug );
+        if ( $term && ! is_wp_error( $term ) ) {
             return (int) $term->term_id;
         }
 
         return 0;
     }
 
-    protected static function resolve_platform_slug($value) {
-        if (!is_string($value)) {
+    protected static function resolve_platform_slug( $value ) {
+        if ( ! is_string( $value ) ) {
             return '';
         }
 
-        $value = trim($value);
-        if ($value === '') {
+        $value = trim( $value );
+        if ( $value === '' ) {
             return '';
         }
 
-        return sanitize_title($value);
+        return sanitize_title( $value );
     }
 
-    protected static function normalize_date($raw_date) {
-        if (!is_string($raw_date)) {
+    protected static function normalize_date( $raw_date ) {
+        if ( ! is_string( $raw_date ) ) {
             return '';
         }
 
-        $raw_date = trim($raw_date);
-        if ($raw_date === '') {
+        $raw_date = trim( $raw_date );
+        if ( $raw_date === '' ) {
             return '';
         }
 
-        $date = DateTime::createFromFormat('Y-m-d', $raw_date);
-        if ($date instanceof DateTime) {
-            return $date->format('Y-m-d');
+        $date = DateTime::createFromFormat( 'Y-m-d', $raw_date );
+        if ( $date instanceof DateTime ) {
+            return $date->format( 'Y-m-d' );
         }
 
-        $timestamp = strtotime($raw_date);
-        if ($timestamp) {
-            return gmdate('Y-m-d', $timestamp);
+        $timestamp = strtotime( $raw_date );
+        if ( $timestamp ) {
+            return gmdate( 'Y-m-d', $timestamp );
         }
 
         return '';
     }
 
-    protected static function determine_availability($date_iso) {
-        if ($date_iso === '') {
-            return [
+    protected static function determine_availability( $date_iso ) {
+        if ( $date_iso === '' ) {
+            return array(
                 'status' => 'unknown',
-                'label'  => esc_html__('À confirmer', 'notation-jlg'),
-            ];
+                'label'  => esc_html__( 'À confirmer', 'notation-jlg' ),
+            );
         }
 
         $timezone = null;
 
-        if (function_exists('wp_timezone')) {
+        if ( function_exists( 'wp_timezone' ) ) {
             $timezone = wp_timezone();
         }
 
-        if (!$timezone instanceof DateTimeZone) {
-            $timezone_string = function_exists('wp_timezone_string') ? wp_timezone_string() : 'UTC';
+        if ( ! $timezone instanceof DateTimeZone ) {
+            $timezone_string = function_exists( 'wp_timezone_string' ) ? wp_timezone_string() : 'UTC';
 
             try {
-                $timezone = new DateTimeZone(is_string($timezone_string) && $timezone_string !== '' ? $timezone_string : 'UTC');
-            } catch (Exception $exception) {
-                $timezone = new DateTimeZone('UTC');
+                $timezone = new DateTimeZone( is_string( $timezone_string ) && $timezone_string !== '' ? $timezone_string : 'UTC' );
+            } catch ( Exception $exception ) {
+                $timezone = new DateTimeZone( 'UTC' );
             }
         }
 
-        $release_date = DateTimeImmutable::createFromFormat('!Y-m-d', $date_iso, $timezone);
+        $release_date = DateTimeImmutable::createFromFormat( '!Y-m-d', $date_iso, $timezone );
 
-        if (!$release_date instanceof DateTimeImmutable) {
-            return [
+        if ( ! $release_date instanceof DateTimeImmutable ) {
+            return array(
                 'status' => 'unknown',
-                'label'  => esc_html__('À confirmer', 'notation-jlg'),
-            ];
+                'label'  => esc_html__( 'À confirmer', 'notation-jlg' ),
+            );
         }
 
         $parse_errors = DateTimeImmutable::getLastErrors();
-        if (is_array($parse_errors) && (($parse_errors['warning_count'] ?? 0) > 0 || ($parse_errors['error_count'] ?? 0) > 0)) {
-            return [
+        if ( is_array( $parse_errors ) && ( ( $parse_errors['warning_count'] ?? 0 ) > 0 || ( $parse_errors['error_count'] ?? 0 ) > 0 ) ) {
+            return array(
                 'status' => 'unknown',
-                'label'  => esc_html__('À confirmer', 'notation-jlg'),
-            ];
+                'label'  => esc_html__( 'À confirmer', 'notation-jlg' ),
+            );
         }
 
-        if ($release_date->getTimestamp() > (int) current_time('timestamp')) {
-            return [
+        if ( $release_date->getTimestamp() > (int) current_time( 'timestamp' ) ) {
+            return array(
                 'status' => 'upcoming',
-                'label'  => esc_html__('À venir', 'notation-jlg'),
-            ];
+                'label'  => esc_html__( 'À venir', 'notation-jlg' ),
+            );
         }
 
-        return [
+        return array(
             'status' => 'available',
-            'label'  => esc_html__('Disponible', 'notation-jlg'),
-        ];
+            'label'  => esc_html__( 'Disponible', 'notation-jlg' ),
+        );
     }
 
-    protected static function build_letter_navigation($letters_map) {
-        $letters_map = is_array($letters_map) ? $letters_map : [];
-        $alphabet = range('A', 'Z');
-        $letters = [];
+    protected static function build_letter_navigation( $letters_map ) {
+        $letters_map = is_array( $letters_map ) ? $letters_map : array();
+        $alphabet    = range( 'A', 'Z' );
+        $letters     = array();
 
-        foreach ($alphabet as $letter) {
-            $letters[] = [
+        foreach ( $alphabet as $letter ) {
+            $letters[] = array(
                 'value'   => $letter,
                 'label'   => $letter,
-                'enabled' => !empty($letters_map[$letter]),
-            ];
+                'enabled' => ! empty( $letters_map[ $letter ] ),
+            );
         }
 
-        $letters[] = [
+        $letters[] = array(
             'value'   => '#',
             'label'   => '#',
-            'enabled' => !empty($letters_map['#']),
-        ];
+            'enabled' => ! empty( $letters_map['#'] ),
+        );
 
         return $letters;
     }
 
     protected static function get_filters_snapshot() {
-        if (is_array(self::$filters_snapshot)) {
+        if ( is_array( self::$filters_snapshot ) ) {
             return self::$filters_snapshot;
         }
 
-        $snapshot = get_transient(self::SNAPSHOT_TRANSIENT_KEY);
+        $snapshot = get_transient( self::SNAPSHOT_TRANSIENT_KEY );
 
-        if (!is_array($snapshot) || empty($snapshot['posts'])) {
+        if ( ! is_array( $snapshot ) || empty( $snapshot['posts'] ) ) {
             $snapshot = self::build_filters_snapshot();
 
-            $ttl = apply_filters('jlg_game_explorer_snapshot_ttl', defined('MINUTE_IN_SECONDS') ? 5 * MINUTE_IN_SECONDS : 300);
-            if (is_numeric($ttl) && (int) $ttl > 0) {
-                set_transient(self::SNAPSHOT_TRANSIENT_KEY, $snapshot, (int) $ttl);
+            $ttl = apply_filters( 'jlg_game_explorer_snapshot_ttl', defined( 'MINUTE_IN_SECONDS' ) ? 5 * MINUTE_IN_SECONDS : 300 );
+            if ( is_numeric( $ttl ) && (int) $ttl > 0 ) {
+                set_transient( self::SNAPSHOT_TRANSIENT_KEY, $snapshot, (int) $ttl );
             }
         }
 
@@ -550,175 +552,180 @@ class JLG_Shortcode_Game_Explorer {
     }
 
     protected static function build_filters_snapshot() {
-        $snapshot = [
-            'posts' => [],
-            'letters_map' => [],
-            'categories_map' => [],
-            'platforms_map' => [],
-        ];
+        $snapshot = array(
+            'posts'          => array(),
+            'letters_map'    => array(),
+            'categories_map' => array(),
+            'platforms_map'  => array(),
+        );
 
         $rated_posts = JLG_Helpers::get_rated_post_ids();
-        if (empty($rated_posts)) {
+        if ( empty( $rated_posts ) ) {
             return $snapshot;
         }
 
-        $rated_posts = array_values(array_filter(array_map('intval', $rated_posts), static function ($post_id) {
-            return $post_id > 0;
-        }));
+        $rated_posts = array_values(
+            array_filter(
+                array_map( 'intval', $rated_posts ),
+                static function ( $post_id ) {
+					return $post_id > 0;
+                }
+            )
+        );
 
-        if (empty($rated_posts)) {
+        if ( empty( $rated_posts ) ) {
             return $snapshot;
         }
 
-        $post_id_chunks = count($rated_posts) > 100 ? array_chunk($rated_posts, 100) : [$rated_posts];
+        $post_id_chunks = count( $rated_posts ) > 100 ? array_chunk( $rated_posts, 100 ) : array( $rated_posts );
 
-        if (function_exists('update_meta_cache')) {
-            foreach ($post_id_chunks as $post_id_chunk) {
-                if (!empty($post_id_chunk)) {
-                    update_meta_cache('post', $post_id_chunk);
+        if ( function_exists( 'update_meta_cache' ) ) {
+            foreach ( $post_id_chunks as $post_id_chunk ) {
+                if ( ! empty( $post_id_chunk ) ) {
+                    update_meta_cache( 'post', $post_id_chunk );
                 }
             }
         }
 
-        if (function_exists('update_object_term_cache')) {
-            foreach ($post_id_chunks as $post_id_chunk) {
-                if (!empty($post_id_chunk)) {
-                    update_object_term_cache($post_id_chunk, 'post', ['category']);
+        if ( function_exists( 'update_object_term_cache' ) ) {
+            foreach ( $post_id_chunks as $post_id_chunk ) {
+                if ( ! empty( $post_id_chunk ) ) {
+                    update_object_term_cache( $post_id_chunk, 'post', array( 'category' ) );
                 }
             }
         }
 
-        foreach ($rated_posts as $post_id) {
-            if ($post_id <= 0) {
+        foreach ( $rated_posts as $post_id ) {
+            if ( $post_id <= 0 ) {
                 continue;
             }
 
-            $post = get_post($post_id);
-            if (!$post || $post->post_status !== 'publish') {
+            $post = get_post( $post_id );
+            if ( ! $post || $post->post_status !== 'publish' ) {
                 continue;
             }
 
-            $title = JLG_Helpers::get_game_title($post_id);
-            if ($title === '') {
-                $title = get_the_title($post_id);
+            $title = JLG_Helpers::get_game_title( $post_id );
+            if ( $title === '' ) {
+                $title = get_the_title( $post_id );
             }
 
-            $letter = self::normalize_letter($title);
-            if ($letter !== '') {
-                $snapshot['letters_map'][$letter] = true;
+            $letter = self::normalize_letter( $title );
+            if ( $letter !== '' ) {
+                $snapshot['letters_map'][ $letter ] = true;
             }
 
-            $release_raw = get_post_meta($post_id, '_jlg_date_sortie', true);
-            $release_iso = self::normalize_date($release_raw);
-            $availability = self::determine_availability($release_iso);
+            $release_raw  = get_post_meta( $post_id, '_jlg_date_sortie', true );
+            $release_iso  = self::normalize_date( $release_raw );
+            $availability = self::determine_availability( $release_iso );
 
-            $developer = get_post_meta($post_id, '_jlg_developpeur', true);
-            $developer = is_string($developer) ? sanitize_text_field($developer) : '';
-            $publisher = get_post_meta($post_id, '_jlg_editeur', true);
-            $publisher = is_string($publisher) ? sanitize_text_field($publisher) : '';
+            $developer = get_post_meta( $post_id, '_jlg_developpeur', true );
+            $developer = is_string( $developer ) ? sanitize_text_field( $developer ) : '';
+            $publisher = get_post_meta( $post_id, '_jlg_editeur', true );
+            $publisher = is_string( $publisher ) ? sanitize_text_field( $publisher ) : '';
 
-            $platform_meta = get_post_meta($post_id, '_jlg_plateformes', true);
-            $platform_labels = [];
-            $platform_slugs = [];
+            $platform_meta   = get_post_meta( $post_id, '_jlg_plateformes', true );
+            $platform_labels = array();
+            $platform_slugs  = array();
 
-            if (is_array($platform_meta)) {
-                foreach ($platform_meta as $platform_item) {
-                    if (!is_string($platform_item)) {
+            if ( is_array( $platform_meta ) ) {
+                foreach ( $platform_meta as $platform_item ) {
+                    if ( ! is_string( $platform_item ) ) {
                         continue;
                     }
 
-                    $label = sanitize_text_field($platform_item);
-                    if ($label === '') {
+                    $label = sanitize_text_field( $platform_item );
+                    if ( $label === '' ) {
                         continue;
                     }
 
-                    $slug = self::resolve_platform_slug($label);
+                    $slug              = self::resolve_platform_slug( $label );
                     $platform_labels[] = $label;
-                    if ($slug !== '') {
+                    if ( $slug !== '' ) {
                         $platform_slugs[] = $slug;
-                        if (!isset($snapshot['platforms_map'][$slug])) {
-                            $snapshot['platforms_map'][$slug] = $label;
+                        if ( ! isset( $snapshot['platforms_map'][ $slug ] ) ) {
+                            $snapshot['platforms_map'][ $slug ] = $label;
                         }
                     }
                 }
-            } elseif (is_string($platform_meta) && $platform_meta !== '') {
-                $label = sanitize_text_field($platform_meta);
-                $slug = self::resolve_platform_slug($label);
+            } elseif ( is_string( $platform_meta ) && $platform_meta !== '' ) {
+                $label             = sanitize_text_field( $platform_meta );
+                $slug              = self::resolve_platform_slug( $label );
                 $platform_labels[] = $label;
-                if ($slug !== '') {
+                if ( $slug !== '' ) {
                     $platform_slugs[] = $slug;
-                    if (!isset($snapshot['platforms_map'][$slug])) {
-                        $snapshot['platforms_map'][$slug] = $label;
+                    if ( ! isset( $snapshot['platforms_map'][ $slug ] ) ) {
+                        $snapshot['platforms_map'][ $slug ] = $label;
                     }
                 }
             }
 
-            $terms = get_the_terms($post_id, 'category');
-            $category_ids = [];
-            $category_slugs = [];
-            $primary_genre = '';
+            $terms          = get_the_terms( $post_id, 'category' );
+            $category_ids   = array();
+            $category_slugs = array();
+            $primary_genre  = '';
 
-            if ($terms && !is_wp_error($terms)) {
-                foreach ($terms as $term) {
-                    $snapshot['categories_map'][$term->term_id] = $term->name;
-                    $category_ids[] = (int) $term->term_id;
-                    $category_slugs[] = $term->slug;
-                    if ($primary_genre === '') {
+            if ( $terms && ! is_wp_error( $terms ) ) {
+                foreach ( $terms as $term ) {
+                    $snapshot['categories_map'][ $term->term_id ] = $term->name;
+                    $category_ids[]                               = (int) $term->term_id;
+                    $category_slugs[]                             = $term->slug;
+                    if ( $primary_genre === '' ) {
                         $primary_genre = $term->name;
                     }
                 }
             }
 
             $search_tokens = strtolower(
-                wp_strip_all_tags($title . ' ' . $developer . ' ' . $publisher . ' ' . $primary_genre . ' ' . implode(' ', $platform_labels))
+                wp_strip_all_tags( $title . ' ' . $developer . ' ' . $publisher . ' ' . $primary_genre . ' ' . implode( ' ', $platform_labels ) )
             );
 
-            $snapshot['posts'][$post_id] = [
-                'letter'           => $letter,
-                'category_ids'     => $category_ids,
-                'category_slugs'   => $category_slugs,
-                'primary_genre'    => $primary_genre,
-                'platform_labels'  => $platform_labels,
-                'platform_slugs'   => $platform_slugs,
-                'developer'        => $developer,
-                'publisher'        => $publisher,
-                'release_iso'      => $release_iso,
-                'availability'     => $availability['status'],
-                'search_haystack'  => $search_tokens,
-            ];
+            $snapshot['posts'][ $post_id ] = array(
+                'letter'          => $letter,
+                'category_ids'    => $category_ids,
+                'category_slugs'  => $category_slugs,
+                'primary_genre'   => $primary_genre,
+                'platform_labels' => $platform_labels,
+                'platform_slugs'  => $platform_slugs,
+                'developer'       => $developer,
+                'publisher'       => $publisher,
+                'release_iso'     => $release_iso,
+                'availability'    => $availability['status'],
+                'search_haystack' => $search_tokens,
+            );
         }
 
         return $snapshot;
     }
 
-    protected static function filter_snapshot_post_ids($snapshot, $letter, $category_id, $category_slug, $platform_slug, $availability, $search) {
-        $matched_ids = [];
-        $search = is_string($search) ? strtolower($search) : '';
+    protected static function filter_snapshot_post_ids( $snapshot, $letter, $category_id, $category_slug, $platform_slug, $availability, $search ) {
+        $matched_ids = array();
+        $search      = is_string( $search ) ? strtolower( $search ) : '';
 
-        foreach ($snapshot['posts'] as $post_id => $data) {
-            if ($letter !== '' && ($data['letter'] ?? '') !== $letter) {
+        foreach ( $snapshot['posts'] as $post_id => $data ) {
+            if ( $letter !== '' && ( $data['letter'] ?? '' ) !== $letter ) {
                 continue;
             }
 
-            if ($category_id > 0) {
-                if (empty($data['category_ids']) || !in_array($category_id, $data['category_ids'], true)) {
+            if ( $category_id > 0 ) {
+                if ( empty( $data['category_ids'] ) || ! in_array( $category_id, $data['category_ids'], true ) ) {
                     continue;
                 }
-            } elseif ($category_slug !== '') {
-                if (empty($data['category_slugs']) || !in_array($category_slug, $data['category_slugs'], true)) {
+            } elseif ( $category_slug !== '' ) {
+                if ( empty( $data['category_slugs'] ) || ! in_array( $category_slug, $data['category_slugs'], true ) ) {
                     continue;
                 }
             }
 
-            if ($platform_slug !== '' && (empty($data['platform_slugs']) || !in_array($platform_slug, $data['platform_slugs'], true))) {
+            if ( $platform_slug !== '' && ( empty( $data['platform_slugs'] ) || ! in_array( $platform_slug, $data['platform_slugs'], true ) ) ) {
                 continue;
             }
 
-            if ($availability !== '' && ($data['availability'] ?? '') !== $availability) {
+            if ( $availability !== '' && ( $data['availability'] ?? '' ) !== $availability ) {
                 continue;
             }
 
-            if ($search !== '' && strpos($data['search_haystack'] ?? '', $search) === false) {
+            if ( $search !== '' && strpos( $data['search_haystack'] ?? '', $search ) === false ) {
                 continue;
             }
 
@@ -728,152 +735,152 @@ class JLG_Shortcode_Game_Explorer {
         return $matched_ids;
     }
 
-    public static function get_render_context($atts, $request = []) {
+    public static function get_render_context( $atts, $request = array() ) {
         $defaults = self::get_default_atts();
-        $atts = shortcode_atts($defaults, $atts, 'jlg_game_explorer');
+        $atts     = shortcode_atts( $defaults, $atts, 'jlg_game_explorer' );
 
-        $atts['id'] = self::normalize_container_id($atts['id'] ?? '');
-        $request_prefix = self::get_request_prefix($atts['id']);
-        $request_keys = self::build_request_keys($request_prefix);
+        $atts['id']     = self::normalize_container_id( $atts['id'] ?? '' );
+        $request_prefix = self::get_request_prefix( $atts['id'] );
+        $request_keys   = self::build_request_keys( $request_prefix );
 
-        $request = self::extract_request_params($request, $request_keys);
+        $request = self::extract_request_params( $request, $request_keys );
 
-        $options = JLG_Helpers::get_plugin_options();
-        $posts_per_page = isset($atts['posts_per_page']) ? (int) $atts['posts_per_page'] : $defaults['posts_per_page'];
-        if ($posts_per_page < 1) {
-            $posts_per_page = isset($options['game_explorer_posts_per_page']) ? (int) $options['game_explorer_posts_per_page'] : 12;
+        $options        = JLG_Helpers::get_plugin_options();
+        $posts_per_page = isset( $atts['posts_per_page'] ) ? (int) $atts['posts_per_page'] : $defaults['posts_per_page'];
+        if ( $posts_per_page < 1 ) {
+            $posts_per_page = isset( $options['game_explorer_posts_per_page'] ) ? (int) $options['game_explorer_posts_per_page'] : 12;
         }
-        $posts_per_page = max(1, min($posts_per_page, 60));
+        $posts_per_page = max( 1, min( $posts_per_page, 60 ) );
 
-        $columns = isset($atts['columns']) ? (int) $atts['columns'] : $defaults['columns'];
-        if ($columns < 1) {
-            $columns = isset($options['game_explorer_columns']) ? (int) $options['game_explorer_columns'] : 3;
+        $columns = isset( $atts['columns'] ) ? (int) $atts['columns'] : $defaults['columns'];
+        if ( $columns < 1 ) {
+            $columns = isset( $options['game_explorer_columns'] ) ? (int) $options['game_explorer_columns'] : 3;
         }
-        $columns = max(1, min($columns, 4));
+        $columns = max( 1, min( $columns, 4 ) );
 
-        $filters_enabled = self::normalize_filters($atts['filters']);
+        $filters_enabled = self::normalize_filters( $atts['filters'] );
 
-        $orderby = (isset($request['orderby']) && is_string($request['orderby'])) ? sanitize_key($request['orderby']) : 'date';
-        $order = isset($request['order']) ? strtoupper(sanitize_text_field($request['order'])) : 'DESC';
-        if (!in_array($order, ['ASC', 'DESC'], true)) {
+        $orderby = ( isset( $request['orderby'] ) && is_string( $request['orderby'] ) ) ? sanitize_key( $request['orderby'] ) : 'date';
+        $order   = isset( $request['order'] ) ? strtoupper( sanitize_text_field( $request['order'] ) ) : 'DESC';
+        if ( ! in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
             $order = 'DESC';
         }
 
-        $letter_filter = isset($request['letter']) ? self::normalize_letter($request['letter']) : '';
-        $category_filter = isset($request['category']) ? sanitize_text_field($request['category']) : '';
-        $platform_filter = isset($request['platform']) ? sanitize_text_field($request['platform']) : '';
-        $availability_filter = (isset($request['availability']) && is_string($request['availability'])) ? sanitize_key($request['availability']) : '';
-        $search_filter = isset($request['search']) ? sanitize_text_field($request['search']) : '';
-        $paged = isset($request['paged']) ? max(1, (int) $request['paged']) : 1;
+        $letter_filter       = isset( $request['letter'] ) ? self::normalize_letter( $request['letter'] ) : '';
+        $category_filter     = isset( $request['category'] ) ? sanitize_text_field( $request['category'] ) : '';
+        $platform_filter     = isset( $request['platform'] ) ? sanitize_text_field( $request['platform'] ) : '';
+        $availability_filter = ( isset( $request['availability'] ) && is_string( $request['availability'] ) ) ? sanitize_key( $request['availability'] ) : '';
+        $search_filter       = isset( $request['search'] ) ? sanitize_text_field( $request['search'] ) : '';
+        $paged               = isset( $request['paged'] ) ? max( 1, (int) $request['paged'] ) : 1;
 
-        if (empty($filters_enabled['letter'])) {
+        if ( empty( $filters_enabled['letter'] ) ) {
             $letter_filter = '';
         }
-        if (empty($filters_enabled['category'])) {
+        if ( empty( $filters_enabled['category'] ) ) {
             $category_filter = '';
         }
-        if (empty($filters_enabled['platform'])) {
+        if ( empty( $filters_enabled['platform'] ) ) {
             $platform_filter = '';
         }
-        if (empty($filters_enabled['availability'])) {
+        if ( empty( $filters_enabled['availability'] ) ) {
             $availability_filter = '';
         }
-        if (empty($filters_enabled['search'])) {
+        if ( empty( $filters_enabled['search'] ) ) {
             $search_filter = '';
         }
 
-        $forced_category = self::resolve_category_id($atts['categorie']);
-        if ($forced_category > 0) {
+        $forced_category = self::resolve_category_id( $atts['categorie'] );
+        if ( $forced_category > 0 ) {
             $category_filter = (string) $forced_category;
         }
 
-        $forced_platform = self::resolve_platform_slug($atts['plateforme']);
-        if ($forced_platform !== '') {
+        $forced_platform = self::resolve_platform_slug( $atts['plateforme'] );
+        if ( $forced_platform !== '' ) {
             $platform_filter = $forced_platform;
         }
 
-        $forced_letter = self::normalize_letter($atts['lettre']);
-        if ($forced_letter !== '') {
+        $forced_letter = self::normalize_letter( $atts['lettre'] );
+        if ( $forced_letter !== '' ) {
             $letter_filter = $forced_letter;
         }
 
-        $allowed_orderby = ['date', 'score', 'title'];
-        if (!in_array($orderby, $allowed_orderby, true)) {
+        $allowed_orderby = array( 'date', 'score', 'title' );
+        if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
             $orderby = 'date';
         }
 
         $snapshot = self::get_filters_snapshot();
-        if (empty($snapshot['posts'])) {
-            $message = '<p>' . esc_html__('Aucun test noté n\'est disponible pour le moment.', 'notation-jlg') . '</p>';
+        if ( empty( $snapshot['posts'] ) ) {
+            $message = '<p>' . esc_html__( 'Aucun test noté n\'est disponible pour le moment.', 'notation-jlg' ) . '</p>';
 
-            return [
+            return array(
                 'error'   => true,
                 'message' => $message,
                 'atts'    => $atts,
-            ];
+            );
         }
 
-        $letters_map = isset($snapshot['letters_map']) && is_array($snapshot['letters_map']) ? $snapshot['letters_map'] : [];
-        $letters = self::build_letter_navigation($letters_map);
+        $letters_map = isset( $snapshot['letters_map'] ) && is_array( $snapshot['letters_map'] ) ? $snapshot['letters_map'] : array();
+        $letters     = self::build_letter_navigation( $letters_map );
 
-        $categories_map = isset($snapshot['categories_map']) && is_array($snapshot['categories_map']) ? $snapshot['categories_map'] : [];
-        $categories_list = [];
-        if (!empty($categories_map)) {
-            asort($categories_map, SORT_NATURAL | SORT_FLAG_CASE);
-            foreach ($categories_map as $id => $name) {
-                $categories_list[] = [
+        $categories_map  = isset( $snapshot['categories_map'] ) && is_array( $snapshot['categories_map'] ) ? $snapshot['categories_map'] : array();
+        $categories_list = array();
+        if ( ! empty( $categories_map ) ) {
+            asort( $categories_map, SORT_NATURAL | SORT_FLAG_CASE );
+            foreach ( $categories_map as $id => $name ) {
+                $categories_list[] = array(
                     'value' => (string) $id,
                     'label' => $name,
-                ];
+                );
             }
         }
 
-        $platforms_map = isset($snapshot['platforms_map']) && is_array($snapshot['platforms_map']) ? $snapshot['platforms_map'] : [];
-        $platforms_list = [];
-        if (!empty($platforms_map)) {
+        $platforms_map  = isset( $snapshot['platforms_map'] ) && is_array( $snapshot['platforms_map'] ) ? $snapshot['platforms_map'] : array();
+        $platforms_list = array();
+        if ( ! empty( $platforms_map ) ) {
             $registered_platforms = JLG_Helpers::get_registered_platform_labels();
-            foreach ($registered_platforms as $slug => $label) {
-                $normalized_slug = self::resolve_platform_slug($label);
-                if ($normalized_slug !== '' && isset($platforms_map[$normalized_slug])) {
-                    $platforms_list[$normalized_slug] = $platforms_map[$normalized_slug];
+            foreach ( $registered_platforms as $slug => $label ) {
+                $normalized_slug = self::resolve_platform_slug( $label );
+                if ( $normalized_slug !== '' && isset( $platforms_map[ $normalized_slug ] ) ) {
+                    $platforms_list[ $normalized_slug ] = $platforms_map[ $normalized_slug ];
                 }
             }
-            foreach ($platforms_map as $slug => $label) {
-                if (!isset($platforms_list[$slug])) {
-                    $platforms_list[$slug] = $label;
+            foreach ( $platforms_map as $slug => $label ) {
+                if ( ! isset( $platforms_list[ $slug ] ) ) {
+                    $platforms_list[ $slug ] = $label;
                 }
             }
-            natcasesort($platforms_list);
+            natcasesort( $platforms_list );
         }
 
-        $platform_entries = [];
-        foreach ($platforms_list as $slug => $label) {
-            $platform_entries[] = [
+        $platform_entries = array();
+        foreach ( $platforms_list as $slug => $label ) {
+            $platform_entries[] = array(
                 'value' => $slug,
                 'label' => $label,
-            ];
+            );
         }
 
-        $availability_options = [
-            'available'  => esc_html__('Disponible', 'notation-jlg'),
-            'upcoming'   => esc_html__('À venir', 'notation-jlg'),
-            'unknown'    => esc_html__('À confirmer', 'notation-jlg'),
-        ];
+        $availability_options = array(
+            'available' => esc_html__( 'Disponible', 'notation-jlg' ),
+            'upcoming'  => esc_html__( 'À venir', 'notation-jlg' ),
+            'unknown'   => esc_html__( 'À confirmer', 'notation-jlg' ),
+        );
 
-        $category_filter_id = 0;
+        $category_filter_id   = 0;
         $category_filter_slug = '';
-        if ($category_filter !== '') {
-            if (ctype_digit((string) $category_filter)) {
+        if ( $category_filter !== '' ) {
+            if ( ctype_digit( (string) $category_filter ) ) {
                 $category_filter_id = (int) $category_filter;
             } else {
-                $category_filter_slug = sanitize_title($category_filter);
+                $category_filter_slug = sanitize_title( $category_filter );
             }
         }
 
-        $platform_filter_slug = $platform_filter !== '' ? self::resolve_platform_slug($platform_filter) : '';
-        $letter_filter = is_string($letter_filter) ? $letter_filter : '';
-        $availability_filter = is_string($availability_filter) ? $availability_filter : '';
-        $search_filter = is_string($search_filter) ? $search_filter : '';
+        $platform_filter_slug = $platform_filter !== '' ? self::resolve_platform_slug( $platform_filter ) : '';
+        $letter_filter        = is_string( $letter_filter ) ? $letter_filter : '';
+        $availability_filter  = is_string( $availability_filter ) ? $availability_filter : '';
+        $search_filter        = is_string( $search_filter ) ? $search_filter : '';
 
         $matched_post_ids = self::filter_snapshot_post_ids(
             $snapshot,
@@ -887,47 +894,50 @@ class JLG_Shortcode_Game_Explorer {
 
         $category_filter_value = $category_filter_id > 0 ? (string) $category_filter_id : $category_filter_slug;
 
-        $no_results_message = '<p>' . esc_html__('Aucun jeu ne correspond à vos filtres actuels.', 'notation-jlg') . '</p>';
+        $no_results_message = '<p>' . esc_html__( 'Aucun jeu ne correspond à vos filtres actuels.', 'notation-jlg' ) . '</p>';
 
-        if (empty($matched_post_ids)) {
-            return [
-                'atts'               => array_merge($atts, [
-                    'posts_per_page' => $posts_per_page,
-                    'columns'        => $columns,
-                ]),
-                'games'              => [],
-                'letters'            => $letters,
-                'filters_enabled'    => $filters_enabled,
-                'current_filters'    => [
+        if ( empty( $matched_post_ids ) ) {
+            return array(
+                'atts'                 => array_merge(
+                    $atts,
+                    array(
+						'posts_per_page' => $posts_per_page,
+						'columns'        => $columns,
+					)
+                ),
+                'games'                => array(),
+                'letters'              => $letters,
+                'filters_enabled'      => $filters_enabled,
+                'current_filters'      => array(
                     'letter'       => $letter_filter,
                     'category'     => $category_filter_value,
                     'platform'     => $platform_filter_slug,
                     'availability' => $availability_filter,
                     'search'       => $search_filter,
-                ],
-                'sort_options'       => self::get_sort_options(),
-                'sort_key'           => $orderby,
-                'sort_order'         => $order,
-                'pagination'         => [
+                ),
+                'sort_options'         => self::get_sort_options(),
+                'sort_key'             => $orderby,
+                'sort_order'           => $order,
+                'pagination'           => array(
                     'current' => 1,
                     'total'   => 0,
-                ],
-                'categories_list'    => $categories_list,
-                'platforms_list'     => $platform_entries,
+                ),
+                'categories_list'      => $categories_list,
+                'platforms_list'       => $platform_entries,
                 'availability_options' => $availability_options,
-                'total_items'        => 0,
-                'message'            => $no_results_message,
-                'config_payload'     => [
-                    'atts' => [
+                'total_items'          => 0,
+                'message'              => $no_results_message,
+                'config_payload'       => array(
+                    'atts'    => array(
                         'id'             => $atts['id'],
                         'posts_per_page' => $posts_per_page,
                         'columns'        => $columns,
-                        'filters'        => implode(',', array_keys(array_filter($filters_enabled))),
+                        'filters'        => implode( ',', array_keys( array_filter( $filters_enabled ) ) ),
                         'categorie'      => $atts['categorie'],
                         'plateforme'     => $atts['plateforme'],
                         'lettre'         => $atts['lettre'],
-                    ],
-                    'state' => [
+                    ),
+                    'state'   => array(
                         'orderby'      => $orderby,
                         'order'        => $order,
                         'letter'       => $letter_filter,
@@ -936,38 +946,38 @@ class JLG_Shortcode_Game_Explorer {
                         'availability' => $availability_filter,
                         'search'       => $search_filter,
                         'paged'        => 1,
-                    ],
-                    'request' => [
+                    ),
+                    'request' => array(
                         'prefix' => $request_prefix,
                         'keys'   => $request_keys,
-                    ],
-                ],
-                'request_prefix'     => $request_prefix,
-                'request_keys'       => $request_keys,
-            ];
+                    ),
+                ),
+                'request_prefix'       => $request_prefix,
+                'request_keys'         => $request_keys,
+            );
         }
 
-        $matched_post_ids = array_values(array_unique(array_map('intval', $matched_post_ids)));
+        $matched_post_ids = array_values( array_unique( array_map( 'intval', $matched_post_ids ) ) );
 
-        $total_items = count($matched_post_ids);
-        $total_pages = (int) ceil($total_items / $posts_per_page);
-        if ($total_pages === 0) {
+        $total_items = count( $matched_post_ids );
+        $total_pages = (int) ceil( $total_items / $posts_per_page );
+        if ( $total_pages === 0 ) {
             $total_pages = 1;
         }
-        if ($paged > $total_pages) {
+        if ( $paged > $total_pages ) {
             $paged = $total_pages;
         }
-        if ($paged < 1) {
+        if ( $paged < 1 ) {
             $paged = 1;
         }
 
-        $post_types = JLG_Helpers::get_allowed_post_types();
-        $post_statuses = apply_filters('jlg_rated_post_statuses', ['publish']);
-        if (!is_array($post_statuses) || empty($post_statuses)) {
-            $post_statuses = ['publish'];
+        $post_types    = JLG_Helpers::get_allowed_post_types();
+        $post_statuses = apply_filters( 'jlg_rated_post_statuses', array( 'publish' ) );
+        if ( ! is_array( $post_statuses ) || empty( $post_statuses ) ) {
+            $post_statuses = array( 'publish' );
         }
 
-        $query_args = [
+        $query_args = array(
             'post_type'              => $post_types,
             'post_status'            => $post_statuses,
             'post__in'               => $matched_post_ids,
@@ -978,122 +988,122 @@ class JLG_Shortcode_Game_Explorer {
             'ignore_sticky_posts'    => true,
             'no_found_rows'          => true,
             'update_post_term_cache' => false,
-        ];
+        );
 
-        if ($orderby === 'score') {
-            $query_args['meta_key'] = '_jlg_average_score';
-            $query_args['orderby'] = 'meta_value_num';
+        if ( $orderby === 'score' ) {
+            $query_args['meta_key']  = '_jlg_average_score';
+            $query_args['orderby']   = 'meta_value_num';
             $query_args['meta_type'] = 'DECIMAL';
-        } elseif ($orderby === 'title') {
+        } elseif ( $orderby === 'title' ) {
             $query_args['orderby'] = 'title';
         }
 
-        $query = new WP_Query($query_args);
+        $query = new WP_Query( $query_args );
 
-        $games = [];
-        if ($query->have_posts()) {
-            foreach ($query->posts as $post) {
-                $post_id = (int) $post->ID;
-                $post_info = isset($snapshot['posts'][$post_id]) ? $snapshot['posts'][$post_id] : [];
+        $games = array();
+        if ( $query->have_posts() ) {
+            foreach ( $query->posts as $post ) {
+                $post_id   = (int) $post->ID;
+                $post_info = isset( $snapshot['posts'][ $post_id ] ) ? $snapshot['posts'][ $post_id ] : array();
 
-                $title = JLG_Helpers::get_game_title($post_id);
-                if ($title === '') {
-                    $title = get_the_title($post_id);
+                $title = JLG_Helpers::get_game_title( $post_id );
+                if ( $title === '' ) {
+                    $title = get_the_title( $post_id );
                 }
 
-                $score_data = JLG_Helpers::get_resolved_average_score($post_id);
-                $score_value = isset($score_data['value']) ? $score_data['value'] : null;
-                $score_display = isset($score_data['formatted']) && $score_data['formatted'] !== ''
+                $score_data    = JLG_Helpers::get_resolved_average_score( $post_id );
+                $score_value   = isset( $score_data['value'] ) ? $score_data['value'] : null;
+                $score_display = isset( $score_data['formatted'] ) && $score_data['formatted'] !== ''
                     ? $score_data['formatted']
-                    : esc_html__('N/A', 'notation-jlg');
-                $score_color = $score_value !== null
-                    ? JLG_Helpers::calculate_color_from_note($score_value, $options)
-                    : ($options['color_mid'] ?? '#f97316');
+                    : esc_html__( 'N/A', 'notation-jlg' );
+                $score_color   = $score_value !== null
+                    ? JLG_Helpers::calculate_color_from_note( $score_value, $options )
+                    : ( $options['color_mid'] ?? '#f97316' );
 
-                $cover_meta = get_post_meta($post_id, '_jlg_cover_image_url', true);
-                $cover_url = '';
-                if (is_string($cover_meta) && $cover_meta !== '') {
-                    $cover_url = esc_url_raw($cover_meta);
+                $cover_meta = get_post_meta( $post_id, '_jlg_cover_image_url', true );
+                $cover_url  = '';
+                if ( is_string( $cover_meta ) && $cover_meta !== '' ) {
+                    $cover_url = esc_url_raw( $cover_meta );
                 }
-                if ($cover_url === '') {
-                    $thumbnail = get_the_post_thumbnail_url($post_id, 'large');
-                    if ($thumbnail) {
+                if ( $cover_url === '' ) {
+                    $thumbnail = get_the_post_thumbnail_url( $post_id, 'large' );
+                    if ( $thumbnail ) {
                         $cover_url = $thumbnail;
                     }
                 }
 
-                $release_iso = isset($post_info['release_iso']) ? $post_info['release_iso'] : '';
+                $release_iso     = isset( $post_info['release_iso'] ) ? $post_info['release_iso'] : '';
                 $release_display = '';
-                if ($release_iso !== '') {
-                    $release_display = date_i18n(get_option('date_format'), strtotime($release_iso . ' 00:00:00'));
+                if ( $release_iso !== '' ) {
+                    $release_display = date_i18n( get_option( 'date_format' ), strtotime( $release_iso . ' 00:00:00' ) );
                 }
-                $availability_data = self::determine_availability($release_iso);
-                $availability_status = isset($post_info['availability']) ? $post_info['availability'] : $availability_data['status'];
+                $availability_data   = self::determine_availability( $release_iso );
+                $availability_status = isset( $post_info['availability'] ) ? $post_info['availability'] : $availability_data['status'];
 
-                $developer = isset($post_info['developer']) ? $post_info['developer'] : '';
-                $publisher = isset($post_info['publisher']) ? $post_info['publisher'] : '';
+                $developer = isset( $post_info['developer'] ) ? $post_info['developer'] : '';
+                $publisher = isset( $post_info['publisher'] ) ? $post_info['publisher'] : '';
 
-                $platform_labels = isset($post_info['platform_labels']) ? $post_info['platform_labels'] : [];
-                $platform_slugs = isset($post_info['platform_slugs']) ? $post_info['platform_slugs'] : [];
+                $platform_labels = isset( $post_info['platform_labels'] ) ? $post_info['platform_labels'] : array();
+                $platform_slugs  = isset( $post_info['platform_slugs'] ) ? $post_info['platform_slugs'] : array();
 
-                $category_ids = isset($post_info['category_ids']) ? $post_info['category_ids'] : [];
-                $category_slugs = isset($post_info['category_slugs']) ? $post_info['category_slugs'] : [];
-                $primary_genre = isset($post_info['primary_genre']) ? $post_info['primary_genre'] : '';
+                $category_ids   = isset( $post_info['category_ids'] ) ? $post_info['category_ids'] : array();
+                $category_slugs = isset( $post_info['category_slugs'] ) ? $post_info['category_slugs'] : array();
+                $primary_genre  = isset( $post_info['primary_genre'] ) ? $post_info['primary_genre'] : '';
 
-                $excerpt = get_the_excerpt($post_id);
-                if (!is_string($excerpt) || $excerpt === '') {
-                    $excerpt = wp_trim_words(wp_strip_all_tags($post->post_content), 24, '…');
+                $excerpt = get_the_excerpt( $post_id );
+                if ( ! is_string( $excerpt ) || $excerpt === '' ) {
+                    $excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 24, '…' );
                 }
 
-                $letter = isset($post_info['letter']) && $post_info['letter'] !== '' ? $post_info['letter'] : self::normalize_letter($title);
+                $letter = isset( $post_info['letter'] ) && $post_info['letter'] !== '' ? $post_info['letter'] : self::normalize_letter( $title );
 
-                $games[] = [
-                    'post_id'             => $post_id,
-                    'title'               => $title,
-                    'permalink'           => get_permalink($post_id),
-                    'score_value'         => $score_value,
-                    'score_display'       => $score_display,
-                    'score_color'         => $score_color,
-                    'cover_url'           => $cover_url,
-                    'release_date'        => $release_iso,
-                    'release_display'     => $release_display,
-                    'developer'           => $developer,
-                    'publisher'           => $publisher,
-                    'platforms'           => $platform_labels,
-                    'platform_slugs'      => $platform_slugs,
-                    'category_ids'        => $category_ids,
-                    'category_slugs'      => $category_slugs,
-                    'genre'               => $primary_genre,
-                    'excerpt'             => $excerpt,
-                    'letter'              => $letter,
-                    'availability'        => $availability_status,
-                    'availability_label'  => $availability_data['label'],
-                    'timestamp'           => get_post_time('U', true, $post),
-                    'search_haystack'     => isset($post_info['search_haystack']) ? $post_info['search_haystack'] : '',
-                ];
+                $games[] = array(
+                    'post_id'            => $post_id,
+                    'title'              => $title,
+                    'permalink'          => get_permalink( $post_id ),
+                    'score_value'        => $score_value,
+                    'score_display'      => $score_display,
+                    'score_color'        => $score_color,
+                    'cover_url'          => $cover_url,
+                    'release_date'       => $release_iso,
+                    'release_display'    => $release_display,
+                    'developer'          => $developer,
+                    'publisher'          => $publisher,
+                    'platforms'          => $platform_labels,
+                    'platform_slugs'     => $platform_slugs,
+                    'category_ids'       => $category_ids,
+                    'category_slugs'     => $category_slugs,
+                    'genre'              => $primary_genre,
+                    'excerpt'            => $excerpt,
+                    'letter'             => $letter,
+                    'availability'       => $availability_status,
+                    'availability_label' => $availability_data['label'],
+                    'timestamp'          => get_post_time( 'U', true, $post ),
+                    'search_haystack'    => isset( $post_info['search_haystack'] ) ? $post_info['search_haystack'] : '',
+                );
             }
             wp_reset_postdata();
         }
 
-        if (empty($games)) {
+        if ( empty( $games ) ) {
             $total_items = 0;
             $total_pages = 0;
-            $paged = 1;
+            $paged       = 1;
         }
 
         $message = $no_results_message;
 
-        $config_payload = [
-            'atts' => [
+        $config_payload = array(
+            'atts'    => array(
                 'id'             => $atts['id'],
                 'posts_per_page' => $posts_per_page,
                 'columns'        => $columns,
-                'filters'        => implode(',', array_keys(array_filter($filters_enabled))),
+                'filters'        => implode( ',', array_keys( array_filter( $filters_enabled ) ) ),
                 'categorie'      => $atts['categorie'],
                 'plateforme'     => $atts['plateforme'],
                 'lettre'         => $atts['lettre'],
-            ],
-            'state' => [
+            ),
+            'state'   => array(
                 'orderby'      => $orderby,
                 'order'        => $order,
                 'letter'       => $letter_filter,
@@ -1102,97 +1112,100 @@ class JLG_Shortcode_Game_Explorer {
                 'availability' => $availability_filter,
                 'search'       => $search_filter,
                 'paged'        => $paged,
-            ],
-            'request' => [
+            ),
+            'request' => array(
                 'prefix' => $request_prefix,
                 'keys'   => $request_keys,
-            ],
-        ];
+            ),
+        );
 
-        return [
-            'atts'               => array_merge($atts, [
-                'posts_per_page' => $posts_per_page,
-                'columns'        => $columns,
-            ]),
-            'games'              => array_values($games),
-            'letters'            => $letters,
-            'filters_enabled'    => $filters_enabled,
-            'current_filters'    => [
+        return array(
+            'atts'                 => array_merge(
+                $atts,
+                array(
+					'posts_per_page' => $posts_per_page,
+					'columns'        => $columns,
+				)
+            ),
+            'games'                => array_values( $games ),
+            'letters'              => $letters,
+            'filters_enabled'      => $filters_enabled,
+            'current_filters'      => array(
                 'letter'       => $letter_filter,
                 'category'     => $category_filter_value,
                 'platform'     => $platform_filter_slug,
                 'availability' => $availability_filter,
                 'search'       => $search_filter,
-            ],
-            'sort_options'       => self::get_sort_options(),
-            'sort_key'           => $orderby,
-            'sort_order'         => $order,
-            'pagination'         => [
+            ),
+            'sort_options'         => self::get_sort_options(),
+            'sort_key'             => $orderby,
+            'sort_order'           => $order,
+            'pagination'           => array(
                 'current' => $paged,
                 'total'   => $total_pages,
-            ],
-            'categories_list'    => $categories_list,
-            'platforms_list'     => $platform_entries,
+            ),
+            'categories_list'      => $categories_list,
+            'platforms_list'       => $platform_entries,
             'availability_options' => $availability_options,
-            'total_items'        => $total_items,
-            'message'            => $message,
-            'config_payload'     => $config_payload,
-            'request_prefix'     => $request_prefix,
-            'request_keys'       => $request_keys,
-        ];
+            'total_items'          => $total_items,
+            'message'              => $message,
+            'config_payload'       => $config_payload,
+            'request_prefix'       => $request_prefix,
+            'request_keys'         => $request_keys,
+        );
     }
 
-    private static function normalize_container_id($raw_id) {
-        $raw_id = is_string($raw_id) ? $raw_id : '';
-        $sanitized = sanitize_html_class($raw_id);
+    private static function normalize_container_id( $raw_id ) {
+        $raw_id    = is_string( $raw_id ) ? $raw_id : '';
+        $sanitized = sanitize_html_class( $raw_id );
 
-        if ($sanitized === '') {
+        if ( $sanitized === '' ) {
             $sanitized = 'jlg-game-explorer-' . uniqid();
         }
 
         return $sanitized;
     }
 
-    private static function get_request_prefix($container_id) {
-        $container_id = is_string($container_id) ? $container_id : '';
-        $prefix = sanitize_title($container_id);
+    private static function get_request_prefix( $container_id ) {
+        $container_id = is_string( $container_id ) ? $container_id : '';
+        $prefix       = sanitize_title( $container_id );
 
-        if ($prefix === '') {
+        if ( $prefix === '' ) {
             $prefix = 'jlg-game-explorer';
         }
 
         return $prefix;
     }
 
-    private static function build_request_keys($prefix) {
-        $keys = [];
+    private static function build_request_keys( $prefix ) {
+        $keys = array();
 
-        foreach (self::REQUEST_KEYS as $key) {
-            $keys[$key] = $prefix !== '' ? $key . '__' . $prefix : $key;
+        foreach ( self::REQUEST_KEYS as $key ) {
+            $keys[ $key ] = $prefix !== '' ? $key . '__' . $prefix : $key;
         }
 
         return $keys;
     }
 
-    private static function extract_request_params($request, array $request_keys) {
-        if (!is_array($request)) {
-            return [];
+    private static function extract_request_params( $request, array $request_keys ) {
+        if ( ! is_array( $request ) ) {
+            return array();
         }
 
-        if (function_exists('wp_unslash')) {
-            $request = wp_unslash($request);
+        if ( function_exists( 'wp_unslash' ) ) {
+            $request = wp_unslash( $request );
         }
 
-        $normalized = [];
+        $normalized = array();
 
-        foreach ($request_keys as $key => $namespaced_key) {
-            if (array_key_exists($namespaced_key, $request)) {
-                $normalized[$key] = $request[$namespaced_key];
+        foreach ( $request_keys as $key => $namespaced_key ) {
+            if ( array_key_exists( $namespaced_key, $request ) ) {
+                $normalized[ $key ] = $request[ $namespaced_key ];
                 continue;
             }
 
-            if (array_key_exists($key, $request)) {
-                $normalized[$key] = $request[$key];
+            if ( array_key_exists( $key, $request ) ) {
+                $normalized[ $key ] = $request[ $key ];
             }
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-info.php
@@ -1,15 +1,17 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Game_Info {
-    
+
     public function __construct() {
-        add_shortcode('jlg_fiche_technique', [$this, 'render']);
+        add_shortcode( 'jlg_fiche_technique', array( $this, 'render' ) );
     }
 
-    public function render($atts = [], $content = '', $shortcode_tag = '') {
+    public function render( $atts = array(), $content = '', $shortcode_tag = '' ) {
         // Définition de tous les champs possibles avec leur libellé
-        $all_possible_fields = [
+        $all_possible_fields = array(
             'developpeur'  => 'Développeur',
             'editeur'      => 'Éditeur',
             'date_sortie'  => 'Date de sortie',
@@ -17,125 +19,142 @@ class JLG_Shortcode_Game_Info {
             'pegi'         => 'PEGI',
             'temps_de_jeu' => 'Temps de jeu',
             'plateformes'  => 'Plateformes',
-        ];
-        
-        // Attributs du shortcode
-        $default_fields_order = implode(',', array_keys($all_possible_fields));
-        $atts = shortcode_atts([
-            'titre'  => 'Fiche Technique',
-            'champs' => $default_fields_order,
-            'post_id' => '',
-        ], $atts, 'jlg_fiche_technique');
+        );
 
-        $post_id = $this->resolve_target_post_id($atts['post_id']);
-        if (!$post_id) {
+        // Attributs du shortcode
+        $default_fields_order = implode( ',', array_keys( $all_possible_fields ) );
+        $atts                 = shortcode_atts(
+            array(
+				'titre'   => 'Fiche Technique',
+				'champs'  => $default_fields_order,
+				'post_id' => '',
+            ),
+            $atts,
+            'jlg_fiche_technique'
+        );
+
+        $post_id = $this->resolve_target_post_id( $atts['post_id'] );
+        if ( ! $post_id ) {
             return '';
         }
 
         // On transforme la liste de l'attribut en tableau
-        $requested_fields = array_map('trim', explode(',', $atts['champs']));
+        $requested_fields = array_map( 'trim', explode( ',', $atts['champs'] ) );
 
-        $data_to_display = [];
-        foreach ($requested_fields as $field_key) {
+        $data_to_display = array();
+        foreach ( $requested_fields as $field_key ) {
             // On vérifie si le champ demandé est valide
-            if (array_key_exists($field_key, $all_possible_fields)) {
-                $meta_value = $this->sanitize_meta_value(get_post_meta($post_id, '_jlg_' . $field_key, true));
+            if ( array_key_exists( $field_key, $all_possible_fields ) ) {
+                $meta_value = $this->sanitize_meta_value( get_post_meta( $post_id, '_jlg_' . $field_key, true ) );
 
-                if ($this->has_displayable_value($meta_value)) {
-                    $data_to_display[$field_key] = [
-                        'label' => $all_possible_fields[$field_key],
+                if ( $this->has_displayable_value( $meta_value ) ) {
+                    $data_to_display[ $field_key ] = array(
+                        'label' => $all_possible_fields[ $field_key ],
                         'value' => $meta_value,
-                    ];
+                    );
                 }
             }
         }
 
-        if (empty($data_to_display)) {
+        if ( empty( $data_to_display ) ) {
             return '';
         }
-        
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_fiche_technique');
 
-        return JLG_Frontend::get_template_html('shortcode-game-info', [
-            'titre'             => sanitize_text_field($atts['titre']),
-            'champs_a_afficher' => $data_to_display,
-        ]);
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'jlg_fiche_technique' );
+
+        return JLG_Frontend::get_template_html(
+            'shortcode-game-info',
+            array(
+				'titre'             => sanitize_text_field( $atts['titre'] ),
+				'champs_a_afficher' => $data_to_display,
+			)
+        );
     }
 
-    private function resolve_target_post_id($post_id_attribute) {
-        $post_id = absint($post_id_attribute);
+    private function resolve_target_post_id( $post_id_attribute ) {
+        $post_id       = absint( $post_id_attribute );
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        if ($post_id && $this->is_valid_target_post($post_id, $allowed_types)) {
+        if ( $post_id && $this->is_valid_target_post( $post_id, $allowed_types ) ) {
             return $post_id;
         }
 
-        if ($post_id_attribute !== '' && $post_id === 0) {
+        if ( $post_id_attribute !== '' && $post_id === 0 ) {
             return 0;
         }
 
         $current_post_id = get_the_ID();
-        if (!$current_post_id) {
+        if ( ! $current_post_id ) {
             return 0;
         }
 
-        if (function_exists('is_singular') && !is_singular($allowed_types)) {
+        if ( function_exists( 'is_singular' ) && ! is_singular( $allowed_types ) ) {
             return 0;
         }
 
-        return $this->is_valid_target_post($current_post_id, $allowed_types) ? $current_post_id : 0;
+        return $this->is_valid_target_post( $current_post_id, $allowed_types ) ? $current_post_id : 0;
     }
 
-    private function is_valid_target_post($post_id, ?array $allowed_types = null) {
-        if ($allowed_types === null) {
+    private function is_valid_target_post( $post_id, ?array $allowed_types = null ) {
+        if ( $allowed_types === null ) {
             $allowed_types = JLG_Helpers::get_allowed_post_types();
         }
 
-        $post = get_post($post_id);
-        if (!$post instanceof WP_Post) {
+        $post = get_post( $post_id );
+        if ( ! $post instanceof WP_Post ) {
             return false;
         }
 
-        if (!in_array($post->post_type ?? '', $allowed_types, true)) {
+        if ( ! in_array( $post->post_type ?? '', $allowed_types, true ) ) {
             return false;
         }
 
         $status = $post->post_status ?? '';
 
-        if ($status === 'publish') {
+        if ( $status === 'publish' ) {
             return true;
         }
 
-        return current_user_can('read_post', $post_id);
+        return current_user_can( 'read_post', $post_id );
     }
 
-    private function sanitize_meta_value($meta_value) {
-        if (is_array($meta_value)) {
-            $sanitized = array_filter(array_map(static function ($value) {
-                if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
-                    $clean_value = sanitize_text_field((string) $value);
+    private function sanitize_meta_value( $meta_value ) {
+        if ( is_array( $meta_value ) ) {
+            $sanitized = array_filter(
+                array_map(
+                    static function ( $value ) {
+						if ( is_scalar( $value ) || ( is_object( $value ) && method_exists( $value, '__toString' ) ) ) {
+							$clean_value = sanitize_text_field( (string) $value );
 
-                    return wp_strip_all_tags($clean_value);
-                }
+							return wp_strip_all_tags( $clean_value );
+						}
 
-                return '';
-            }, $meta_value));
+						return '';
+					},
+                    $meta_value
+                )
+            );
 
-            return array_values(array_filter($sanitized, static function ($value) {
-                return $value !== '';
-            }));
+            return array_values(
+                array_filter(
+                    $sanitized,
+                    static function ( $value ) {
+						return $value !== '';
+					}
+                )
+            );
         }
 
-        if (is_scalar($meta_value) || (is_object($meta_value) && method_exists($meta_value, '__toString'))) {
-            return wp_strip_all_tags(sanitize_text_field((string) $meta_value));
+        if ( is_scalar( $meta_value ) || ( is_object( $meta_value ) && method_exists( $meta_value, '__toString' ) ) ) {
+            return wp_strip_all_tags( sanitize_text_field( (string) $meta_value ) );
         }
 
         return '';
     }
 
-    private function has_displayable_value($value) {
-        if (is_array($value)) {
-            return !empty($value);
+    private function has_displayable_value( $value ) {
+        if ( is_array( $value ) ) {
+            return ! empty( $value );
         }
 
         return $value !== '';

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-pros-cons.php
@@ -1,33 +1,38 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Pros_Cons {
-    
+
     public function __construct() {
-        add_shortcode('jlg_points_forts_faibles', [$this, 'render']);
+        add_shortcode( 'jlg_points_forts_faibles', array( $this, 'render' ) );
     }
 
-    public function render($atts = [], $content = '', $shortcode_tag = '') {
+    public function render( $atts = array(), $content = '', $shortcode_tag = '' ) {
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
         // Sécurité : ne s'exécute que sur les contenus autorisés
-        if (!is_singular($allowed_types)) {
+        if ( ! is_singular( $allowed_types ) ) {
             return '';
         }
 
-        $pros = get_post_meta(get_the_ID(), '_jlg_points_forts', true);
-        $cons = get_post_meta(get_the_ID(), '_jlg_points_faibles', true);
+        $pros = get_post_meta( get_the_ID(), '_jlg_points_forts', true );
+        $cons = get_post_meta( get_the_ID(), '_jlg_points_faibles', true );
 
         // Sécurité : ne s'exécute que si les données existent
-        if (empty($pros) && empty($cons)) {
+        if ( empty( $pros ) && empty( $cons ) ) {
             return '';
         }
-        
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_points_forts_faibles');
 
-        return JLG_Frontend::get_template_html('shortcode-pros-cons', [
-            'pros_list' => !empty($pros) ? array_filter(explode("\n", $pros)) : [],
-            'cons_list' => !empty($cons) ? array_filter(explode("\n", $cons)) : [],
-        ]);
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'jlg_points_forts_faibles' );
+
+        return JLG_Frontend::get_template_html(
+            'shortcode-pros-cons',
+            array(
+				'pros_list' => ! empty( $pros ) ? array_filter( explode( "\n", $pros ) ) : array(),
+				'cons_list' => ! empty( $cons ) ? array_filter( explode( "\n", $cons ) ) : array(),
+			)
+        );
     }
 }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-rating-block.php
@@ -1,57 +1,66 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Rating_Block {
-    
+
     public function __construct() {
-        add_shortcode('bloc_notation_jeu', [$this, 'render']);
+        add_shortcode( 'bloc_notation_jeu', array( $this, 'render' ) );
     }
 
-    public function render($atts, $content = '', $shortcode_tag = '') {
-        $atts = shortcode_atts([
-            'post_id' => get_the_ID()
-        ], $atts, 'bloc_notation_jeu');
-        
-        $post_id = intval($atts['post_id']);
+    public function render( $atts, $content = '', $shortcode_tag = '' ) {
+        $atts = shortcode_atts(
+            array(
+				'post_id' => get_the_ID(),
+            ),
+            $atts,
+            'bloc_notation_jeu'
+        );
 
-        if (!$post_id) {
+        $post_id = intval( $atts['post_id'] );
+
+        if ( ! $post_id ) {
             return '';
         }
 
-        $post = get_post($post_id);
+        $post          = get_post( $post_id );
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        if (!$post instanceof WP_Post || !in_array($post->post_type ?? '', $allowed_types, true)) {
+        if ( ! $post instanceof WP_Post || ! in_array( $post->post_type ?? '', $allowed_types, true ) ) {
             return '';
         }
 
-        if (($post->post_status ?? '') !== 'publish' && !current_user_can('read_post', $post_id)) {
+        if ( ( $post->post_status ?? '' ) !== 'publish' && ! current_user_can( 'read_post', $post_id ) ) {
             return '';
         }
 
         // Sécurité : ne s'exécute que si des notes existent
-        $average_score = JLG_Helpers::get_average_score_for_post($post_id);
-        if ($average_score === null) {
+        $average_score = JLG_Helpers::get_average_score_for_post( $post_id );
+        if ( $average_score === null ) {
             return '';
         }
 
         $categories = JLG_Helpers::get_rating_categories();
-        $scores = [];
-        
-        foreach (array_keys($categories) as $key) {
-            $score_value = get_post_meta($post_id, '_note_' . $key, true);
-            if ($score_value !== '' && is_numeric($score_value)) {
-                $scores[$key] = floatval($score_value);
+        $scores     = array();
+
+        foreach ( array_keys( $categories ) as $key ) {
+            $score_value = get_post_meta( $post_id, '_note_' . $key, true );
+            if ( $score_value !== '' && is_numeric( $score_value ) ) {
+                $scores[ $key ] = floatval( $score_value );
             }
         }
-        
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'bloc_notation_jeu');
 
-        return JLG_Frontend::get_template_html('shortcode-rating-block', [
-            'options'       => JLG_Helpers::get_plugin_options(),
-            'average_score' => $average_score,
-            'scores'        => $scores,
-            'categories'    => $categories,
-        ]);
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'bloc_notation_jeu' );
+
+        return JLG_Frontend::get_template_html(
+            'shortcode-rating-block',
+            array(
+				'options'       => JLG_Helpers::get_plugin_options(),
+				'average_score' => $average_score,
+				'scores'        => $scores,
+				'categories'    => $categories,
+			)
+        );
     }
 }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-summary-display.php
@@ -1,271 +1,282 @@
 <?php
 /**
  * Shortcode pour le tableau/grille récapitulatif
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Summary_Display {
 
     private const MAX_SYNC_AVERAGE_REBUILDS = 10;
-    private const REQUEST_KEYS = [
+    private const REQUEST_KEYS              = array(
         'orderby',
         'order',
         'cat_filter',
         'letter_filter',
         'genre_filter',
         'paged',
-    ];
-    
+    );
+
     public function __construct() {
-        add_shortcode('jlg_tableau_recap', [$this, 'render']);
+        add_shortcode( 'jlg_tableau_recap', array( $this, 'render' ) );
     }
 
-    public function render($atts, $content = '', $shortcode_tag = '') {
-        $context = self::get_render_context($atts, $_GET, true);
+    public function render( $atts, $content = '', $shortcode_tag = '' ) {
+        $context = self::get_render_context( $atts, $_GET, true );
 
-        if (!empty($context['error']) && !empty($context['message'])) {
+        if ( ! empty( $context['error'] ) && ! empty( $context['message'] ) ) {
             return $context['message'];
         }
 
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'jlg_tableau_recap');
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'jlg_tableau_recap' );
 
-        return JLG_Frontend::get_template_html('shortcode-summary-display', $context);
+        return JLG_Frontend::get_template_html( 'shortcode-summary-display', $context );
     }
 
-    public static function get_render_context($atts, $request = [], $use_global_paged = false) {
+    public static function get_render_context( $atts, $request = array(), $use_global_paged = false ) {
         $default_atts = self::get_default_atts();
-        $atts = shortcode_atts($default_atts, $atts, 'jlg_tableau_recap');
+        $atts         = shortcode_atts( $default_atts, $atts, 'jlg_tableau_recap' );
 
-        $atts['id'] = self::normalize_table_id($atts['id'] ?? '');
-        $request_prefix = self::get_request_prefix($atts['id']);
-        $request_keys = self::build_request_keys($request_prefix);
+        $atts['id']     = self::normalize_table_id( $atts['id'] ?? '' );
+        $request_prefix = self::get_request_prefix( $atts['id'] );
+        $request_keys   = self::build_request_keys( $request_prefix );
 
-        $request = self::extract_request_params($request, $request_keys);
+        $request = self::extract_request_params( $request, $request_keys );
 
-        $default_posts_per_page = isset($default_atts['posts_per_page']) ? intval($default_atts['posts_per_page']) : 12;
-        if ($default_posts_per_page < 1) {
+        $default_posts_per_page = isset( $default_atts['posts_per_page'] ) ? intval( $default_atts['posts_per_page'] ) : 12;
+        if ( $default_posts_per_page < 1 ) {
             $default_posts_per_page = 1;
         }
 
-        $posts_per_page = isset($atts['posts_per_page']) ? intval($atts['posts_per_page']) : $default_posts_per_page;
-        if ($posts_per_page < 1) {
+        $posts_per_page = isset( $atts['posts_per_page'] ) ? intval( $atts['posts_per_page'] ) : $default_posts_per_page;
+        if ( $posts_per_page < 1 ) {
             $posts_per_page = $default_posts_per_page;
         }
-        $posts_per_page = max(1, min($posts_per_page, 50));
+        $posts_per_page = max( 1, min( $posts_per_page, 50 ) );
 
         $atts['posts_per_page'] = $posts_per_page;
-        $atts['id'] = sanitize_html_class($atts['id']);
-        if ($atts['id'] === '') {
+        $atts['id']             = sanitize_html_class( $atts['id'] );
+        if ( $atts['id'] === '' ) {
             $atts['id'] = 'jlg-table-' . uniqid();
         }
-        if (!in_array($atts['layout'], ['table', 'grid'], true)) {
+        if ( ! in_array( $atts['layout'], array( 'table', 'grid' ), true ) ) {
             $atts['layout'] = 'table';
         }
 
-        $request = is_array($request) ? $request : [];
+        $request = is_array( $request ) ? $request : array();
 
-        $orderby = (isset($request['orderby']) && is_string($request['orderby'])) ? sanitize_key($request['orderby']) : 'date';
-        $order = isset($request['order']) && in_array(strtoupper($request['order']), ['ASC', 'DESC'], true)
-            ? strtoupper($request['order'])
+        $orderby       = ( isset( $request['orderby'] ) && is_string( $request['orderby'] ) ) ? sanitize_key( $request['orderby'] ) : 'date';
+        $order         = isset( $request['order'] ) && in_array( strtoupper( $request['order'] ), array( 'ASC', 'DESC' ), true )
+            ? strtoupper( $request['order'] )
             : 'DESC';
-        $cat_filter = isset($request['cat_filter']) ? intval($request['cat_filter']) : 0;
+        $cat_filter    = isset( $request['cat_filter'] ) ? intval( $request['cat_filter'] ) : 0;
         $letter_filter = '';
-        if (isset($request['letter_filter'])) {
-            $letter_filter = self::normalize_letter_filter($request['letter_filter']);
-        } elseif (!empty($atts['letter_filter'])) {
-            $letter_filter = self::normalize_letter_filter($atts['letter_filter']);
+        if ( isset( $request['letter_filter'] ) ) {
+            $letter_filter = self::normalize_letter_filter( $request['letter_filter'] );
+        } elseif ( ! empty( $atts['letter_filter'] ) ) {
+            $letter_filter = self::normalize_letter_filter( $atts['letter_filter'] );
         }
 
         $genre_filter = '';
-        if (isset($request['genre_filter'])) {
-            $genre_filter = sanitize_text_field($request['genre_filter']);
-        } elseif (!empty($atts['genre_filter'])) {
-            $genre_filter = sanitize_text_field($atts['genre_filter']);
+        if ( isset( $request['genre_filter'] ) ) {
+            $genre_filter = sanitize_text_field( $request['genre_filter'] );
+        } elseif ( ! empty( $atts['genre_filter'] ) ) {
+            $genre_filter = sanitize_text_field( $atts['genre_filter'] );
         }
 
         $atts['letter_filter'] = $letter_filter;
-        $atts['genre_filter'] = $genre_filter;
+        $atts['genre_filter']  = $genre_filter;
 
-        $paged = isset($request['paged']) ? intval($request['paged']) : 0;
-        if ($paged < 1) {
-            $paged = ($use_global_paged && get_query_var('paged')) ? intval(get_query_var('paged')) : 1;
+        $paged = isset( $request['paged'] ) ? intval( $request['paged'] ) : 0;
+        if ( $paged < 1 ) {
+            $paged = ( $use_global_paged && get_query_var( 'paged' ) ) ? intval( get_query_var( 'paged' ) ) : 1;
         }
 
         $sorting_options = self::get_sorting_options();
-        if (!isset($sorting_options[$orderby])) {
+        if ( ! isset( $sorting_options[ $orderby ] ) ) {
             $orderby = 'date';
         }
 
-        $sorting = $sorting_options[$orderby];
+        $sorting = $sorting_options[ $orderby ];
         $orderby = $sorting['key'];
 
-        $rated_post_ids = JLG_Helpers::get_rated_post_ids();
+        $rated_post_ids     = JLG_Helpers::get_rated_post_ids();
         $allowed_post_types = JLG_Helpers::get_allowed_post_types();
-        $allowed_post_types = array_values(array_unique(array_filter($allowed_post_types, static function ($type) {
-            return is_string($type) && $type !== '';
-        })));
+        $allowed_post_types = array_values(
+            array_unique(
+                array_filter(
+                    $allowed_post_types,
+                    static function ( $type ) {
+						return is_string( $type ) && $type !== '';
+					}
+                )
+            )
+        );
 
-        if (empty($allowed_post_types)) {
-            $allowed_post_types = ['post'];
+        if ( empty( $allowed_post_types ) ) {
+            $allowed_post_types = array( 'post' );
         }
 
-        if (!empty($rated_post_ids) && isset($sorting['meta_key']) && $sorting['meta_key'] === '_jlg_average_score') {
-            $max_sync = apply_filters('jlg_summary_max_sync_average_rebuilds', self::MAX_SYNC_AVERAGE_REBUILDS, $atts);
-            $max_sync = max(0, intval($max_sync));
+        if ( ! empty( $rated_post_ids ) && isset( $sorting['meta_key'] ) && $sorting['meta_key'] === '_jlg_average_score' ) {
+            $max_sync = apply_filters( 'jlg_summary_max_sync_average_rebuilds', self::MAX_SYNC_AVERAGE_REBUILDS, $atts );
+            $max_sync = max( 0, intval( $max_sync ) );
 
-            $posts_missing_average = get_posts([
-                'post_type'      => $allowed_post_types,
-                'post__in'       => $rated_post_ids,
-                'fields'         => 'ids',
-                'posts_per_page' => $max_sync + 1,
-                'orderby'        => 'ID',
-                'order'          => 'ASC',
-                'no_found_rows'  => true,
-                'meta_query'     => [
-                    'relation' => 'OR',
-                    [
-                        'key'     => '_jlg_average_score',
-                        'compare' => 'NOT EXISTS',
-                    ],
-                    [
-                        'key'     => '_jlg_average_score',
-                        'value'   => '',
-                        'compare' => '=',
-                    ],
-                ],
-            ]);
+            $posts_missing_average = get_posts(
+                array(
+					'post_type'      => $allowed_post_types,
+					'post__in'       => $rated_post_ids,
+					'fields'         => 'ids',
+					'posts_per_page' => $max_sync + 1,
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+					'no_found_rows'  => true,
+					'meta_query'     => array(
+						'relation' => 'OR',
+						array(
+							'key'     => '_jlg_average_score',
+							'compare' => 'NOT EXISTS',
+						),
+						array(
+							'key'     => '_jlg_average_score',
+							'value'   => '',
+							'compare' => '=',
+						),
+					),
+                )
+            );
 
-            if (!empty($posts_missing_average)) {
-                $sync_targets = array_slice($posts_missing_average, 0, $max_sync);
+            if ( ! empty( $posts_missing_average ) ) {
+                $sync_targets = array_slice( $posts_missing_average, 0, $max_sync );
 
-                foreach ($sync_targets as $post_id) {
-                    JLG_Helpers::get_resolved_average_score($post_id);
+                foreach ( $sync_targets as $post_id ) {
+                    JLG_Helpers::get_resolved_average_score( $post_id );
                 }
 
-                $async_targets = array_diff($posts_missing_average, $sync_targets);
+                $async_targets = array_diff( $posts_missing_average, $sync_targets );
 
-                if (!empty($async_targets)) {
-                    JLG_Helpers::queue_average_score_rebuild($async_targets);
+                if ( ! empty( $async_targets ) ) {
+                    JLG_Helpers::queue_average_score_rebuild( $async_targets );
                 }
             }
         }
-        if (empty($rated_post_ids)) {
-            $no_results = '<p>' . esc_html__('Aucun article noté trouvé.', 'notation-jlg') . '</p>';
+        if ( empty( $rated_post_ids ) ) {
+            $no_results = '<p>' . esc_html__( 'Aucun article noté trouvé.', 'notation-jlg' ) . '</p>';
 
-            return [
-                'error'        => true,
-                'message'      => $no_results,
-                'atts'         => $atts,
-                'paged'        => $paged,
-                'orderby'      => $orderby,
-                'order'        => $order,
-                'cat_filter'   => $cat_filter,
-                'letter_filter'=> $letter_filter,
-                'genre_filter' => $genre_filter,
-                'colonnes'     => self::prepare_columns($atts),
+            return array(
+                'error'                => true,
+                'message'              => $no_results,
+                'atts'                 => $atts,
+                'paged'                => $paged,
+                'orderby'              => $orderby,
+                'order'                => $order,
+                'cat_filter'           => $cat_filter,
+                'letter_filter'        => $letter_filter,
+                'genre_filter'         => $genre_filter,
+                'colonnes'             => self::prepare_columns( $atts ),
                 'colonnes_disponibles' => self::get_available_columns(),
-                'error_message' => $no_results,
-                'request_prefix' => $request_prefix,
-                'request_keys'   => $request_keys,
-            ];
+                'error_message'        => $no_results,
+                'request_prefix'       => $request_prefix,
+                'request_keys'         => $request_keys,
+            );
         }
 
-        $args = [
+        $args = array(
             'post_type'      => $allowed_post_types,
             'posts_per_page' => $posts_per_page,
             'paged'          => $paged,
             'order'          => $order,
-        ];
+        );
 
-        $max_post_in = apply_filters('jlg_summary_max_post__in', 500, $atts);
-        $max_post_in = max(0, intval($max_post_in));
+        $max_post_in = apply_filters( 'jlg_summary_max_post__in', 500, $atts );
+        $max_post_in = max( 0, intval( $max_post_in ) );
 
-        if ($max_post_in === 0 || count($rated_post_ids) <= $max_post_in) {
+        if ( $max_post_in === 0 || count( $rated_post_ids ) <= $max_post_in ) {
             $args['post__in'] = $rated_post_ids;
         } else {
-            $args['meta_query'][] = [
+            $args['meta_query'][] = array(
                 'key'     => '_jlg_average_score',
                 'compare' => 'EXISTS',
-            ];
+            );
         }
 
-        if ($orderby === 'average_score' || $orderby === 'note') {
-            $args['orderby'] = 'meta_value_num';
+        if ( $orderby === 'average_score' || $orderby === 'note' ) {
+            $args['orderby']  = 'meta_value_num';
             $args['meta_key'] = '_jlg_average_score';
-        } elseif (!empty($sorting['meta_key'])) {
-            $args['orderby'] = $sorting['orderby'];
+        } elseif ( ! empty( $sorting['meta_key'] ) ) {
+            $args['orderby']  = $sorting['orderby'];
             $args['meta_key'] = $sorting['meta_key'];
 
-            if (!empty($sorting['type'])) {
+            if ( ! empty( $sorting['type'] ) ) {
                 $args['meta_type'] = $sorting['type'];
             }
         } else {
             $args['orderby'] = $sorting['orderby'];
         }
 
-        if (!empty($atts['categorie'])) {
-            $args['category_name'] = sanitize_text_field($atts['categorie']);
-        } elseif ($cat_filter > 0) {
+        if ( ! empty( $atts['categorie'] ) ) {
+            $args['category_name'] = sanitize_text_field( $atts['categorie'] );
+        } elseif ( $cat_filter > 0 ) {
             $args['cat'] = $cat_filter;
         }
 
-        if ($genre_filter !== '') {
-            $genre_taxonomy = apply_filters('jlg_summary_genre_taxonomy', 'jlg_game_genre');
+        if ( $genre_filter !== '' ) {
+            $genre_taxonomy = apply_filters( 'jlg_summary_genre_taxonomy', 'jlg_game_genre' );
 
-            if (!empty($genre_taxonomy) && taxonomy_exists($genre_taxonomy)) {
-                if (!isset($args['tax_query']) || !is_array($args['tax_query'])) {
-                    $args['tax_query'] = [];
+            if ( ! empty( $genre_taxonomy ) && taxonomy_exists( $genre_taxonomy ) ) {
+                if ( ! isset( $args['tax_query'] ) || ! is_array( $args['tax_query'] ) ) {
+                    $args['tax_query'] = array();
                 }
 
-                if (!isset($args['tax_query']['relation'])) {
+                if ( ! isset( $args['tax_query']['relation'] ) ) {
                     $args['tax_query']['relation'] = 'AND';
                 }
 
-                $args['tax_query'][] = [
+                $args['tax_query'][] = array(
                     'taxonomy' => $genre_taxonomy,
                     'field'    => 'slug',
                     'terms'    => $genre_filter,
-                ];
+                );
             } else {
-                $genre_meta_key = apply_filters('jlg_summary_genre_meta_key', '_jlg_genre');
+                $genre_meta_key = apply_filters( 'jlg_summary_genre_meta_key', '_jlg_genre' );
 
-                if (!empty($genre_meta_key)) {
-                    if (!isset($args['meta_query']) || !is_array($args['meta_query'])) {
-                        $args['meta_query'] = [];
+                if ( ! empty( $genre_meta_key ) ) {
+                    if ( ! isset( $args['meta_query'] ) || ! is_array( $args['meta_query'] ) ) {
+                        $args['meta_query'] = array();
                     }
 
-                    if (!isset($args['meta_query']['relation'])) {
+                    if ( ! isset( $args['meta_query']['relation'] ) ) {
                         $args['meta_query']['relation'] = 'AND';
                     }
 
-                    $args['meta_query'][] = [
+                    $args['meta_query'][] = array(
                         'key'     => $genre_meta_key,
                         'value'   => $genre_filter,
                         'compare' => 'LIKE',
-                    ];
+                    );
                 }
             }
         }
 
-        $letter_filter_active = ($letter_filter !== '');
+        $letter_filter_active = ( $letter_filter !== '' );
 
-        if ($letter_filter_active) {
-            self::set_letter_filter($letter_filter);
+        if ( $letter_filter_active ) {
+            self::set_letter_filter( $letter_filter );
         }
 
         try {
-            $query = new WP_Query($args);
+            $query = new WP_Query( $args );
         } finally {
-            if ($letter_filter_active) {
+            if ( $letter_filter_active ) {
                 self::clear_letter_filter();
             }
         }
 
-        return [
+        return array(
             'query'                => $query,
             'atts'                 => $atts,
             'paged'                => $paged,
@@ -274,18 +285,18 @@ class JLG_Shortcode_Summary_Display {
             'cat_filter'           => $cat_filter,
             'letter_filter'        => $letter_filter,
             'genre_filter'         => $genre_filter,
-            'colonnes'             => self::prepare_columns($atts),
+            'colonnes'             => self::prepare_columns( $atts ),
             'colonnes_disponibles' => self::get_available_columns(),
             'error'                => false,
             'error_message'        => '',
             'atts_defaults'        => $default_atts,
             'request_prefix'       => $request_prefix,
             'request_keys'         => $request_keys,
-        ];
+        );
     }
 
     public static function get_default_atts() {
-        return [
+        return array(
             'posts_per_page' => 12,
             'layout'         => 'table',
             'categorie'      => '',
@@ -293,137 +304,137 @@ class JLG_Shortcode_Summary_Display {
             'id'             => 'jlg-table-' . uniqid(),
             'letter_filter'  => '',
             'genre_filter'   => '',
-        ];
+        );
     }
 
-    public static function normalize_letter_filter($value) {
-        if ($value === null) {
+    public static function normalize_letter_filter( $value ) {
+        if ( $value === null ) {
             return '';
         }
 
-        $value = sanitize_text_field($value);
-        $value = trim($value);
+        $value = sanitize_text_field( $value );
+        $value = trim( $value );
 
-        if ($value === '') {
+        if ( $value === '' ) {
             return '';
         }
 
-        $char = substr($value, 0, 1);
+        $char = substr( $value, 0, 1 );
 
-        if ($char === '#') {
+        if ( $char === '#' ) {
             return '#';
         }
 
-        if (ctype_digit($char)) {
+        if ( ctype_digit( $char ) ) {
             return '#';
         }
 
-        if (ctype_alpha($char)) {
-            return strtoupper($char);
+        if ( ctype_alpha( $char ) ) {
+            return strtoupper( $char );
         }
 
         return '';
     }
 
     protected static function get_available_columns() {
-        return [
-            'titre' => [
-                'label'    => __('Titre du jeu', 'notation-jlg'),
+        return array(
+            'titre'       => array(
+                'label'    => __( 'Titre du jeu', 'notation-jlg' ),
                 'sortable' => true,
-                'sort'     => [
-                    'key'      => 'title',
-                    'orderby'  => 'title',
-                    'aliases'  => ['titre'],
-                ],
-            ],
-            'date' => [
-                'label'    => __('Date', 'notation-jlg'),
+                'sort'     => array(
+                    'key'     => 'title',
+                    'orderby' => 'title',
+                    'aliases' => array( 'titre' ),
+                ),
+            ),
+            'date'        => array(
+                'label'    => __( 'Date', 'notation-jlg' ),
                 'sortable' => true,
-                'sort'     => [
+                'sort'     => array(
                     'key'     => 'date',
                     'orderby' => 'date',
-                ],
-            ],
-            'note' => [
-                'label'    => __('Note', 'notation-jlg'),
+                ),
+            ),
+            'note'        => array(
+                'label'    => __( 'Note', 'notation-jlg' ),
                 'sortable' => true,
-                'sort'     => [
+                'sort'     => array(
                     'key'      => 'average_score',
                     'orderby'  => 'meta_value_num',
                     'meta_key' => '_jlg_average_score',
-                    'aliases'  => ['note'],
-                ],
-            ],
-            'developpeur' => [
-                'label'    => __('Développeur', 'notation-jlg'),
+                    'aliases'  => array( 'note' ),
+                ),
+            ),
+            'developpeur' => array(
+                'label'    => __( 'Développeur', 'notation-jlg' ),
                 'sortable' => true,
-                'sort'     => [
+                'sort'     => array(
                     'key'      => 'meta__jlg_developpeur',
                     'orderby'  => 'meta_value',
                     'meta_key' => '_jlg_developpeur',
                     'type'     => 'CHAR',
-                    'aliases'  => ['developpeur'],
-                ],
-            ],
-            'editeur' => [
-                'label'    => __('Éditeur', 'notation-jlg'),
+                    'aliases'  => array( 'developpeur' ),
+                ),
+            ),
+            'editeur'     => array(
+                'label'    => __( 'Éditeur', 'notation-jlg' ),
                 'sortable' => true,
-                'sort'     => [
+                'sort'     => array(
                     'key'      => 'meta__jlg_editeur',
                     'orderby'  => 'meta_value',
                     'meta_key' => '_jlg_editeur',
                     'type'     => 'CHAR',
-                    'aliases'  => ['editeur'],
-                ],
-            ],
-        ];
+                    'aliases'  => array( 'editeur' ),
+                ),
+            ),
+        );
     }
 
     protected static function get_sorting_options() {
         $columns = self::get_available_columns();
-        $options = [];
+        $options = array();
 
-        foreach ($columns as $column_key => $column) {
-            if (empty($column['sortable'])) {
+        foreach ( $columns as $column_key => $column ) {
+            if ( empty( $column['sortable'] ) ) {
                 continue;
             }
 
-            $sort = isset($column['sort']) && is_array($column['sort']) ? $column['sort'] : [];
-            $primary_key = isset($sort['key']) ? sanitize_key($sort['key']) : sanitize_key($column_key);
-            $option = [
+            $sort        = isset( $column['sort'] ) && is_array( $column['sort'] ) ? $column['sort'] : array();
+            $primary_key = isset( $sort['key'] ) ? sanitize_key( $sort['key'] ) : sanitize_key( $column_key );
+            $option      = array(
                 'key'     => $primary_key,
-                'orderby' => isset($sort['orderby']) ? $sort['orderby'] : $primary_key,
-            ];
+                'orderby' => isset( $sort['orderby'] ) ? $sort['orderby'] : $primary_key,
+            );
 
-            if (!empty($sort['meta_key'])) {
+            if ( ! empty( $sort['meta_key'] ) ) {
                 $option['meta_key'] = $sort['meta_key'];
             }
 
-            if (!empty($sort['type'])) {
+            if ( ! empty( $sort['type'] ) ) {
                 $option['type'] = $sort['type'];
             }
 
-            $options[$primary_key] = $option;
+            $options[ $primary_key ] = $option;
 
-            $aliases = [];
+            $aliases = array();
 
-            if (!empty($sort['aliases']) && is_array($sort['aliases'])) {
-                $aliases = array_map('sanitize_key', $sort['aliases']);
+            if ( ! empty( $sort['aliases'] ) && is_array( $sort['aliases'] ) ) {
+                $aliases = array_map( 'sanitize_key', $sort['aliases'] );
             }
 
-            $aliases[] = sanitize_key($column_key);
-            $aliases = array_unique(array_filter($aliases));
+            $aliases[] = sanitize_key( $column_key );
+            $aliases   = array_unique( array_filter( $aliases ) );
 
-            foreach ($aliases as $alias) {
-                $options[$alias] = $option;
+            foreach ( $aliases as $alias ) {
+                $options[ $alias ] = $option;
             }
         }
 
-        if (!isset($options['date'])) {
-            $options['date'] = [
+        if ( ! isset( $options['date'] ) ) {
+            $options['date'] = array(
                 'key'     => 'date',
                 'orderby' => 'date',
-            ];
+            );
         }
 
         return $options;
@@ -431,75 +442,75 @@ class JLG_Shortcode_Summary_Display {
 
     public static function get_allowed_sort_keys() {
         $options = self::get_sorting_options();
-        $allowed = [];
+        $allowed = array();
 
-        foreach ($options as $key => $option) {
-            $allowed[] = sanitize_key($key);
-            if (isset($option['key'])) {
-                $allowed[] = sanitize_key($option['key']);
+        foreach ( $options as $key => $option ) {
+            $allowed[] = sanitize_key( $key );
+            if ( isset( $option['key'] ) ) {
+                $allowed[] = sanitize_key( $option['key'] );
             }
         }
 
         $allowed[] = 'date';
 
-        return array_values(array_unique(array_filter($allowed)));
+        return array_values( array_unique( array_filter( $allowed ) ) );
     }
 
-    protected static function prepare_columns($atts) {
-        $requested = array_filter(array_map('trim', explode(',', $atts['colonnes'])));
+    protected static function prepare_columns( $atts ) {
+        $requested = array_filter( array_map( 'trim', explode( ',', $atts['colonnes'] ) ) );
         $available = self::get_available_columns();
-        $columns = [];
+        $columns   = array();
 
-        foreach ($requested as $column) {
-            if (isset($available[$column])) {
+        foreach ( $requested as $column ) {
+            if ( isset( $available[ $column ] ) ) {
                 $columns[] = $column;
             }
         }
 
-        if (empty($columns)) {
-            $columns = ['titre', 'date', 'note'];
+        if ( empty( $columns ) ) {
+            $columns = array( 'titre', 'date', 'note' );
         }
 
         return $columns;
     }
 
-    protected static function set_letter_filter($letter) {
+    protected static function set_letter_filter( $letter ) {
         self::$active_letter_filter = $letter;
 
-        if (!self::$letter_filter_hooked) {
-            add_filter('posts_where', [__CLASS__, 'filter_letter_where']);
+        if ( ! self::$letter_filter_hooked ) {
+            add_filter( 'posts_where', array( __CLASS__, 'filter_letter_where' ) );
             self::$letter_filter_hooked = true;
         }
     }
 
     protected static function clear_letter_filter() {
-        if (self::$letter_filter_hooked) {
-            remove_filter('posts_where', [__CLASS__, 'filter_letter_where']);
+        if ( self::$letter_filter_hooked ) {
+            remove_filter( 'posts_where', array( __CLASS__, 'filter_letter_where' ) );
             self::$letter_filter_hooked = false;
         }
 
         self::$active_letter_filter = '';
     }
 
-    public static function filter_letter_where($where) {
+    public static function filter_letter_where( $where ) {
         global $wpdb;
 
-        if (self::$active_letter_filter === '') {
+        if ( self::$active_letter_filter === '' ) {
             return $where;
         }
 
         $meta_subquery = "(SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = '_jlg_game_title' ORDER BY meta_id DESC LIMIT 1)";
 
-        if (self::$active_letter_filter === '#') {
+        if ( self::$active_letter_filter === '#' ) {
             $condition = "REGEXP '^[0-9]'";
             $where    .= " AND (({$meta_subquery} {$condition}) OR ({$wpdb->posts}.post_title {$condition}))";
 
             return $where;
         }
 
-        $like = $wpdb->esc_like(self::$active_letter_filter) . '%';
-        $meta_condition = $wpdb->prepare('LIKE %s', $like);
-        $title_condition = $wpdb->prepare('LIKE %s', $like);
+        $like            = $wpdb->esc_like( self::$active_letter_filter ) . '%';
+        $meta_condition  = $wpdb->prepare( 'LIKE %s', $like );
+        $title_condition = $wpdb->prepare( 'LIKE %s', $like );
 
         $where .= " AND (({$meta_subquery} {$meta_condition}) OR ({$wpdb->posts}.post_title {$title_condition}))";
 
@@ -509,57 +520,57 @@ class JLG_Shortcode_Summary_Display {
     private static $active_letter_filter = '';
     private static $letter_filter_hooked = false;
 
-    private static function normalize_table_id($raw_id) {
-        $raw_id = is_string($raw_id) ? $raw_id : '';
-        $sanitized = sanitize_html_class($raw_id);
+    private static function normalize_table_id( $raw_id ) {
+        $raw_id    = is_string( $raw_id ) ? $raw_id : '';
+        $sanitized = sanitize_html_class( $raw_id );
 
-        if ($sanitized === '') {
+        if ( $sanitized === '' ) {
             $sanitized = 'jlg-table-' . uniqid();
         }
 
         return $sanitized;
     }
 
-    private static function get_request_prefix($table_id) {
-        $table_id = is_string($table_id) ? $table_id : '';
-        $prefix = sanitize_title($table_id);
+    private static function get_request_prefix( $table_id ) {
+        $table_id = is_string( $table_id ) ? $table_id : '';
+        $prefix   = sanitize_title( $table_id );
 
-        if ($prefix === '') {
+        if ( $prefix === '' ) {
             $prefix = 'jlg-table';
         }
 
         return $prefix;
     }
 
-    private static function build_request_keys($prefix) {
-        $keys = [];
+    private static function build_request_keys( $prefix ) {
+        $keys = array();
 
-        foreach (self::REQUEST_KEYS as $key) {
-            $keys[$key] = $prefix !== '' ? $key . '__' . $prefix : $key;
+        foreach ( self::REQUEST_KEYS as $key ) {
+            $keys[ $key ] = $prefix !== '' ? $key . '__' . $prefix : $key;
         }
 
         return $keys;
     }
 
-    private static function extract_request_params($request, array $request_keys) {
-        if (!is_array($request)) {
-            return [];
+    private static function extract_request_params( $request, array $request_keys ) {
+        if ( ! is_array( $request ) ) {
+            return array();
         }
 
-        if (function_exists('wp_unslash')) {
-            $request = wp_unslash($request);
+        if ( function_exists( 'wp_unslash' ) ) {
+            $request = wp_unslash( $request );
         }
 
-        $normalized = [];
+        $normalized = array();
 
-        foreach ($request_keys as $key => $namespaced_key) {
-            if (array_key_exists($namespaced_key, $request)) {
-                $normalized[$key] = $request[$namespaced_key];
+        foreach ( $request_keys as $key => $namespaced_key ) {
+            if ( array_key_exists( $namespaced_key, $request ) ) {
+                $normalized[ $key ] = $request[ $namespaced_key ];
                 continue;
             }
 
-            if (array_key_exists($key, $request)) {
-                $normalized[$key] = $request[$key];
+            if ( array_key_exists( $key, $request ) ) {
+                $normalized[ $key ] = $request[ $key ];
             }
         }
 

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-tagline.php
@@ -1,37 +1,42 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_Tagline {
-    
+
     public function __construct() {
-        add_shortcode('tagline_notation_jlg', [$this, 'render']);
+        add_shortcode( 'tagline_notation_jlg', array( $this, 'render' ) );
     }
 
-    public function render($atts = [], $content = '', $shortcode_tag = '') {
+    public function render( $atts = array(), $content = '', $shortcode_tag = '' ) {
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        if (!is_singular($allowed_types)) {
+        if ( ! is_singular( $allowed_types ) ) {
             return '';
         }
 
         $options = JLG_Helpers::get_plugin_options();
-        if (empty($options['tagline_enabled'])) {
+        if ( empty( $options['tagline_enabled'] ) ) {
             return '';
         }
 
-        $tagline_fr = get_post_meta(get_the_ID(), '_jlg_tagline_fr', true);
-        $tagline_en = get_post_meta(get_the_ID(), '_jlg_tagline_en', true);
+        $tagline_fr = get_post_meta( get_the_ID(), '_jlg_tagline_fr', true );
+        $tagline_en = get_post_meta( get_the_ID(), '_jlg_tagline_en', true );
 
-        if (empty($tagline_fr) && empty($tagline_en)) {
+        if ( empty( $tagline_fr ) && empty( $tagline_en ) ) {
             return '';
         }
-        
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'tagline_notation_jlg');
 
-        return JLG_Frontend::get_template_html('shortcode-tagline', [
-            'options' => $options,
-            'tagline_fr' => $tagline_fr,
-            'tagline_en' => $tagline_en
-        ]);
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'tagline_notation_jlg' );
+
+        return JLG_Frontend::get_template_html(
+            'shortcode-tagline',
+            array(
+				'options'    => $options,
+				'tagline_fr' => $tagline_fr,
+				'tagline_en' => $tagline_en,
+			)
+        );
     }
 }

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-user-rating.php
@@ -1,36 +1,41 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Shortcode_User_Rating {
-    
+
     public function __construct() {
-        add_shortcode('notation_utilisateurs_jlg', [$this, 'render']);
+        add_shortcode( 'notation_utilisateurs_jlg', array( $this, 'render' ) );
     }
 
-    public function render($atts = [], $content = '', $shortcode_tag = '') {
+    public function render( $atts = array(), $content = '', $shortcode_tag = '' ) {
         $allowed_types = JLG_Helpers::get_allowed_post_types();
 
-        if (!is_singular($allowed_types)) {
+        if ( ! is_singular( $allowed_types ) ) {
             return '';
         }
 
         $options = JLG_Helpers::get_plugin_options();
-        if (empty($options['user_rating_enabled'])) {
+        if ( empty( $options['user_rating_enabled'] ) ) {
             return '';
         }
 
-        $post_id = get_the_ID();
-        list($has_voted, $user_vote) = JLG_Frontend::get_user_vote_for_post($post_id);
+        $post_id                     = get_the_ID();
+        list($has_voted, $user_vote) = JLG_Frontend::get_user_vote_for_post( $post_id );
 
-        JLG_Frontend::mark_shortcode_rendered($shortcode_tag ?: 'notation_utilisateurs_jlg');
+        JLG_Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'notation_utilisateurs_jlg' );
 
-        return JLG_Frontend::get_template_html('shortcode-user-rating', [
-            'options' => $options,
-            'post_id' => $post_id,
-            'avg_rating' => get_post_meta($post_id, '_jlg_user_rating_avg', true),
-            'count' => get_post_meta($post_id, '_jlg_user_rating_count', true),
-            'has_voted' => $has_voted,
-            'user_vote' => $user_vote
-        ]);
+        return JLG_Frontend::get_template_html(
+            'shortcode-user-rating',
+            array(
+				'options'    => $options,
+				'post_id'    => $post_id,
+				'avg_rating' => get_post_meta( $post_id, '_jlg_user_rating_avg', true ),
+				'count'      => get_post_meta( $post_id, '_jlg_user_rating_count', true ),
+				'has_voted'  => $has_voted,
+				'user_vote'  => $user_vote,
+			)
+        );
     }
 }

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-form-renderer.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-form-renderer.php
@@ -1,98 +1,101 @@
 <?php
 /**
  * Rendu des champs de formulaire
- * 
+ *
  * @package JLG_Notation
  * @version 5.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Form_Renderer {
     private static $option_name = 'notation_jlg_settings';
 
-    public static function text_field($args) {
+    public static function text_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
         printf(
             '<input type="text" class="regular-text" name="%s[%s]" value="%s" placeholder="%s" />',
-            esc_attr(self::$option_name),
-            esc_attr($args['id']),
-            esc_attr($options[$args['id']] ?? ''),
-            esc_attr($args['placeholder'] ?? '')
+            esc_attr( self::$option_name ),
+            esc_attr( $args['id'] ),
+            esc_attr( $options[ $args['id'] ] ?? '' ),
+            esc_attr( $args['placeholder'] ?? '' )
         );
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    public static function color_field($args) {
+    public static function color_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
         printf(
             '<input type="color" name="%s[%s]" value="%s" />',
-            esc_attr(self::$option_name),
-            esc_attr($args['id']),
-            esc_attr($options[$args['id']] ?? '#000000')
+            esc_attr( self::$option_name ),
+            esc_attr( $args['id'] ),
+            esc_attr( $options[ $args['id'] ] ?? '#000000' )
         );
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    public static function checkbox_field($args) {
+    public static function checkbox_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
         printf(
             '<input type="checkbox" name="%s[%s]" value="1" %s />',
-            esc_attr(self::$option_name),
-            esc_attr($args['id']),
-            checked(1, $options[$args['id']] ?? 0, false)
+            esc_attr( self::$option_name ),
+            esc_attr( $args['id'] ),
+            checked( 1, $options[ $args['id'] ] ?? 0, false )
         );
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    public static function select_field($args) {
+    public static function select_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
-        $value = $options[$args['id']] ?? '';
-        
-        printf('<select name="%s[%s]">', esc_attr(self::$option_name), esc_attr($args['id']));
-        foreach ($args['options'] as $key => $label) {
-            printf('<option value="%s"%s>%s</option>', 
-                esc_attr($key), 
-                selected($value, $key, false), 
-                esc_html($label)
+        $value   = $options[ $args['id'] ] ?? '';
+
+        printf( '<select name="%s[%s]">', esc_attr( self::$option_name ), esc_attr( $args['id'] ) );
+        foreach ( $args['options'] as $key => $label ) {
+            printf(
+                '<option value="%s"%s>%s</option>',
+                esc_attr( $key ),
+                selected( $value, $key, false ),
+                esc_html( $label )
             );
         }
         echo '</select>';
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    public static function number_field($args) {
+    public static function number_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
-        $min = $args['min'] ?? 0;
-        $max = $args['max'] ?? 100;
-        $step = $args['step'] ?? 1;
+        $min     = $args['min'] ?? 0;
+        $max     = $args['max'] ?? 100;
+        $step    = $args['step'] ?? 1;
         printf(
             '<input type="number" class="small-text" name="%s[%s]" value="%s" min="%s" max="%s" step="%s" />',
-            esc_attr(self::$option_name),
-            esc_attr($args['id']),
-            esc_attr($options[$args['id']] ?? $min),
-            esc_attr($min),
-            esc_attr($max),
-            esc_attr($step)
+            esc_attr( self::$option_name ),
+            esc_attr( $args['id'] ),
+            esc_attr( $options[ $args['id'] ] ?? $min ),
+            esc_attr( $min ),
+            esc_attr( $max ),
+            esc_attr( $step )
         );
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    public static function textarea_field($args) {
+    public static function textarea_field( $args ) {
         $options = JLG_Helpers::get_plugin_options();
         printf(
             '<textarea name="%s[%s]" rows="10" cols="50" class="large-text code" placeholder="%s">%s</textarea>',
-            esc_attr(self::$option_name),
-            esc_attr($args['id']),
-            esc_attr($args['placeholder'] ?? ''),
-            esc_textarea($options[$args['id']] ?? '')
+            esc_attr( self::$option_name ),
+            esc_attr( $args['id'] ),
+            esc_attr( $args['placeholder'] ?? '' ),
+            esc_textarea( $options[ $args['id'] ] ?? '' )
         );
-        self::render_description($args);
+        self::render_description( $args );
     }
 
-    private static function render_description($args) {
-        if (isset($args['desc'])) {
-            printf('<p class="description">%s</p>', wp_kses_post($args['desc']));
+    private static function render_description( $args ) {
+        if ( isset( $args['desc'] ) ) {
+            printf( '<p class="description">%s</p>', wp_kses_post( $args['desc'] ) );
         }
     }
 }

--- a/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
+++ b/plugin-notation-jeux_V4/includes/utils/class-jlg-template-loader.php
@@ -1,98 +1,100 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class JLG_Template_Loader {
-    private static $templates_dir = '';
-    private static $template_cache = [];
+    private static $templates_dir  = '';
+    private static $template_cache = array();
 
     public static function init() {
         self::$templates_dir = JLG_NOTATION_PLUGIN_DIR . 'templates/';
     }
 
-    public static function get_template($template_name, $variables = []) {
-        if (empty(self::$templates_dir)) {
+    public static function get_template( $template_name, $variables = array() ) {
+        if ( empty( self::$templates_dir ) ) {
             self::init();
         }
 
-        return self::load_template_from_directory(self::$templates_dir, $template_name, $variables);
+        return self::load_template_from_directory( self::$templates_dir, $template_name, $variables );
     }
 
-    public static function get_admin_template($template_name, $variables = []) {
+    public static function get_admin_template( $template_name, $variables = array() ) {
         $directory = JLG_NOTATION_PLUGIN_DIR . 'admin/templates/';
-        return self::load_template_from_directory($directory, $template_name, $variables);
+        return self::load_template_from_directory( $directory, $template_name, $variables );
     }
 
-    public static function get_template_from_directory($directory, $template_name, $variables = []) {
-        return self::load_template_from_directory($directory, $template_name, $variables);
+    public static function get_template_from_directory( $directory, $template_name, $variables = array() ) {
+        return self::load_template_from_directory( $directory, $template_name, $variables );
     }
 
-    private static function load_template_from_directory($directory, $template_name, $variables) {
-        $template_path = self::build_template_path($directory, $template_name);
+    private static function load_template_from_directory( $directory, $template_name, $variables ) {
+        $template_path = self::build_template_path( $directory, $template_name );
 
-        if (!file_exists($template_path)) {
-            $relative_name = self::get_relative_template_name($directory, $template_name);
-            return self::handle_missing_template($relative_name);
+        if ( ! file_exists( $template_path ) ) {
+            $relative_name = self::get_relative_template_name( $directory, $template_name );
+            return self::handle_missing_template( $relative_name );
         }
 
-        return self::load_template_file($template_path, $variables);
+        return self::load_template_file( $template_path, $variables );
     }
 
-    private static function build_template_path($directory, $template_name) {
-        $directory = rtrim($directory, '/\\') . '/';
-        $template_name = ltrim($template_name, '/');
+    private static function build_template_path( $directory, $template_name ) {
+        $directory     = rtrim( $directory, '/\\' ) . '/';
+        $template_name = ltrim( $template_name, '/' );
 
-        if (substr($template_name, -4) !== '.php') {
+        if ( substr( $template_name, -4 ) !== '.php' ) {
             $template_name .= '.php';
         }
 
         return $directory . $template_name;
     }
 
-    private static function get_relative_template_name($directory, $template_name) {
-        $directory = rtrim($directory, '/\\') . '/';
-        $relative_base = str_replace(JLG_NOTATION_PLUGIN_DIR, '', $directory);
-        $relative_base = trim($relative_base, '/');
+    private static function get_relative_template_name( $directory, $template_name ) {
+        $directory     = rtrim( $directory, '/\\' ) . '/';
+        $relative_base = str_replace( JLG_NOTATION_PLUGIN_DIR, '', $directory );
+        $relative_base = trim( $relative_base, '/' );
 
-        $template_name = ltrim($template_name, '/');
+        $template_name = ltrim( $template_name, '/' );
 
-        if (!empty($relative_base)) {
+        if ( ! empty( $relative_base ) ) {
             return $relative_base . '/' . $template_name;
         }
 
         return $template_name;
     }
 
-    private static function load_template_file($template_path, $variables) {
-        $variables = is_array($variables) ? $variables : [];
+    private static function load_template_file( $template_path, $variables ) {
+        $variables = is_array( $variables ) ? $variables : array();
 
         ob_start();
-        (static function ($__template_path, $__variables) {
+        ( static function ( $__template_path, $__variables ) {
             $variables = $__variables;
             include $__template_path;
-        })($template_path, $variables);
+        } )( $template_path, $variables );
 
         return ob_get_clean();
     }
 
-    private static function handle_missing_template($template_name) {
-        if (current_user_can('manage_options')) {
+    private static function handle_missing_template( $template_name ) {
+        if ( current_user_can( 'manage_options' ) ) {
             return sprintf(
                 '<div class="notice notice-warning"><p>Template manquant : <code>%s</code></p></div>',
-                esc_html($template_name)
+                esc_html( $template_name )
             );
         }
         return '<!-- Template JLG manquant -->';
     }
 
-    public static function display_template($template_name, $variables = []) {
-        echo self::get_template($template_name, $variables);
+    public static function display_template( $template_name, $variables = array() ) {
+        echo self::get_template( $template_name, $variables );
     }
 
-    public static function display_admin_template($template_name, $variables = []) {
-        echo self::get_admin_template($template_name, $variables);
+    public static function display_admin_template( $template_name, $variables = array() ) {
+        echo self::get_admin_template( $template_name, $variables );
     }
 
-    public static function display_template_from_directory($directory, $template_name, $variables = []) {
-        echo self::get_template_from_directory($directory, $template_name, $variables);
+    public static function display_template_from_directory( $directory, $template_name, $variables = array() ) {
+        echo self::get_template_from_directory( $directory, $template_name, $variables );
     }
 }

--- a/plugin-notation-jeux_V4/phpcs.xml.dist
+++ b/plugin-notation-jeux_V4/phpcs.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset name="Notation JLG Coding Standards">
+    <description>WordPress coding standard configuration for the Notation JLG plugin.</description>
+
+    <arg name="report" value="full"/>
+    <arg name="extensions" value="php"/>
+
+    <file>.</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+    <exclude-pattern>assets/*</exclude-pattern>
+    <exclude-pattern>admin/templates/*</exclude-pattern>
+
+    <config name="minimum_supported_wp_version" value="5.0"/>
+    <config name="testVersion" value="7.4-"/>
+    <config name="ignore_warnings_on_exit" value="1"/>
+
+    <rule ref="WordPress-Extra">
+        <exclude name="Generic.WhiteSpace.DisallowSpaceIndent"/>
+        <exclude name="WordPress.WP.I18n"/>
+        <exclude name="WordPress.NamingConventions.PrefixAllGlobals"/>
+        <exclude name="WordPress.PHP.YodaConditions"/>
+        <exclude name="WordPress.Security.EscapeOutput"/>
+        <exclude name="WordPress.WP.GlobalVariablesOverride"/>
+        <exclude name="WordPress.Security.NonceVerification"/>
+        <exclude name="WordPress.Files.FileName"/>
+        <exclude name="Universal.Files.SeparateFunctionsFromOO"/>
+        <exclude name="Universal.Operators.DisallowShortTernary"/>
+        <exclude name="Universal.ControlStructures.DisallowLonelyIf"/>
+    </rule>
+</ruleset>

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -12,31 +12,42 @@
  * Requires PHP: 7.4
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 // Constantes
-define('JLG_NOTATION_VERSION', '5.0');
-define('JLG_NOTATION_PLUGIN_FILE', __FILE__);
-define('JLG_NOTATION_PLUGIN_DIR', plugin_dir_path(__FILE__));
-define('JLG_NOTATION_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('JLG_NOTATION_PLUGIN_BASENAME', plugin_basename(__FILE__));
+define( 'JLG_NOTATION_VERSION', '5.0' );
+define( 'JLG_NOTATION_PLUGIN_FILE', __FILE__ );
+define( 'JLG_NOTATION_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'JLG_NOTATION_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'JLG_NOTATION_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
-add_action('plugins_loaded', function() {
-    load_plugin_textdomain('notation-jlg', false, dirname(JLG_NOTATION_PLUGIN_BASENAME) . '/languages');
-});
+add_action(
+    'plugins_loaded',
+    function () {
+		load_plugin_textdomain( 'notation-jlg', false, dirname( JLG_NOTATION_PLUGIN_BASENAME ) . '/languages' );
+	}
+);
 
 // Vérifications de compatibilité
-if (version_compare(PHP_VERSION, '7.4', '<')) {
-    add_action('admin_notices', function() {
-        echo '<div class="notice notice-error"><p><strong>JLG Notation:</strong> PHP 7.4+ requis. Version actuelle: ' . esc_html(PHP_VERSION) . '</p></div>';
-    });
+if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
+    add_action(
+        'admin_notices',
+        function () {
+			echo '<div class="notice notice-error"><p><strong>JLG Notation:</strong> PHP 7.4+ requis. Version actuelle: ' . esc_html( PHP_VERSION ) . '</p></div>';
+		}
+    );
     return;
 }
 
-if (version_compare(get_bloginfo('version'), '5.0', '<')) {
-    add_action('admin_notices', function() {
-        echo '<div class="notice notice-error"><p><strong>JLG Notation:</strong> WordPress 5.0+ requis. Version actuelle: ' . esc_html(get_bloginfo('version')) . '</p></div>';
-    });
+if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+    add_action(
+        'admin_notices',
+        function () {
+			echo '<div class="notice notice-error"><p><strong>JLG Notation:</strong> WordPress 5.0+ requis. Version actuelle: ' . esc_html( get_bloginfo( 'version' ) ) . '</p></div>';
+		}
+    );
     return;
 }
 
@@ -44,16 +55,16 @@ if (version_compare(get_bloginfo('version'), '5.0', '<')) {
  * Classe principale refactorisée
  */
 final class JLG_Plugin_De_Notation_Main {
-    private static $instance = null;
-    private $admin = null;
-    private $assets = null;
-    private $frontend = null;
-    private $blocks = null;
-    private const MIGRATION_BATCH_SIZE = 50;
+    private static $instance                = null;
+    private $admin                          = null;
+    private $assets                         = null;
+    private $frontend                       = null;
+    private $blocks                         = null;
+    private const MIGRATION_BATCH_SIZE      = 50;
     private const MIGRATION_SCAN_BATCH_SIZE = 200;
 
     public static function get_instance() {
-        if (self::$instance === null) {
+        if ( self::$instance === null ) {
             self::$instance = new self();
         }
         return self::$instance;
@@ -62,11 +73,11 @@ final class JLG_Plugin_De_Notation_Main {
     private function __construct() {
         $this->load_dependencies();
         $this->init_components();
-        add_action('jlg_process_v5_migration', [$this, 'process_migration_batch']);
-        add_action('jlg_queue_average_rebuild', [$this, 'queue_additional_posts_for_migration']);
-        add_action('init', [$this, 'ensure_migration_schedule']);
-        register_activation_hook(__FILE__, [$this, 'on_activation']);
-        register_deactivation_hook(__FILE__, [$this, 'on_deactivation']);
+        add_action( 'jlg_process_v5_migration', array( $this, 'process_migration_batch' ) );
+        add_action( 'jlg_queue_average_rebuild', array( $this, 'queue_additional_posts_for_migration' ) );
+        add_action( 'init', array( $this, 'ensure_migration_schedule' ) );
+        register_activation_hook( __FILE__, array( $this, 'on_activation' ) );
+        register_deactivation_hook( __FILE__, array( $this, 'on_deactivation' ) );
     }
 
     private function load_dependencies() {
@@ -76,24 +87,24 @@ final class JLG_Plugin_De_Notation_Main {
         require_once JLG_NOTATION_PLUGIN_DIR . 'functions.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/shortcodes/class-jlg-shortcode-game-explorer.php';
 
-        add_action('update_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
-        add_action('add_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
-        add_action('delete_option_notation_jlg_settings', ['JLG_Helpers', 'flush_plugin_options_cache'], 10, 0);
-        add_action('added_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
-        add_action('updated_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
-        add_action('deleted_post_meta', ['JLG_Helpers', 'maybe_handle_rating_meta_change'], 10, 4);
-        add_action('transition_post_status', ['JLG_Helpers', 'maybe_clear_rated_post_ids_cache_for_status_change'], 20, 3);
+        add_action( 'update_option_notation_jlg_settings', array( 'JLG_Helpers', 'flush_plugin_options_cache' ), 10, 0 );
+        add_action( 'add_option_notation_jlg_settings', array( 'JLG_Helpers', 'flush_plugin_options_cache' ), 10, 0 );
+        add_action( 'delete_option_notation_jlg_settings', array( 'JLG_Helpers', 'flush_plugin_options_cache' ), 10, 0 );
+        add_action( 'added_post_meta', array( 'JLG_Helpers', 'maybe_handle_rating_meta_change' ), 10, 4 );
+        add_action( 'updated_post_meta', array( 'JLG_Helpers', 'maybe_handle_rating_meta_change' ), 10, 4 );
+        add_action( 'deleted_post_meta', array( 'JLG_Helpers', 'maybe_handle_rating_meta_change' ), 10, 4 );
+        add_action( 'transition_post_status', array( 'JLG_Helpers', 'maybe_clear_rated_post_ids_cache_for_status_change' ), 20, 3 );
 
-        if (class_exists('JLG_Shortcode_Game_Explorer')) {
-            add_action('added_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
-            add_action('updated_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
-            add_action('deleted_post_meta', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta'], 20, 4);
-            add_action('save_post', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_post'], 20, 3);
-            add_action('transition_post_status', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_status_change'], 20, 3);
-            add_action('set_object_terms', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_terms'], 20, 4);
-            add_action('created_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 3);
-            add_action('edited_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 3);
-            add_action('delete_term', ['JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event'], 20, 4);
+        if ( class_exists( 'JLG_Shortcode_Game_Explorer' ) ) {
+            add_action( 'added_post_meta', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta' ), 20, 4 );
+            add_action( 'updated_post_meta', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta' ), 20, 4 );
+            add_action( 'deleted_post_meta', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_meta' ), 20, 4 );
+            add_action( 'save_post', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_post' ), 20, 3 );
+            add_action( 'transition_post_status', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_status_change' ), 20, 3 );
+            add_action( 'set_object_terms', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_terms' ), 20, 4 );
+            add_action( 'created_term', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event' ), 20, 3 );
+            add_action( 'edited_term', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event' ), 20, 3 );
+            add_action( 'delete_term', array( 'JLG_Shortcode_Game_Explorer', 'maybe_clear_filters_snapshot_for_term_event' ), 20, 4 );
         }
 
         // Frontend (toujours)
@@ -101,29 +112,29 @@ final class JLG_Plugin_De_Notation_Main {
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-frontend.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-widget.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-blocks.php';
-        
+
         // Admin seulement si nécessaire
-        if (is_admin()) {
+        if ( is_admin() ) {
             $this->load_admin_classes();
         }
     }
 
     private function load_admin_classes() {
         // Utilitaires admin
-        $utils_files = [
+        $utils_files = array(
             'includes/utils/class-jlg-form-renderer.php',
             'includes/utils/class-jlg-template-loader.php',
-            'includes/utils/class-jlg-validator.php'
-        ];
+            'includes/utils/class-jlg-validator.php',
+        );
 
         // Classes admin
-        $admin_files = [
-            'includes/admin/class-jlg-admin-core.php'
-        ];
+        $admin_files = array(
+            'includes/admin/class-jlg-admin-core.php',
+        );
 
-        foreach (array_merge($utils_files, $admin_files) as $file) {
+        foreach ( array_merge( $utils_files, $admin_files ) as $file ) {
             $path = JLG_NOTATION_PLUGIN_DIR . $file;
-            if (file_exists($path)) {
+            if ( file_exists( $path ) ) {
                 require_once $path;
             }
         }
@@ -131,84 +142,89 @@ final class JLG_Plugin_De_Notation_Main {
 
     private function init_components() {
         // Assets communs
-        if (class_exists('JLG_Assets')) {
+        if ( class_exists( 'JLG_Assets' ) ) {
             $this->assets = JLG_Assets::get_instance();
         }
 
         // Frontend
-        $doing_ajax = function_exists('wp_doing_ajax') ? wp_doing_ajax() : (defined('DOING_AJAX') && DOING_AJAX);
-        if ((!is_admin() || $doing_ajax) && class_exists('JLG_Frontend')) {
+        $doing_ajax = function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : ( defined( 'DOING_AJAX' ) && DOING_AJAX );
+        if ( ( ! is_admin() || $doing_ajax ) && class_exists( 'JLG_Frontend' ) ) {
             $this->frontend = new JLG_Frontend();
         }
 
         // Widget
-        if (class_exists('JLG_Latest_Reviews_Widget')) {
-            add_action('widgets_init', function() {
-                register_widget('JLG_Latest_Reviews_Widget');
-            });
+        if ( class_exists( 'JLG_Latest_Reviews_Widget' ) ) {
+            add_action(
+                'widgets_init',
+                function () {
+					register_widget( 'JLG_Latest_Reviews_Widget' );
+				}
+            );
         }
 
         // Blocks
-        if (class_exists('JLG_Blocks')) {
+        if ( class_exists( 'JLG_Blocks' ) ) {
             $this->blocks = new JLG_Blocks();
         }
 
         // Admin
-        if (is_admin() && class_exists('JLG_Admin_Core')) {
+        if ( is_admin() && class_exists( 'JLG_Admin_Core' ) ) {
             $this->admin = JLG_Admin_Core::get_instance();
         }
     }
 
     public function on_activation() {
         // Migration automatique depuis v4
-        $current_version = get_option('jlg_notation_version', '4.0');
+        $current_version = get_option( 'jlg_notation_version', '4.0' );
 
-        if (version_compare($current_version, '5.0', '<')) {
+        if ( version_compare( $current_version, '5.0', '<' ) ) {
             $this->queue_migration_from_v4();
         }
 
         // Options par défaut
-        if (!get_option('notation_jlg_settings')) {
-            add_option('notation_jlg_settings', JLG_Helpers::get_default_settings());
+        if ( ! get_option( 'notation_jlg_settings' ) ) {
+            add_option( 'notation_jlg_settings', JLG_Helpers::get_default_settings() );
         }
 
-        update_option('jlg_notation_version', JLG_NOTATION_VERSION);
+        update_option( 'jlg_notation_version', JLG_NOTATION_VERSION );
         flush_rewrite_rules();
     }
 
     public function on_deactivation() {
-        if (function_exists('wp_clear_scheduled_hook')) {
-            wp_clear_scheduled_hook('jlg_process_v5_migration');
+        if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+            wp_clear_scheduled_hook( 'jlg_process_v5_migration' );
         }
 
-        delete_option('jlg_migration_v5_queue');
-        delete_option('jlg_migration_v5_scan_state');
-        delete_option('jlg_migration_v5_completed');
+        delete_option( 'jlg_migration_v5_queue' );
+        delete_option( 'jlg_migration_v5_scan_state' );
+        delete_option( 'jlg_migration_v5_completed' );
     }
 
     private function queue_migration_from_v4() {
-        $this->store_migration_queue([]);
-        $this->store_migration_scan_state([
-            'last_post_id' => 0,
-            'complete' => false,
-        ]);
+        $this->store_migration_queue( array() );
+        $this->store_migration_scan_state(
+            array(
+				'last_post_id' => 0,
+				'complete'     => false,
+            )
+        );
 
         $this->schedule_next_migration_event();
     }
 
     public function ensure_migration_schedule() {
-        if (!function_exists('wp_next_scheduled') || !function_exists('wp_schedule_single_event')) {
+        if ( ! function_exists( 'wp_next_scheduled' ) || ! function_exists( 'wp_schedule_single_event' ) ) {
             return;
         }
 
-        $queue = $this->get_migration_queue();
+        $queue      = $this->get_migration_queue();
         $scan_state = $this->get_migration_scan_state();
 
-        if (empty($queue) && !empty($scan_state['complete'])) {
+        if ( empty( $queue ) && ! empty( $scan_state['complete'] ) ) {
             return;
         }
 
-        if (!wp_next_scheduled('jlg_process_v5_migration')) {
+        if ( ! wp_next_scheduled( 'jlg_process_v5_migration' ) ) {
             $this->schedule_next_migration_event();
         }
     }
@@ -216,12 +232,12 @@ final class JLG_Plugin_De_Notation_Main {
     public function process_migration_batch() {
         $queue = $this->get_migration_queue();
 
-        if (empty($queue)) {
+        if ( empty( $queue ) ) {
             $queue = $this->populate_migration_queue_batch();
         }
 
-        if (empty($queue)) {
-            if ($this->is_migration_scan_complete()) {
+        if ( empty( $queue ) ) {
+            if ( $this->is_migration_scan_complete() ) {
                 $this->finalize_migration();
             } else {
                 $this->schedule_next_migration_event();
@@ -230,19 +246,19 @@ final class JLG_Plugin_De_Notation_Main {
             return;
         }
 
-        $batch = array_splice($queue, 0, self::MIGRATION_BATCH_SIZE);
+        $batch = array_splice( $queue, 0, self::MIGRATION_BATCH_SIZE );
 
-        foreach ($batch as $post_id) {
-            $post_id = intval($post_id);
+        foreach ( $batch as $post_id ) {
+            $post_id = intval( $post_id );
 
-            if ($post_id > 0) {
-                JLG_Helpers::get_resolved_average_score($post_id);
+            if ( $post_id > 0 ) {
+                JLG_Helpers::get_resolved_average_score( $post_id );
             }
         }
 
-        $this->store_migration_queue($queue);
+        $this->store_migration_queue( $queue );
 
-        if (!empty($queue) || !$this->is_migration_scan_complete()) {
+        if ( ! empty( $queue ) || ! $this->is_migration_scan_complete() ) {
             $this->schedule_next_migration_event();
         } else {
             $this->finalize_migration();
@@ -250,146 +266,156 @@ final class JLG_Plugin_De_Notation_Main {
     }
 
     private function schedule_next_migration_event() {
-        if (!function_exists('wp_schedule_single_event') || !function_exists('wp_next_scheduled')) {
+        if ( ! function_exists( 'wp_schedule_single_event' ) || ! function_exists( 'wp_next_scheduled' ) ) {
             return;
         }
 
-        if (wp_next_scheduled('jlg_process_v5_migration')) {
+        if ( wp_next_scheduled( 'jlg_process_v5_migration' ) ) {
             return;
         }
 
-        $delay = defined('MINUTE_IN_SECONDS') ? MINUTE_IN_SECONDS : 60;
-        wp_schedule_single_event(time() + $delay, 'jlg_process_v5_migration');
+        $delay = defined( 'MINUTE_IN_SECONDS' ) ? MINUTE_IN_SECONDS : 60;
+        wp_schedule_single_event( time() + $delay, 'jlg_process_v5_migration' );
     }
 
     private function populate_migration_queue_batch() {
-        $queue = $this->get_migration_queue();
+        $queue      = $this->get_migration_queue();
         $scan_state = $this->get_migration_scan_state();
 
-        if (!empty($scan_state['complete'])) {
+        if ( ! empty( $scan_state['complete'] ) ) {
             return $queue;
         }
 
-        $batch_size = (int) apply_filters('jlg_migration_v5_scan_batch_size', self::MIGRATION_SCAN_BATCH_SIZE);
-        if ($batch_size <= 0) {
+        $batch_size = (int) apply_filters( 'jlg_migration_v5_scan_batch_size', self::MIGRATION_SCAN_BATCH_SIZE );
+        if ( $batch_size <= 0 ) {
             $batch_size = self::MIGRATION_SCAN_BATCH_SIZE;
         }
 
-        $last_post_id = isset($scan_state['last_post_id']) ? (int) $scan_state['last_post_id'] : 0;
-        $fetched = JLG_Helpers::get_rated_post_ids_batch($last_post_id, $batch_size);
+        $last_post_id = isset( $scan_state['last_post_id'] ) ? (int) $scan_state['last_post_id'] : 0;
+        $fetched      = JLG_Helpers::get_rated_post_ids_batch( $last_post_id, $batch_size );
 
-        if (empty($fetched)) {
+        if ( empty( $fetched ) ) {
             $scan_state['complete'] = true;
-            $this->store_migration_scan_state($scan_state);
+            $this->store_migration_scan_state( $scan_state );
 
             return $queue;
         }
 
-        $scan_state['last_post_id'] = max($fetched);
+        $scan_state['last_post_id'] = max( $fetched );
 
-        if ($batch_size > 0 && count($fetched) < $batch_size) {
+        if ( $batch_size > 0 && count( $fetched ) < $batch_size ) {
             $scan_state['complete'] = true;
         }
 
-        $queue = array_values(array_unique(array_merge($queue, $fetched)));
-        $this->store_migration_queue($queue);
-        $this->store_migration_scan_state($scan_state);
+        $queue = array_values( array_unique( array_merge( $queue, $fetched ) ) );
+        $this->store_migration_queue( $queue );
+        $this->store_migration_scan_state( $scan_state );
 
         return $queue;
     }
 
     private function get_migration_queue() {
-        $queue = get_option('jlg_migration_v5_queue', []);
+        $queue = get_option( 'jlg_migration_v5_queue', array() );
 
-        if (!is_array($queue)) {
-            return [];
+        if ( ! is_array( $queue ) ) {
+            return array();
         }
 
-        $queue = array_values(array_filter(array_map('intval', $queue), static function ($post_id) {
-            return $post_id > 0;
-        }));
+        $queue = array_values(
+            array_filter(
+                array_map( 'intval', $queue ),
+                static function ( $post_id ) {
+					return $post_id > 0;
+                }
+            )
+        );
 
-        sort($queue);
+        sort( $queue );
 
         return $queue;
     }
 
-    private function store_migration_queue(array $queue) {
-        $queue = array_values(array_filter(array_map('intval', $queue), static function ($post_id) {
-            return $post_id > 0;
-        }));
+    private function store_migration_queue( array $queue ) {
+        $queue = array_values(
+            array_filter(
+                array_map( 'intval', $queue ),
+                static function ( $post_id ) {
+					return $post_id > 0;
+                }
+            )
+        );
 
-        sort($queue);
+        sort( $queue );
 
-        if (empty($queue)) {
-            delete_option('jlg_migration_v5_queue');
+        if ( empty( $queue ) ) {
+            delete_option( 'jlg_migration_v5_queue' );
 
             return;
         }
 
-        update_option('jlg_migration_v5_queue', $queue, false);
+        update_option( 'jlg_migration_v5_queue', $queue, false );
     }
 
     private function get_migration_scan_state() {
-        $state = get_option('jlg_migration_v5_scan_state', []);
+        $state = get_option( 'jlg_migration_v5_scan_state', array() );
 
-        if (!is_array($state)) {
-            $state = [];
+        if ( ! is_array( $state ) ) {
+            $state = array();
         }
 
-        $has_complete_flag = is_array($state) && array_key_exists('complete', $state);
+        $has_complete_flag = is_array( $state ) && array_key_exists( 'complete', $state );
 
-        return [
-            'last_post_id' => isset($state['last_post_id']) ? (int) $state['last_post_id'] : 0,
-            'complete' => $has_complete_flag ? !empty($state['complete']) : false,
-        ];
+        return array(
+            'last_post_id' => isset( $state['last_post_id'] ) ? (int) $state['last_post_id'] : 0,
+            'complete'     => $has_complete_flag ? ! empty( $state['complete'] ) : false,
+        );
     }
 
-    private function store_migration_scan_state(array $state) {
-        $normalized = [
-            'last_post_id' => isset($state['last_post_id']) ? max(0, (int) $state['last_post_id']) : 0,
-            'complete' => !empty($state['complete']),
-        ];
+    private function store_migration_scan_state( array $state ) {
+        $normalized = array(
+            'last_post_id' => isset( $state['last_post_id'] ) ? max( 0, (int) $state['last_post_id'] ) : 0,
+            'complete'     => ! empty( $state['complete'] ),
+        );
 
-        update_option('jlg_migration_v5_scan_state', $normalized, false);
+        update_option( 'jlg_migration_v5_scan_state', $normalized, false );
     }
 
     private function is_migration_scan_complete() {
         $state = $this->get_migration_scan_state();
 
-        return !empty($state['complete']);
+        return ! empty( $state['complete'] );
     }
 
     private function finalize_migration() {
-        $this->store_migration_queue([]);
-        delete_option('jlg_migration_v5_scan_state');
-        update_option('jlg_migration_v5_completed', current_time('mysql'), false);
+        $this->store_migration_queue( array() );
+        delete_option( 'jlg_migration_v5_scan_state' );
+        update_option( 'jlg_migration_v5_completed', current_time( 'mysql' ), false );
     }
 
-    public function queue_additional_posts_for_migration($post_ids) {
-        if (!is_array($post_ids)) {
-            $post_ids = [$post_ids];
+    public function queue_additional_posts_for_migration( $post_ids ) {
+        if ( ! is_array( $post_ids ) ) {
+            $post_ids = array( $post_ids );
         }
 
         $post_ids = array_filter(
-            array_map('intval', $post_ids),
-            static function ($post_id) {
+            array_map( 'intval', $post_ids ),
+            static function ( $post_id ) {
                 return $post_id > 0;
             }
         );
 
-        if (empty($post_ids)) {
+        if ( empty( $post_ids ) ) {
             return;
         }
 
-        $queue = $this->get_migration_queue();
-        $updated_queue = array_values(array_unique(array_merge($queue, $post_ids)));
+        $queue         = $this->get_migration_queue();
+        $updated_queue = array_values( array_unique( array_merge( $queue, $post_ids ) ) );
 
-        if ($updated_queue === $queue) {
+        if ( $updated_queue === $queue ) {
             return;
         }
 
-        $this->store_migration_queue($updated_queue);
+        $this->store_migration_queue( $updated_queue );
         $this->schedule_next_migration_event();
     }
 }
@@ -399,15 +425,17 @@ function jlg_notation() {
     return JLG_Plugin_De_Notation_Main::get_instance();
 }
 
-function jlg_get_post_rating($post_id = null) {
-    if (!$post_id) $post_id = get_the_ID();
-    return JLG_Helpers::get_average_score_for_post($post_id);
+function jlg_get_post_rating( $post_id = null ) {
+    if ( ! $post_id ) {
+		$post_id = get_the_ID();
+    }
+    return JLG_Helpers::get_average_score_for_post( $post_id );
 }
 
-function jlg_display_post_rating($post_id = null) {
-    $score = jlg_get_post_rating($post_id);
-    if ($score !== null) {
-        echo '<span class="jlg-post-rating">' . esc_html(number_format_i18n($score, 1)) . '/10</span>';
+function jlg_display_post_rating( $post_id = null ) {
+    $score = jlg_get_post_rating( $post_id );
+    if ( $score !== null ) {
+        echo '<span class="jlg-post-rating">' . esc_html( number_format_i18n( $score, 1 ) ) . '/10</span>';
     }
 }
 

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -1,83 +1,89 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-$games = is_array($games) ? $games : [];
-$message = isset($message) ? $message : '';
-$pagination = is_array($pagination) ? $pagination : ['current' => 1, 'total' => 0];
-$total_items = isset($total_items) ? (int) $total_items : 0;
+$games       = is_array( $games ) ? $games : array();
+$message     = isset( $message ) ? $message : '';
+$pagination  = is_array( $pagination ) ? $pagination : array(
+	'current' => 1,
+	'total'   => 0,
+);
+$total_items = isset( $total_items ) ? (int) $total_items : 0;
 
-if (empty($games)) {
-    echo wp_kses_post($message);
+if ( empty( $games ) ) {
+    echo wp_kses_post( $message );
     return;
 }
 ?>
 <div class="jlg-ge-grid">
-    <?php foreach ($games as $game) :
-        $permalink = isset($game['permalink']) ? $game['permalink'] : '';
-        $title = isset($game['title']) ? $game['title'] : '';
-        $score_display = isset($game['score_display']) ? $game['score_display'] : '';
-        $score_color = isset($game['score_color']) ? $game['score_color'] : '';
-        $cover_url = isset($game['cover_url']) ? $game['cover_url'] : '';
-        $release_display = isset($game['release_display']) ? $game['release_display'] : '';
-        $developer = isset($game['developer']) ? $game['developer'] : '';
-        $publisher = isset($game['publisher']) ? $game['publisher'] : '';
-        $platforms = isset($game['platforms']) && is_array($game['platforms']) ? $game['platforms'] : [];
-        $genre = isset($game['genre']) ? $game['genre'] : '';
-        $availability_label = isset($game['availability_label']) ? $game['availability_label'] : '';
-        $availability_status = isset($game['availability']) ? $game['availability'] : '';
-        $excerpt = isset($game['excerpt']) ? $game['excerpt'] : '';
+    <?php
+    foreach ( $games as $game ) :
+        $permalink           = isset( $game['permalink'] ) ? $game['permalink'] : '';
+        $title               = isset( $game['title'] ) ? $game['title'] : '';
+        $score_display       = isset( $game['score_display'] ) ? $game['score_display'] : '';
+        $score_color         = isset( $game['score_color'] ) ? $game['score_color'] : '';
+        $cover_url           = isset( $game['cover_url'] ) ? $game['cover_url'] : '';
+        $release_display     = isset( $game['release_display'] ) ? $game['release_display'] : '';
+        $developer           = isset( $game['developer'] ) ? $game['developer'] : '';
+        $publisher           = isset( $game['publisher'] ) ? $game['publisher'] : '';
+        $platforms           = isset( $game['platforms'] ) && is_array( $game['platforms'] ) ? $game['platforms'] : array();
+        $genre               = isset( $game['genre'] ) ? $game['genre'] : '';
+        $availability_label  = isset( $game['availability_label'] ) ? $game['availability_label'] : '';
+        $availability_status = isset( $game['availability'] ) ? $game['availability'] : '';
+        $excerpt             = isset( $game['excerpt'] ) ? $game['excerpt'] : '';
         ?>
-        <article class="jlg-ge-card" data-post-id="<?php echo esc_attr($game['post_id']); ?>">
-            <a class="jlg-ge-card__media" href="<?php echo esc_url($permalink); ?>">
-                <?php if ($cover_url) : ?>
-                    <img src="<?php echo esc_url($cover_url); ?>" alt="<?php echo esc_attr($title); ?>" loading="lazy">
+        <article class="jlg-ge-card" data-post-id="<?php echo esc_attr( $game['post_id'] ); ?>">
+            <a class="jlg-ge-card__media" href="<?php echo esc_url( $permalink ); ?>">
+                <?php if ( $cover_url ) : ?>
+                    <img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy">
                 <?php else : ?>
-                    <span class="jlg-ge-card__placeholder"><?php esc_html_e('Visuel indisponible', 'notation-jlg'); ?></span>
+                    <span class="jlg-ge-card__placeholder"><?php esc_html_e( 'Visuel indisponible', 'notation-jlg' ); ?></span>
                 <?php endif; ?>
-                <?php if ($score_display !== '') : ?>
-                    <span class="jlg-ge-card__score" style="--jlg-ge-score-color: <?php echo esc_attr($score_color); ?>;">
-                        <?php echo esc_html($score_display); ?>
+                <?php if ( $score_display !== '' ) : ?>
+                    <span class="jlg-ge-card__score" style="--jlg-ge-score-color: <?php echo esc_attr( $score_color ); ?>;">
+                        <?php echo esc_html( $score_display ); ?>
                         <span class="jlg-ge-card__score-outof">/10</span>
                     </span>
                 <?php endif; ?>
             </a>
             <div class="jlg-ge-card__body">
                 <h3 class="jlg-ge-card__title">
-                    <a href="<?php echo esc_url($permalink); ?>"><?php echo esc_html($title); ?></a>
+                    <a href="<?php echo esc_url( $permalink ); ?>"><?php echo esc_html( $title ); ?></a>
                 </h3>
-                <?php if ($excerpt !== '') : ?>
-                    <p class="jlg-ge-card__excerpt"><?php echo esc_html($excerpt); ?></p>
+                <?php if ( $excerpt !== '' ) : ?>
+                    <p class="jlg-ge-card__excerpt"><?php echo esc_html( $excerpt ); ?></p>
                 <?php endif; ?>
                 <dl class="jlg-ge-card__meta">
-                    <?php if ($release_display !== '') : ?>
+                    <?php if ( $release_display !== '' ) : ?>
                         <div class="jlg-ge-card__meta-row">
-                            <dt><?php esc_html_e('Sortie', 'notation-jlg'); ?></dt>
-                            <dd><?php echo esc_html($release_display); ?></dd>
+                            <dt><?php esc_html_e( 'Sortie', 'notation-jlg' ); ?></dt>
+                            <dd><?php echo esc_html( $release_display ); ?></dd>
                         </div>
                     <?php endif; ?>
-                    <?php if ($developer !== '') : ?>
+                    <?php if ( $developer !== '' ) : ?>
                         <div class="jlg-ge-card__meta-row">
-                            <dt><?php esc_html_e('Développeur', 'notation-jlg'); ?></dt>
-                            <dd><?php echo esc_html($developer); ?></dd>
+                            <dt><?php esc_html_e( 'Développeur', 'notation-jlg' ); ?></dt>
+                            <dd><?php echo esc_html( $developer ); ?></dd>
                         </div>
                     <?php endif; ?>
-                    <?php if ($publisher !== '') : ?>
+                    <?php if ( $publisher !== '' ) : ?>
                         <div class="jlg-ge-card__meta-row">
-                            <dt><?php esc_html_e('Éditeur', 'notation-jlg'); ?></dt>
-                            <dd><?php echo esc_html($publisher); ?></dd>
+                            <dt><?php esc_html_e( 'Éditeur', 'notation-jlg' ); ?></dt>
+                            <dd><?php echo esc_html( $publisher ); ?></dd>
                         </div>
                     <?php endif; ?>
                 </dl>
                 <div class="jlg-ge-card__badges">
-                    <?php foreach (array_slice($platforms, 0, 4) as $platform_label) : ?>
-                        <span class="jlg-ge-badge jlg-ge-badge--platform"><?php echo esc_html($platform_label); ?></span>
+                    <?php foreach ( array_slice( $platforms, 0, 4 ) as $platform_label ) : ?>
+                        <span class="jlg-ge-badge jlg-ge-badge--platform"><?php echo esc_html( $platform_label ); ?></span>
                     <?php endforeach; ?>
-                    <?php if ($genre !== '') : ?>
-                        <span class="jlg-ge-badge jlg-ge-badge--genre"><?php echo esc_html($genre); ?></span>
+                    <?php if ( $genre !== '' ) : ?>
+                        <span class="jlg-ge-badge jlg-ge-badge--genre"><?php echo esc_html( $genre ); ?></span>
                     <?php endif; ?>
-                    <?php if ($availability_label !== '') : ?>
-                        <span class="jlg-ge-badge jlg-ge-badge--availability jlg-ge-badge--availability-<?php echo esc_attr($availability_status); ?>">
-                            <?php echo esc_html($availability_label); ?>
+                    <?php if ( $availability_label !== '' ) : ?>
+                        <span class="jlg-ge-badge jlg-ge-badge--availability jlg-ge-badge--availability-<?php echo esc_attr( $availability_status ); ?>">
+                            <?php echo esc_html( $availability_label ); ?>
                         </span>
                     <?php endif; ?>
                 </div>
@@ -86,30 +92,31 @@ if (empty($games)) {
     <?php endforeach; ?>
 </div>
 <?php
-$current_page = isset($pagination['current']) ? (int) $pagination['current'] : 1;
-$total_pages = isset($pagination['total']) ? (int) $pagination['total'] : 0;
+$current_page = isset( $pagination['current'] ) ? (int) $pagination['current'] : 1;
+$total_pages  = isset( $pagination['total'] ) ? (int) $pagination['total'] : 0;
 
-if ($total_pages > 1) :
-    $prev_page = max(1, $current_page - 1);
-    $next_page = min($total_pages, $current_page + 1);
+if ( $total_pages > 1 ) :
+    $prev_page = max( 1, $current_page - 1 );
+    $next_page = min( $total_pages, $current_page + 1 );
     ?>
-    <nav class="jlg-ge-pagination" data-role="pagination" aria-label="<?php esc_attr_e('Navigation des pages du Game Explorer', 'notation-jlg'); ?>">
-        <button type="button" class="jlg-ge-page jlg-ge-page--prev" data-page="<?php echo esc_attr($prev_page); ?>" <?php disabled($current_page <= 1); ?>>
-            <?php esc_html_e('Précédent', 'notation-jlg'); ?>
+    <nav class="jlg-ge-pagination" data-role="pagination" aria-label="<?php esc_attr_e( 'Navigation des pages du Game Explorer', 'notation-jlg' ); ?>">
+        <button type="button" class="jlg-ge-page jlg-ge-page--prev" data-page="<?php echo esc_attr( $prev_page ); ?>" <?php disabled( $current_page <= 1 ); ?>>
+            <?php esc_html_e( 'Précédent', 'notation-jlg' ); ?>
         </button>
         <ul>
-            <?php for ($page = 1; $page <= $total_pages; $page++) :
-                $is_active = ($page === $current_page);
+            <?php
+            for ( $page = 1; $page <= $total_pages; $page++ ) :
+                $is_active = ( $page === $current_page );
                 ?>
                 <li>
-                    <button type="button" data-page="<?php echo esc_attr($page); ?>" class="<?php echo esc_attr($is_active ? 'is-active' : ''); ?>">
-                        <?php echo esc_html($page); ?>
+                    <button type="button" data-page="<?php echo esc_attr( $page ); ?>" class="<?php echo esc_attr( $is_active ? 'is-active' : '' ); ?>">
+                        <?php echo esc_html( $page ); ?>
                     </button>
                 </li>
             <?php endfor; ?>
         </ul>
-        <button type="button" class="jlg-ge-page jlg-ge-page--next" data-page="<?php echo esc_attr($next_page); ?>" <?php disabled($current_page >= $total_pages); ?>>
-            <?php esc_html_e('Suivant', 'notation-jlg'); ?>
+        <button type="button" class="jlg-ge-page jlg-ge-page--next" data-page="<?php echo esc_attr( $next_page ); ?>" <?php disabled( $current_page >= $total_pages ); ?>>
+            <?php esc_html_e( 'Suivant', 'notation-jlg' ); ?>
         </button>
     </nav>
 <?php endif; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -1,77 +1,79 @@
 <?php
-if (!defined('ABSPATH')) exit;
-
-$style_attribute = '';
-if (!empty($css_variables)) {
-    $style_attribute = ' style="' . esc_attr($css_variables) . '"';
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-$has_tagline = ($atts['afficher_tagline'] === 'oui' && (!empty($tagline_fr) || !empty($tagline_en)));
-$has_dual_tagline = (!empty($tagline_fr) && !empty($tagline_en));
-$show_rating = ($atts['afficher_notation'] === 'oui' && $average_score !== null);
-$show_points = ($atts['afficher_points'] === 'oui' && (!empty($pros_list) || !empty($cons_list)));
-$data_attributes = sprintf(
+$style_attribute = '';
+if ( ! empty( $css_variables ) ) {
+    $style_attribute = ' style="' . esc_attr( $css_variables ) . '"';
+}
+
+$has_tagline      = ( $atts['afficher_tagline'] === 'oui' && ( ! empty( $tagline_fr ) || ! empty( $tagline_en ) ) );
+$has_dual_tagline = ( ! empty( $tagline_fr ) && ! empty( $tagline_en ) );
+$show_rating      = ( $atts['afficher_notation'] === 'oui' && $average_score !== null );
+$show_points      = ( $atts['afficher_points'] === 'oui' && ( ! empty( $pros_list ) || ! empty( $cons_list ) ) );
+$data_attributes  = sprintf(
     ' data-animations-enabled="%s" data-has-multiple-taglines="%s"',
-    esc_attr($animations_enabled ? 'true' : 'false'),
-    esc_attr($has_dual_tagline ? 'true' : 'false')
+    esc_attr( $animations_enabled ? 'true' : 'false' ),
+    esc_attr( $has_dual_tagline ? 'true' : 'false' )
 );
 ?>
 
-<div class="<?php echo esc_attr($block_classes); ?>"<?php echo $style_attribute; ?><?php echo $data_attributes; ?>>
-    <?php if ($has_tagline): ?>
+<div class="<?php echo esc_attr( $block_classes ); ?>"<?php echo $style_attribute; ?><?php echo $data_attributes; ?>>
+    <?php if ( $has_tagline ) : ?>
     <div class="jlg-aio-header">
-        <?php if ($has_dual_tagline): ?>
+        <?php if ( $has_dual_tagline ) : ?>
         <div class="jlg-aio-flags">
-            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'); ?>"
-                 class="jlg-aio-flag active"
-                 data-lang="fr"
-                 alt="<?php echo esc_attr__('Français', 'notation-jlg'); ?>">
-            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'); ?>"
-                 class="jlg-aio-flag"
-                 data-lang="en"
-                 alt="<?php echo esc_attr__('English', 'notation-jlg'); ?>">
+            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>"
+                class="jlg-aio-flag active"
+                data-lang="fr"
+                alt="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>">
+            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>"
+                class="jlg-aio-flag"
+                data-lang="en"
+                alt="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>">
         </div>
         <?php endif; ?>
 
-        <?php if (!empty($tagline_fr)): ?>
+        <?php if ( ! empty( $tagline_fr ) ) : ?>
         <div class="jlg-aio-tagline" data-lang="fr">
-            <?php echo wp_kses_post($tagline_fr); ?>
+            <?php echo wp_kses_post( $tagline_fr ); ?>
         </div>
         <?php endif; ?>
 
-        <?php if (!empty($tagline_en)): ?>
+        <?php if ( ! empty( $tagline_en ) ) : ?>
         <div class="jlg-aio-tagline" data-lang="en"<?php echo $has_dual_tagline ? ' style="display:none;" hidden' : ''; ?>>
-            <?php echo wp_kses_post($tagline_en); ?>
+            <?php echo wp_kses_post( $tagline_en ); ?>
         </div>
         <?php endif; ?>
     </div>
     <?php endif; ?>
 
-    <?php if ($show_rating): ?>
+    <?php if ( $show_rating ) : ?>
     <div class="jlg-aio-rating">
         <div class="jlg-aio-main-score">
-            <?php if ($score_layout === 'circle'): ?>
+            <?php if ( $score_layout === 'circle' ) : ?>
             <div class="jlg-aio-score-circle">
-                <div class="jlg-aio-score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
-                <div class="jlg-aio-score-label"><?php echo esc_html__('Note Globale', 'notation-jlg'); ?></div>
+                <div class="jlg-aio-score-value"><?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?></div>
+                <div class="jlg-aio-score-label"><?php echo esc_html__( 'Note Globale', 'notation-jlg' ); ?></div>
             </div>
-            <?php else: ?>
-            <div class="jlg-aio-score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
-            <div class="jlg-aio-score-label"><?php echo esc_html__('Note Globale', 'notation-jlg'); ?></div>
+            <?php else : ?>
+            <div class="jlg-aio-score-value"><?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?></div>
+            <div class="jlg-aio-score-label"><?php echo esc_html__( 'Note Globale', 'notation-jlg' ); ?></div>
             <?php endif; ?>
         </div>
 
         <div class="jlg-aio-scores-grid">
-            <?php foreach ($scores as $key => $score_value): ?>
-            <?php $bar_color = JLG_Helpers::calculate_color_from_note($score_value, $options); ?>
+            <?php foreach ( $scores as $key => $score_value ) : ?>
+				<?php $bar_color = JLG_Helpers::calculate_color_from_note( $score_value, $options ); ?>
             <div class="jlg-aio-score-item">
                 <div class="jlg-aio-score-header">
-                    <span class="jlg-aio-score-label"><?php echo esc_html($categories[$key]); ?></span>
-                    <span class="jlg-aio-score-number"><?php echo esc_html(number_format_i18n($score_value, 1)); ?> / 10</span>
+                    <span class="jlg-aio-score-label"><?php echo esc_html( $categories[ $key ] ); ?></span>
+                    <span class="jlg-aio-score-number"><?php echo esc_html( number_format_i18n( $score_value, 1 ) ); ?> / 10</span>
                 </div>
                 <div class="jlg-aio-score-bar-bg">
                     <div class="jlg-aio-score-bar"
-                         style="--bar-color: <?php echo esc_attr($bar_color); ?>; --bar-width: <?php echo esc_attr($score_value * 10); ?>%; width: <?php echo esc_attr($score_value * 10); ?>%;"></div>
+                        style="--bar-color: <?php echo esc_attr( $bar_color ); ?>; --bar-width: <?php echo esc_attr( $score_value * 10 ); ?>%; width: <?php echo esc_attr( $score_value * 10 ); ?>%;"></div>
                 </div>
             </div>
             <?php endforeach; ?>
@@ -79,31 +81,31 @@ $data_attributes = sprintf(
     </div>
     <?php endif; ?>
 
-    <?php if ($show_points): ?>
+    <?php if ( $show_points ) : ?>
     <div class="jlg-aio-points">
-        <?php if (!empty($pros_list)): ?>
+        <?php if ( ! empty( $pros_list ) ) : ?>
         <div class="jlg-aio-points-col pros">
             <div class="jlg-aio-points-title">
                 <span class="jlg-aio-points-icon pros">+</span>
-                <span><?php echo esc_html($atts['titre_points_forts']); ?></span>
+                <span><?php echo esc_html( $atts['titre_points_forts'] ); ?></span>
             </div>
             <ul class="jlg-aio-points-list">
-                <?php foreach ($pros_list as $pro): ?>
-                <li><?php echo esc_html($pro); ?></li>
+                <?php foreach ( $pros_list as $pro ) : ?>
+                <li><?php echo esc_html( $pro ); ?></li>
                 <?php endforeach; ?>
             </ul>
         </div>
         <?php endif; ?>
 
-        <?php if (!empty($cons_list)): ?>
+        <?php if ( ! empty( $cons_list ) ) : ?>
         <div class="jlg-aio-points-col cons">
             <div class="jlg-aio-points-title">
                 <span class="jlg-aio-points-icon cons">−</span>
-                <span><?php echo esc_html($atts['titre_points_faibles']); ?></span>
+                <span><?php echo esc_html( $atts['titre_points_faibles'] ); ?></span>
             </div>
             <ul class="jlg-aio-points-list">
-                <?php foreach ($cons_list as $con): ?>
-                <li><?php echo esc_html($con); ?></li>
+                <?php foreach ( $cons_list as $con ) : ?>
+                <li><?php echo esc_html( $con ); ?></li>
                 <?php endforeach; ?>
             </ul>
         </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -1,91 +1,97 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-$container_id = isset($atts['id']) ? sanitize_html_class($atts['id']) : 'jlg-game-explorer-' . uniqid();
-if ($container_id === '') {
+$container_id = isset( $atts['id'] ) ? sanitize_html_class( $atts['id'] ) : 'jlg-game-explorer-' . uniqid();
+if ( $container_id === '' ) {
     $container_id = 'jlg-game-explorer-' . uniqid();
 }
 
-$columns = isset($atts['columns']) ? (int) $atts['columns'] : 3;
-$columns = max(1, min($columns, 4));
-$filters_enabled = is_array($filters_enabled) ? $filters_enabled : [];
-$current_filters = is_array($current_filters) ? $current_filters : [];
-$letters = is_array($letters) ? $letters : [];
-$sort_options = is_array($sort_options) ? $sort_options : [];
-$categories_list = is_array($categories_list) ? $categories_list : [];
-$platforms_list = is_array($platforms_list) ? $platforms_list : [];
-$availability_options = is_array($availability_options) ? $availability_options : [];
-$total_items = isset($total_items) ? (int) $total_items : 0;
-$sort_key = isset($sort_key) ? $sort_key : 'date';
-$sort_order = isset($sort_order) ? $sort_order : 'DESC';
-$pagination = is_array($pagination) ? $pagination : ['current' => 1, 'total' => 0];
-$config_payload = is_array($config_payload) ? $config_payload : [];
-$request_prefix = isset($request_prefix) ? (string) $request_prefix : '';
-$config_json = wp_json_encode($config_payload);
-if ($config_json === false) {
+$columns              = isset( $atts['columns'] ) ? (int) $atts['columns'] : 3;
+$columns              = max( 1, min( $columns, 4 ) );
+$filters_enabled      = is_array( $filters_enabled ) ? $filters_enabled : array();
+$current_filters      = is_array( $current_filters ) ? $current_filters : array();
+$letters              = is_array( $letters ) ? $letters : array();
+$sort_options         = is_array( $sort_options ) ? $sort_options : array();
+$categories_list      = is_array( $categories_list ) ? $categories_list : array();
+$platforms_list       = is_array( $platforms_list ) ? $platforms_list : array();
+$availability_options = is_array( $availability_options ) ? $availability_options : array();
+$total_items          = isset( $total_items ) ? (int) $total_items : 0;
+$sort_key             = isset( $sort_key ) ? $sort_key : 'date';
+$sort_order           = isset( $sort_order ) ? $sort_order : 'DESC';
+$pagination           = is_array( $pagination ) ? $pagination : array(
+	'current' => 1,
+	'total'   => 0,
+);
+$config_payload       = is_array( $config_payload ) ? $config_payload : array();
+$request_prefix       = isset( $request_prefix ) ? (string) $request_prefix : '';
+$config_json          = wp_json_encode( $config_payload );
+if ( $config_json === false ) {
     $config_json = '{}';
 }
 
-$has_category_filter = !empty($filters_enabled['category']) && !empty($categories_list);
-$has_platform_filter = !empty($filters_enabled['platform']) && !empty($platforms_list);
-$has_availability_filter = !empty($filters_enabled['availability']);
-$has_filters = $has_category_filter || $has_platform_filter || $has_availability_filter;
-$letter_active = isset($current_filters['letter']) ? $current_filters['letter'] : '';
-$category_active = isset($current_filters['category']) ? $current_filters['category'] : '';
-$platform_active = isset($current_filters['platform']) ? $current_filters['platform'] : '';
-$availability_active = isset($current_filters['availability']) ? $current_filters['availability'] : '';
+$has_category_filter     = ! empty( $filters_enabled['category'] ) && ! empty( $categories_list );
+$has_platform_filter     = ! empty( $filters_enabled['platform'] ) && ! empty( $platforms_list );
+$has_availability_filter = ! empty( $filters_enabled['availability'] );
+$has_filters             = $has_category_filter || $has_platform_filter || $has_availability_filter;
+$letter_active           = isset( $current_filters['letter'] ) ? $current_filters['letter'] : '';
+$category_active         = isset( $current_filters['category'] ) ? $current_filters['category'] : '';
+$platform_active         = isset( $current_filters['platform'] ) ? $current_filters['platform'] : '';
+$availability_active     = isset( $current_filters['availability'] ) ? $current_filters['availability'] : '';
 ?>
 
 <div
-    id="<?php echo esc_attr($container_id); ?>"
-    class="jlg-game-explorer jlg-ge-cols-<?php echo esc_attr($columns); ?>"
-    data-columns="<?php echo esc_attr($columns); ?>"
-    data-config="<?php echo esc_attr($config_json); ?>"
-    data-posts-per-page="<?php echo esc_attr($atts['posts_per_page']); ?>"
-    data-total-items="<?php echo esc_attr($total_items); ?>"
-    data-request-prefix="<?php echo esc_attr($request_prefix); ?>"
+    id="<?php echo esc_attr( $container_id ); ?>"
+    class="jlg-game-explorer jlg-ge-cols-<?php echo esc_attr( $columns ); ?>"
+    data-columns="<?php echo esc_attr( $columns ); ?>"
+    data-config="<?php echo esc_attr( $config_json ); ?>"
+    data-posts-per-page="<?php echo esc_attr( $atts['posts_per_page'] ); ?>"
+    data-total-items="<?php echo esc_attr( $total_items ); ?>"
+    data-request-prefix="<?php echo esc_attr( $request_prefix ); ?>"
 >
     <div class="jlg-ge-toolbar">
         <div class="jlg-ge-toolbar__left">
-            <?php if (!empty($filters_enabled['letter']) && !empty($letters)) : ?>
-                <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e('Filtrer par lettre', 'notation-jlg'); ?>">
+            <?php if ( ! empty( $filters_enabled['letter'] ) && ! empty( $letters ) ) : ?>
+                <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
                     <ul>
                         <li>
                             <?php
-                            $all_letters_classes = [];
-                            if ($letter_active === '') {
+                            $all_letters_classes = array();
+                            if ( $letter_active === '' ) {
                                 $all_letters_classes[] = 'is-active';
                             }
                             ?>
                             <button
                                 type="button"
-                                class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $all_letters_classes))); ?>"
+                                class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
                                 data-letter=""
-                                aria-pressed="<?php echo esc_attr($letter_active === '' ? 'true' : 'false'); ?>"
+                                aria-pressed="<?php echo esc_attr( $letter_active === '' ? 'true' : 'false' ); ?>"
                             >
-                                <?php esc_html_e('Tous', 'notation-jlg'); ?>
+                                <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                             </button>
                         </li>
-                        <?php foreach ($letters as $letter_item) :
-                            $value = isset($letter_item['value']) ? $letter_item['value'] : '';
-                            $enabled = !empty($letter_item['enabled']);
-                            $is_active = ($value !== '' && $value === $letter_active);
+                        <?php
+                        foreach ( $letters as $letter_item ) :
+                            $value     = isset( $letter_item['value'] ) ? $letter_item['value'] : '';
+                            $enabled   = ! empty( $letter_item['enabled'] );
+                            $is_active = ( $value !== '' && $value === $letter_active );
                             ?>
                             <li>
                                 <?php
-                                $letter_button_classes = [];
-                                if ($is_active) {
+                                $letter_button_classes = array();
+                                if ( $is_active ) {
                                     $letter_button_classes[] = 'is-active';
                                 }
                                 ?>
                                 <button
                                     type="button"
-                                    data-letter="<?php echo esc_attr($value); ?>"
-                                    class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $letter_button_classes))); ?>"
-                                    <?php disabled(!$enabled); ?>
-                                    aria-pressed="<?php echo esc_attr($is_active ? 'true' : 'false'); ?>"
+                                    data-letter="<?php echo esc_attr( $value ); ?>"
+                                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
+                                    <?php disabled( ! $enabled ); ?>
+                                    aria-pressed="<?php echo esc_attr( $is_active ? 'true' : 'false' ); ?>"
                                 >
-                                    <?php echo esc_html($letter_item['label'] ?? $value); ?>
+                                    <?php echo esc_html( $letter_item['label'] ?? $value ); ?>
                                 </button>
                             </li>
                         <?php endforeach; ?>
@@ -95,28 +101,29 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
         </div>
         <div class="jlg-ge-toolbar__right">
             <div class="jlg-ge-sort">
-                <label for="<?php echo esc_attr($container_id); ?>-sort">
-                    <?php esc_html_e('Trier par', 'notation-jlg'); ?>
+                <label for="<?php echo esc_attr( $container_id ); ?>-sort">
+                    <?php esc_html_e( 'Trier par', 'notation-jlg' ); ?>
                 </label>
-                <select id="<?php echo esc_attr($container_id); ?>-sort" data-role="sort">
-                    <?php foreach ($sort_options as $option) :
-                        $value = isset($option['value']) ? $option['value'] : '';
-                        $option_orderby = isset($option['orderby']) ? $option['orderby'] : '';
-                        $option_order = isset($option['order']) ? $option['order'] : '';
-                        $selected = ($option_orderby === $sort_key && $option_order === $sort_order);
+                <select id="<?php echo esc_attr( $container_id ); ?>-sort" data-role="sort">
+                    <?php
+                    foreach ( $sort_options as $option ) :
+                        $value          = isset( $option['value'] ) ? $option['value'] : '';
+                        $option_orderby = isset( $option['orderby'] ) ? $option['orderby'] : '';
+                        $option_order   = isset( $option['order'] ) ? $option['order'] : '';
+                        $selected       = ( $option_orderby === $sort_key && $option_order === $sort_order );
                         ?>
-                        <option value="<?php echo esc_attr($value); ?>" <?php selected($selected); ?>>
-                            <?php echo esc_html($option['label']); ?>
+                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected ); ?>>
+                            <?php echo esc_html( $option['label'] ); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             </div>
             <div class="jlg-ge-count">
                 <?php
-                $formatted_total_items = number_format_i18n($total_items);
+                $formatted_total_items = number_format_i18n( $total_items );
 
                 printf(
-                    esc_html(_n('%s jeu', '%s jeux', $total_items, 'notation-jlg')),
+                    esc_html( _n( '%s jeu', '%s jeux', $total_items, 'notation-jlg' ) ),
                     $formatted_total_items
                 );
                 ?>
@@ -124,76 +131,81 @@ $availability_active = isset($current_filters['availability']) ? $current_filter
         </div>
     </div>
 
-    <?php if ($has_filters) : ?>
+    <?php if ( $has_filters ) : ?>
         <div class="jlg-ge-filters" data-role="filters">
-            <?php if ($has_category_filter) : ?>
-                <label for="<?php echo esc_attr($container_id); ?>-category" class="screen-reader-text">
-                    <?php esc_html_e('Filtrer par catégorie', 'notation-jlg'); ?>
+            <?php if ( $has_category_filter ) : ?>
+                <label for="<?php echo esc_attr( $container_id ); ?>-category" class="screen-reader-text">
+                    <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
                 </label>
-                <select id="<?php echo esc_attr($container_id); ?>-category" data-role="category">
+                <select id="<?php echo esc_attr( $container_id ); ?>-category" data-role="category">
                     <option value="">
-                        <?php esc_html_e('Toutes les catégories', 'notation-jlg'); ?>
+                        <?php esc_html_e( 'Toutes les catégories', 'notation-jlg' ); ?>
                     </option>
-                    <?php foreach ($categories_list as $category) :
-                        $value = isset($category['value']) ? (string) $category['value'] : '';
-                        $label = isset($category['label']) ? $category['label'] : $value;
+                    <?php
+                    foreach ( $categories_list as $category ) :
+                        $value = isset( $category['value'] ) ? (string) $category['value'] : '';
+                        $label = isset( $category['label'] ) ? $category['label'] : $value;
                         ?>
-                        <option value="<?php echo esc_attr($value); ?>" <?php selected($category_active, $value); ?>>
-                            <?php echo esc_html($label); ?>
+                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $category_active, $value ); ?>>
+                            <?php echo esc_html( $label ); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             <?php endif; ?>
 
-            <?php if ($has_platform_filter) : ?>
-                <label for="<?php echo esc_attr($container_id); ?>-platform" class="screen-reader-text">
-                    <?php esc_html_e('Filtrer par plateforme', 'notation-jlg'); ?>
+            <?php if ( $has_platform_filter ) : ?>
+                <label for="<?php echo esc_attr( $container_id ); ?>-platform" class="screen-reader-text">
+                    <?php esc_html_e( 'Filtrer par plateforme', 'notation-jlg' ); ?>
                 </label>
-                <select id="<?php echo esc_attr($container_id); ?>-platform" data-role="platform">
+                <select id="<?php echo esc_attr( $container_id ); ?>-platform" data-role="platform">
                     <option value="">
-                        <?php esc_html_e('Toutes les plateformes', 'notation-jlg'); ?>
+                        <?php esc_html_e( 'Toutes les plateformes', 'notation-jlg' ); ?>
                     </option>
-                    <?php foreach ($platforms_list as $platform) :
-                        $value = isset($platform['value']) ? (string) $platform['value'] : '';
-                        $label = isset($platform['label']) ? $platform['label'] : $value;
+                    <?php
+                    foreach ( $platforms_list as $platform ) :
+                        $value = isset( $platform['value'] ) ? (string) $platform['value'] : '';
+                        $label = isset( $platform['label'] ) ? $platform['label'] : $value;
                         ?>
-                        <option value="<?php echo esc_attr($value); ?>" <?php selected($platform_active, $value); ?>>
-                            <?php echo esc_html($label); ?>
+                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $platform_active, $value ); ?>>
+                            <?php echo esc_html( $label ); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             <?php endif; ?>
 
-            <?php if ($has_availability_filter) : ?>
-                <label for="<?php echo esc_attr($container_id); ?>-availability" class="screen-reader-text">
-                    <?php esc_html_e('Filtrer par disponibilité', 'notation-jlg'); ?>
+            <?php if ( $has_availability_filter ) : ?>
+                <label for="<?php echo esc_attr( $container_id ); ?>-availability" class="screen-reader-text">
+                    <?php esc_html_e( 'Filtrer par disponibilité', 'notation-jlg' ); ?>
                 </label>
-                <select id="<?php echo esc_attr($container_id); ?>-availability" data-role="availability">
+                <select id="<?php echo esc_attr( $container_id ); ?>-availability" data-role="availability">
                     <option value="">
-                        <?php esc_html_e('Toutes les sorties', 'notation-jlg'); ?>
+                        <?php esc_html_e( 'Toutes les sorties', 'notation-jlg' ); ?>
                     </option>
-                    <?php foreach ($availability_options as $value => $label) : ?>
-                        <option value="<?php echo esc_attr($value); ?>" <?php selected($availability_active, $value); ?>>
-                            <?php echo esc_html($label); ?>
+                    <?php foreach ( $availability_options as $value => $label ) : ?>
+                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $availability_active, $value ); ?>>
+                            <?php echo esc_html( $label ); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             <?php endif; ?>
 
             <button type="button" class="jlg-ge-reset" data-role="reset">
-                <?php esc_html_e('Réinitialiser', 'notation-jlg'); ?>
+                <?php esc_html_e( 'Réinitialiser', 'notation-jlg' ); ?>
             </button>
         </div>
     <?php endif; ?>
 
     <div class="jlg-ge-results" data-role="results">
         <?php
-        echo JLG_Frontend::get_template_html('game-explorer-fragment', [
-            'games'      => $games,
-            'message'    => isset($message) ? $message : '',
-            'pagination' => $pagination,
-            'total_items'=> $total_items,
-        ]);
+        echo JLG_Frontend::get_template_html(
+            'game-explorer-fragment',
+            array(
+				'games'       => $games,
+				'message'     => isset( $message ) ? $message : '',
+				'pagination'  => $pagination,
+				'total_items' => $total_items,
+			)
+        );
         ?>
     </div>
 </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-game-info.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-info.php
@@ -1,25 +1,27 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div class="jlg-game-info-box">
-    <h3><?php echo esc_html($titre); ?></h3>
+    <h3><?php echo esc_html( $titre ); ?></h3>
     <dl>
-        <?php foreach ($champs_a_afficher as $key => $data): ?>
-            <dt><?php echo esc_html($data['label']); ?></dt>
+        <?php foreach ( $champs_a_afficher as $key => $data ) : ?>
+            <dt><?php echo esc_html( $data['label'] ); ?></dt>
             <dd>
                 <?php
-                if (is_array($data['value'])) {
+                if ( is_array( $data['value'] ) ) {
                     $wrapper_class = $key === 'plateformes' ? 'platforms-list' : 'jlg-game-info-list';
-                    echo '<div class="' . esc_attr($wrapper_class) . '">';
-                    foreach ($data['value'] as $item) {
-                        echo '<span>' . esc_html($item) . '</span>';
+                    echo '<div class="' . esc_attr( $wrapper_class ) . '">';
+                    foreach ( $data['value'] as $item ) {
+                        echo '<span>' . esc_html( $item ) . '</span>';
                     }
                     echo '</div>';
-                } elseif ($key === 'date_sortie' && $data['value'] !== '') {
-                    echo esc_html(date_i18n(get_option('date_format'), strtotime($data['value'])));
+                } elseif ( $key === 'date_sortie' && $data['value'] !== '' ) {
+                    echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $data['value'] ) ) );
                 } else {
-                    echo esc_html($data['value']);
+                    echo esc_html( $data['value'] );
                 }
                 ?>
             </dd>

--- a/plugin-notation-jeux_V4/templates/shortcode-pros-cons.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-pros-cons.php
@@ -1,24 +1,40 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div class="jlg-pros-cons-wrapper">
-    <?php if (!empty($pros_list)): ?>
+    <?php if ( ! empty( $pros_list ) ) : ?>
     <div class="jlg-pros-cons-col">
-        <h3><span class="icon icon-pros">+</span> <?php
+        <h3><span class="icon icon-pros">+</span> 
+        <?php
             /* translators: Section title for the list of advantages in the pros and cons block. */
-            esc_html_e('Points Forts', 'notation-jlg');
-        ?></h3>
-        <ul><?php foreach ($pros_list as $pro) echo '<li>' . esc_html(trim($pro)) . '</li>'; ?></ul>
+            esc_html_e( 'Points Forts', 'notation-jlg' );
+        ?>
+        </h3>
+        <ul>
+        <?php
+        foreach ( $pros_list as $pro ) {
+			echo '<li>' . esc_html( trim( $pro ) ) . '</li>';}
+		?>
+        </ul>
     </div>
     <?php endif; ?>
-    <?php if (!empty($cons_list)): ?>
+    <?php if ( ! empty( $cons_list ) ) : ?>
     <div class="jlg-pros-cons-col">
-        <h3><span class="icon icon-cons">-</span> <?php
+        <h3><span class="icon icon-cons">-</span> 
+        <?php
             /* translators: Section title for the list of drawbacks in the pros and cons block. */
-            esc_html_e('Points Faibles', 'notation-jlg');
-        ?></h3>
-        <ul><?php foreach ($cons_list as $con) echo '<li>' . esc_html(trim($con)) . '</li>'; ?></ul>
+            esc_html_e( 'Points Faibles', 'notation-jlg' );
+        ?>
+        </h3>
+        <ul>
+        <?php
+        foreach ( $cons_list as $con ) {
+			echo '<li>' . esc_html( trim( $con ) ) . '</li>';}
+		?>
+        </ul>
     </div>
     <?php endif; ?>
 </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Template pour le bloc de notation principal
- * 
+ *
  * Variables disponibles :
  * - $options : Options du plugin
  * - $average_score : Note moyenne calculée
@@ -9,22 +9,29 @@
  * - $categories : Libellés des catégories
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 $options = JLG_Helpers::get_plugin_options();
 ?>
 
-<div class="review-box-jlg <?php if ($options['enable_animations']) echo 'jlg-animate'; ?>">
+<div class="review-box-jlg 
+<?php
+if ( $options['enable_animations'] ) {
+	echo 'jlg-animate';}
+?>
+">
     <div class="global-score-wrapper">
-        <?php if($options['score_layout'] === 'circle'): ?>
+        <?php if ( $options['score_layout'] === 'circle' ) : ?>
             <div class="score-circle">
-                <div class="score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
-                <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
+                <div class="score-value"><?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?></div>
+                <div class="score-label"><?php esc_html_e( 'Note Globale', 'notation-jlg' ); ?></div>
             </div>
-        <?php else: ?>
+        <?php else : ?>
             <div class="global-score-text">
-                <div class="score-value"><?php echo esc_html(number_format_i18n($average_score, 1)); ?></div>
-                <div class="score-label"><?php esc_html_e('Note Globale', 'notation-jlg'); ?></div>
+                <div class="score-value"><?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?></div>
+                <div class="score-label"><?php esc_html_e( 'Note Globale', 'notation-jlg' ); ?></div>
             </div>
         <?php endif; ?>
     </div>
@@ -32,18 +39,19 @@ $options = JLG_Helpers::get_plugin_options();
     <hr>
     
     <div class="rating-breakdown">
-        <?php foreach ($scores as $key => $score_value) :
-            $bar_color = JLG_Helpers::calculate_color_from_note($score_value, $options);
-        ?>
+        <?php
+        foreach ( $scores as $key => $score_value ) :
+            $bar_color = JLG_Helpers::calculate_color_from_note( $score_value, $options );
+			?>
             <div class="rating-item">
                 <div class="rating-label">
-                    <span><?php echo esc_html($categories[$key]); ?></span>
+                    <span><?php echo esc_html( $categories[ $key ] ); ?></span>
                     <span>
                         <?php
-                        $formatted_score_value = esc_html(number_format_i18n($score_value, 1));
+                        $formatted_score_value = esc_html( number_format_i18n( $score_value, 1 ) );
                         printf(
                             /* translators: 1: Rating value for a specific category. 2: Maximum possible rating. */
-                            esc_html__('%1$s / %2$s', 'notation-jlg'),
+                            esc_html__( '%1$s / %2$s', 'notation-jlg' ),
                             $formatted_score_value,
                             10
                         );
@@ -51,7 +59,7 @@ $options = JLG_Helpers::get_plugin_options();
                     </span>
                 </div>
                 <div class="rating-bar-container">
-                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr($score_value * 10); ?>%; --bar-color: <?php echo esc_attr($bar_color); ?>;"></div>
+                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( $score_value * 10 ); ?>%; --bar-color: <?php echo esc_attr( $bar_color ); ?>;"></div>
                 </div>
             </div>
         <?php endforeach; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -10,149 +10,158 @@
  * - $order : Ordre actuel (ASC/DESC)
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-$table_id = isset($atts['id']) ? sanitize_html_class($atts['id']) : 'jlg-table-' . uniqid();
-$layout = isset($atts['layout']) ? $atts['layout'] : 'table';
-$columns = is_array($colonnes) ? $colonnes : [];
-$available_columns = is_array($colonnes_disponibles) ? $colonnes_disponibles : [];
-$current_orderby = !empty($orderby) ? $orderby : 'date';
-$current_order = !empty($order) ? $order : 'DESC';
-$current_letter_filter = isset($letter_filter) ? sanitize_text_field($letter_filter) : (isset($atts['letter_filter']) ? sanitize_text_field($atts['letter_filter']) : '');
-$current_genre_filter = isset($genre_filter) ? sanitize_text_field($genre_filter) : (isset($atts['genre_filter']) ? sanitize_text_field($atts['genre_filter']) : '');
-$show_filters = empty($atts['categorie']);
-$current_cat_filter = ($show_filters && isset($cat_filter)) ? intval($cat_filter) : 0;
-$columns_attr = !empty($columns) ? implode(',', array_map('sanitize_key', $columns)) : '';
-$genre_taxonomy = apply_filters('jlg_summary_genre_taxonomy', 'jlg_game_genre');
-$has_genre_taxonomy = !empty($genre_taxonomy) && taxonomy_exists($genre_taxonomy);
-$genre_terms = [];
-$request_prefix = isset($request_prefix) ? (string) $request_prefix : '';
-$request_keys = isset($request_keys) && is_array($request_keys) ? $request_keys : [];
-$resolve_request_key = static function ($key) use ($request_prefix, $request_keys) {
-    if (isset($request_keys[$key]) && is_string($request_keys[$key])) {
-        return $request_keys[$key];
+$table_id              = isset( $atts['id'] ) ? sanitize_html_class( $atts['id'] ) : 'jlg-table-' . uniqid();
+$layout                = isset( $atts['layout'] ) ? $atts['layout'] : 'table';
+$columns               = is_array( $colonnes ) ? $colonnes : array();
+$available_columns     = is_array( $colonnes_disponibles ) ? $colonnes_disponibles : array();
+$current_orderby       = ! empty( $orderby ) ? $orderby : 'date';
+$current_order         = ! empty( $order ) ? $order : 'DESC';
+$current_letter_filter = isset( $letter_filter ) ? sanitize_text_field( $letter_filter ) : ( isset( $atts['letter_filter'] ) ? sanitize_text_field( $atts['letter_filter'] ) : '' );
+$current_genre_filter  = isset( $genre_filter ) ? sanitize_text_field( $genre_filter ) : ( isset( $atts['genre_filter'] ) ? sanitize_text_field( $atts['genre_filter'] ) : '' );
+$show_filters          = empty( $atts['categorie'] );
+$current_cat_filter    = ( $show_filters && isset( $cat_filter ) ) ? intval( $cat_filter ) : 0;
+$columns_attr          = ! empty( $columns ) ? implode( ',', array_map( 'sanitize_key', $columns ) ) : '';
+$genre_taxonomy        = apply_filters( 'jlg_summary_genre_taxonomy', 'jlg_game_genre' );
+$has_genre_taxonomy    = ! empty( $genre_taxonomy ) && taxonomy_exists( $genre_taxonomy );
+$genre_terms           = array();
+$request_prefix        = isset( $request_prefix ) ? (string) $request_prefix : '';
+$request_keys          = isset( $request_keys ) && is_array( $request_keys ) ? $request_keys : array();
+$resolve_request_key   = static function ( $key ) use ( $request_prefix, $request_keys ) {
+    if ( isset( $request_keys[ $key ] ) && is_string( $request_keys[ $key ] ) ) {
+        return $request_keys[ $key ];
     }
 
     return $request_prefix !== '' ? $key . '__' . $request_prefix : $key;
 };
 
-if ($show_filters && $has_genre_taxonomy) {
-    $genre_terms = get_terms([
-        'taxonomy'   => $genre_taxonomy,
-        'hide_empty' => false,
-        'orderby'    => 'name',
-        'order'      => 'ASC',
-    ]);
+if ( $show_filters && $has_genre_taxonomy ) {
+    $genre_terms = get_terms(
+        array(
+			'taxonomy'   => $genre_taxonomy,
+			'hide_empty' => false,
+			'orderby'    => 'name',
+			'order'      => 'ASC',
+        )
+    );
 
-    if (is_wp_error($genre_terms)) {
-        $genre_terms = [];
+    if ( is_wp_error( $genre_terms ) ) {
+        $genre_terms = array();
     }
 }
 
-$letters = range('A', 'Z');
+$letters = range( 'A', 'Z' );
 ?>
 
 <div
-    id="<?php echo esc_attr($table_id); ?>"
+    id="<?php echo esc_attr( $table_id ); ?>"
     class="jlg-summary-wrapper"
-    data-posts-per-page="<?php echo esc_attr(intval($atts['posts_per_page'])); ?>"
-    data-layout="<?php echo esc_attr($layout); ?>"
-    data-categorie="<?php echo esc_attr($atts['categorie']); ?>"
-    data-colonnes="<?php echo esc_attr($columns_attr); ?>"
-    data-orderby="<?php echo esc_attr($current_orderby); ?>"
-    data-order="<?php echo esc_attr($current_order); ?>"
-    data-paged="<?php echo esc_attr(intval($paged)); ?>"
-    data-cat-filter="<?php echo esc_attr($current_cat_filter); ?>"
-    data-letter-filter="<?php echo esc_attr($current_letter_filter); ?>"
-    data-genre-filter="<?php echo esc_attr($current_genre_filter); ?>"
-    data-request-prefix="<?php echo esc_attr($request_prefix); ?>"
+    data-posts-per-page="<?php echo esc_attr( intval( $atts['posts_per_page'] ) ); ?>"
+    data-layout="<?php echo esc_attr( $layout ); ?>"
+    data-categorie="<?php echo esc_attr( $atts['categorie'] ); ?>"
+    data-colonnes="<?php echo esc_attr( $columns_attr ); ?>"
+    data-orderby="<?php echo esc_attr( $current_orderby ); ?>"
+    data-order="<?php echo esc_attr( $current_order ); ?>"
+    data-paged="<?php echo esc_attr( intval( $paged ) ); ?>"
+    data-cat-filter="<?php echo esc_attr( $current_cat_filter ); ?>"
+    data-letter-filter="<?php echo esc_attr( $current_letter_filter ); ?>"
+    data-genre-filter="<?php echo esc_attr( $current_genre_filter ); ?>"
+    data-request-prefix="<?php echo esc_attr( $request_prefix ); ?>"
 >
 
-    <?php if ($show_filters) : ?>
+    <?php if ( $show_filters ) : ?>
         <!-- Filtres -->
         <div class="jlg-summary-filters">
-            <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e('Filtrer par lettre', 'notation-jlg'); ?>">
+            <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
                 <?php
-                $all_letters_classes = [];
-                if ($current_letter_filter === '') {
+                $all_letters_classes = array();
+                if ( $current_letter_filter === '' ) {
                     $all_letters_classes[] = 'is-active';
                 }
                 ?>
-                <button type="button" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $all_letters_classes))); ?>" data-letter="">
-                    <?php esc_html_e('Tous', 'notation-jlg'); ?>
+                <button type="button" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>" data-letter="">
+                    <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                 </button>
-                <?php foreach ($letters as $letter) : ?>
+                <?php foreach ( $letters as $letter ) : ?>
                     <?php
-                    $letter_button_classes = [];
-                    if ($current_letter_filter === $letter) {
+                    $letter_button_classes = array();
+                    if ( $current_letter_filter === $letter ) {
                         $letter_button_classes[] = 'is-active';
                     }
                     ?>
-                    <button type="button" data-letter="<?php echo esc_attr($letter); ?>" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $letter_button_classes))); ?>">
-                        <?php echo esc_html($letter); ?>
+                    <button type="button" data-letter="<?php echo esc_attr( $letter ); ?>" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>">
+                        <?php echo esc_html( $letter ); ?>
                     </button>
                 <?php endforeach; ?>
                 <?php
-                $numeric_button_classes = [];
-                if ($current_letter_filter === '#') {
+                $numeric_button_classes = array();
+                if ( $current_letter_filter === '#' ) {
                     $numeric_button_classes[] = 'is-active';
                 }
                 ?>
-                <button type="button" data-letter="#" class="<?php echo esc_attr(implode(' ', array_map('sanitize_html_class', $numeric_button_classes))); ?>">
-                    <?php esc_html_e('0-9', 'notation-jlg'); ?>
+                <button type="button" data-letter="#" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $numeric_button_classes ) ) ); ?>">
+                    <?php esc_html_e( '0-9', 'notation-jlg' ); ?>
                 </button>
             </div>
 
             <form method="get" action="" class="jlg-summary-filters-form">
-                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('orderby')); ?>" value="<?php echo esc_attr($current_orderby); ?>">
-                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('order')); ?>" value="<?php echo esc_attr($current_order); ?>">
-                <input type="hidden" name="<?php echo esc_attr($resolve_request_key('letter_filter')); ?>" value="<?php echo esc_attr($current_letter_filter); ?>">
+                <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'orderby' ) ); ?>" value="<?php echo esc_attr( $current_orderby ); ?>">
+                <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'order' ) ); ?>" value="<?php echo esc_attr( $current_order ); ?>">
+                <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'letter_filter' ) ); ?>" value="<?php echo esc_attr( $current_letter_filter ); ?>">
                 <?php
-                wp_dropdown_categories([
-                    'show_option_all' => __('Toutes les catégories', 'notation-jlg'),
-                    'orderby' => 'name',
-                    'hide_empty' => 1,
-                    'name' => $resolve_request_key('cat_filter'),
-                    'id' => $table_id . '_cat_filter',
-                    'selected' => $current_cat_filter,
-                    'hierarchical' => true,
-                    'class' => 'jlg-cat-filter-select',
-                ]);
+                wp_dropdown_categories(
+                    array(
+						'show_option_all' => __( 'Toutes les catégories', 'notation-jlg' ),
+						'orderby'         => 'name',
+						'hide_empty'      => 1,
+						'name'            => $resolve_request_key( 'cat_filter' ),
+						'id'              => $table_id . '_cat_filter',
+						'selected'        => $current_cat_filter,
+						'hierarchical'    => true,
+						'class'           => 'jlg-cat-filter-select',
+                    )
+                );
                 ?>
-                <?php if ($has_genre_taxonomy && !empty($genre_terms)) : ?>
-                    <label for="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="screen-reader-text">
-                        <?php esc_html_e('Filtrer par genre', 'notation-jlg'); ?>
+                <?php if ( $has_genre_taxonomy && ! empty( $genre_terms ) ) : ?>
+                    <label for="<?php echo esc_attr( $table_id . '_genre_filter' ); ?>" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par genre', 'notation-jlg' ); ?>
                     </label>
-                    <select name="<?php echo esc_attr($resolve_request_key('genre_filter')); ?>" id="<?php echo esc_attr($table_id . '_genre_filter'); ?>" class="jlg-genre-filter-select">
-                        <option value="" <?php selected($current_genre_filter, ''); ?>><?php esc_html_e('Tous les genres', 'notation-jlg'); ?></option>
-                        <?php foreach ($genre_terms as $term) : ?>
-                            <option value="<?php echo esc_attr($term->slug); ?>" <?php selected($current_genre_filter, $term->slug); ?>>
-                                <?php echo esc_html($term->name); ?>
+                    <select name="<?php echo esc_attr( $resolve_request_key( 'genre_filter' ) ); ?>" id="<?php echo esc_attr( $table_id . '_genre_filter' ); ?>" class="jlg-genre-filter-select">
+                        <option value="" <?php selected( $current_genre_filter, '' ); ?>><?php esc_html_e( 'Tous les genres', 'notation-jlg' ); ?></option>
+                        <?php foreach ( $genre_terms as $term ) : ?>
+                            <option value="<?php echo esc_attr( $term->slug ); ?>" <?php selected( $current_genre_filter, $term->slug ); ?>>
+                                <?php echo esc_html( $term->name ); ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
                 <?php else : ?>
-                    <input type="hidden" name="<?php echo esc_attr($resolve_request_key('genre_filter')); ?>" value="<?php echo esc_attr($current_genre_filter); ?>">
+                    <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'genre_filter' ) ); ?>" value="<?php echo esc_attr( $current_genre_filter ); ?>">
                 <?php endif; ?>
-                <input type="submit" value="<?php echo esc_attr__('Filtrer', 'notation-jlg'); ?>">
+                <input type="submit" value="<?php echo esc_attr__( 'Filtrer', 'notation-jlg' ); ?>">
             </form>
         </div>
     <?php endif; ?>
 
     <div class="jlg-summary-content">
         <?php
-        echo JLG_Frontend::get_template_html('summary-table-fragment', [
-            'query'                => $query,
-            'atts'                 => $atts,
-            'paged'                => $paged,
-            'orderby'              => $orderby,
-            'order'                => $order,
-            'colonnes'             => $columns,
-            'colonnes_disponibles' => $available_columns,
-            'error_message'        => isset($error_message) ? $error_message : '',
-            'cat_filter'           => $current_cat_filter,
-            'table_id'             => $table_id,
-        ]);
+        echo JLG_Frontend::get_template_html(
+            'summary-table-fragment',
+            array(
+				'query'                => $query,
+				'atts'                 => $atts,
+				'paged'                => $paged,
+				'orderby'              => $orderby,
+				'order'                => $order,
+				'colonnes'             => $columns,
+				'colonnes_disponibles' => $available_columns,
+				'error_message'        => isset( $error_message ) ? $error_message : '',
+				'cat_filter'           => $current_cat_filter,
+				'table_id'             => $table_id,
+			)
+        );
         ?>
     </div>
 </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-tagline.php
@@ -1,27 +1,49 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-$has_fr = !empty($tagline_fr);
-$has_en = !empty($tagline_en);
+$has_fr       = ! empty( $tagline_fr );
+$has_en       = ! empty( $tagline_en );
 $default_lang = $has_fr ? 'fr' : 'en';
 ?>
 
 <div class="jlg-tagline-block">
-    <?php if ($has_fr && $has_en): ?>
+    <?php if ( $has_fr && $has_en ) : ?>
         <div class="jlg-tagline-flags">
-            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg'); ?>" data-lang="fr" class="jlg-lang-flag <?php if($default_lang == 'fr') echo 'active'; ?>" alt="<?php echo esc_attr__('Français', 'notation-jlg'); ?>">
-            <img src="<?php echo esc_url(JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg'); ?>" data-lang="en" class="jlg-lang-flag <?php if($default_lang == 'en') echo 'active'; ?>" alt="<?php echo esc_attr__('English', 'notation-jlg'); ?>">
+            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>" data-lang="fr" class="jlg-lang-flag 
+            <?php
+            if ( $default_lang == 'fr' ) {
+				echo 'active';}
+			?>
+            " alt="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>">
+            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>" data-lang="en" class="jlg-lang-flag 
+            <?php
+            if ( $default_lang == 'en' ) {
+				echo 'active';}
+			?>
+            " alt="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>">
         </div>
     <?php endif; ?>
 
-    <?php if ($has_fr): ?>
-        <div class="jlg-tagline-text" data-lang="fr" <?php if($default_lang !== 'fr') echo 'style="display:none;"'; ?>>
-            "<?php echo wp_kses_post($tagline_fr); ?>"
+    <?php if ( $has_fr ) : ?>
+        <div class="jlg-tagline-text" data-lang="fr" 
+        <?php
+        if ( $default_lang !== 'fr' ) {
+			echo 'style="display:none;"';}
+		?>
+        >
+            "<?php echo wp_kses_post( $tagline_fr ); ?>"
         </div>
     <?php endif; ?>
-     <?php if ($has_en): ?>
-        <div class="jlg-tagline-text" data-lang="en" <?php if($default_lang !== 'en') echo 'style="display:none;"'; ?>>
-            "<?php echo wp_kses_post($tagline_en); ?>"
+    <?php if ( $has_en ) : ?>
+        <div class="jlg-tagline-text" data-lang="en" 
+        <?php
+        if ( $default_lang !== 'en' ) {
+			echo 'style="display:none;"';}
+		?>
+        >
+            "<?php echo wp_kses_post( $tagline_en ); ?>"
         </div>
     <?php endif; ?>
 </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -1,19 +1,31 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
-<div class="jlg-user-rating-block <?php if ($has_voted) echo esc_attr('has-voted'); ?>">
-    <div class="jlg-user-rating-title"><?php esc_html_e('Votre avis nous intéresse !', 'notation-jlg'); ?></div>
-    <div class="jlg-user-rating-stars" data-post-id="<?php echo esc_attr($post_id); ?>">
-        <?php for ($i = 1; $i <= 5; $i++): ?>
-            <span class="jlg-user-star <?php if($has_voted && $i <= $user_vote) echo esc_attr('selected'); ?>" data-value="<?php echo esc_attr($i); ?>">★</span>
+<div class="jlg-user-rating-block 
+<?php
+if ( $has_voted ) {
+	echo esc_attr( 'has-voted' );}
+?>
+">
+    <div class="jlg-user-rating-title"><?php esc_html_e( 'Votre avis nous intéresse !', 'notation-jlg' ); ?></div>
+    <div class="jlg-user-rating-stars" data-post-id="<?php echo esc_attr( $post_id ); ?>">
+        <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+            <span class="jlg-user-star 
+            <?php
+            if ( $has_voted && $i <= $user_vote ) {
+				echo esc_attr( 'selected' );}
+			?>
+            " data-value="<?php echo esc_attr( $i ); ?>">★</span>
         <?php endfor; ?>
     </div>
     <div class="jlg-user-rating-summary">
         <?php
         /* translators: Abbreviation meaning that the user rating is not available. */
-        $average_display = !empty($avg_rating) ? number_format_i18n(floatval($avg_rating), 2) : __('N/A', 'notation-jlg');
-        $votes_display = !empty($count) ? intval($count) : 0;
+        $average_display = ! empty( $avg_rating ) ? number_format_i18n( floatval( $avg_rating ), 2 ) : __( 'N/A', 'notation-jlg' );
+        $votes_display   = ! empty( $count ) ? intval( $count ) : 0;
         /* translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes. */
         $summary_template = __(
             'Note moyenne : <strong class="jlg-user-rating-avg-value">%1$s</strong> sur %2$s (<span class="jlg-user-rating-count-value">%3$s</span> votes)',
@@ -23,16 +35,21 @@ if (!defined('ABSPATH')) exit;
         echo wp_kses(
             sprintf(
                 $summary_template,
-                esc_html($average_display),
-                esc_html(number_format_i18n(5)),
-                esc_html(number_format_i18n($votes_display))
+                esc_html( $average_display ),
+                esc_html( number_format_i18n( 5 ) ),
+                esc_html( number_format_i18n( $votes_display ) )
             ),
-            [
-                'strong' => ['class' => []],
-                'span' => ['class' => []],
-            ]
+            array(
+                'strong' => array( 'class' => array() ),
+                'span'   => array( 'class' => array() ),
+            )
         );
         ?>
     </div>
-    <div class="jlg-rating-message"><?php if($has_voted) esc_html_e('Merci pour votre vote !', 'notation-jlg'); ?></div>
+    <div class="jlg-rating-message">
+    <?php
+    if ( $has_voted ) {
+		esc_html_e( 'Merci pour votre vote !', 'notation-jlg' );}
+	?>
+    </div>
 </div>

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -3,240 +3,247 @@
  * Fragment HTML pour l'affichage du tableau ou de la grille récapitulative.
  */
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$columns = is_array($colonnes) ? $colonnes : [];
-$available_columns = is_array($colonnes_disponibles) ? $colonnes_disponibles : [];
-$table_id = !empty($table_id) ? sanitize_html_class($table_id) : '';
-if ($table_id === '' && isset($atts['id'])) {
-    $table_id = sanitize_html_class($atts['id']);
+$columns           = is_array( $colonnes ) ? $colonnes : array();
+$available_columns = is_array( $colonnes_disponibles ) ? $colonnes_disponibles : array();
+$table_id          = ! empty( $table_id ) ? sanitize_html_class( $table_id ) : '';
+if ( $table_id === '' && isset( $atts['id'] ) ) {
+    $table_id = sanitize_html_class( $atts['id'] );
 }
-$layout = isset($atts['layout']) ? $atts['layout'] : 'table';
-$base_url = isset($base_url) ? esc_url_raw($base_url) : '';
-$current_orderby = !empty($orderby) ? $orderby : 'date';
-$current_order = !empty($order) ? strtoupper($order) : 'DESC';
-$current_cat_filter = isset($cat_filter) ? intval($cat_filter) : 0;
-$current_letter_filter = isset($letter_filter) ? sanitize_text_field($letter_filter) : (isset($atts['letter_filter']) ? sanitize_text_field($atts['letter_filter']) : '');
-$current_genre_filter = isset($genre_filter) ? sanitize_text_field($genre_filter) : (isset($atts['genre_filter']) ? sanitize_text_field($atts['genre_filter']) : '');
-$genre_taxonomy = apply_filters('jlg_summary_genre_taxonomy', 'jlg_game_genre');
-$has_genre_taxonomy = !empty($genre_taxonomy) && taxonomy_exists($genre_taxonomy);
-$default_empty_message = '<p>' . esc_html__('Aucun article trouvé pour cette sélection.', 'notation-jlg') . '</p>';
-$empty_message = !empty($error_message) ? $error_message : $default_empty_message;
-$columns_count = count($columns);
+$layout                = isset( $atts['layout'] ) ? $atts['layout'] : 'table';
+$base_url              = isset( $base_url ) ? esc_url_raw( $base_url ) : '';
+$current_orderby       = ! empty( $orderby ) ? $orderby : 'date';
+$current_order         = ! empty( $order ) ? strtoupper( $order ) : 'DESC';
+$current_cat_filter    = isset( $cat_filter ) ? intval( $cat_filter ) : 0;
+$current_letter_filter = isset( $letter_filter ) ? sanitize_text_field( $letter_filter ) : ( isset( $atts['letter_filter'] ) ? sanitize_text_field( $atts['letter_filter'] ) : '' );
+$current_genre_filter  = isset( $genre_filter ) ? sanitize_text_field( $genre_filter ) : ( isset( $atts['genre_filter'] ) ? sanitize_text_field( $atts['genre_filter'] ) : '' );
+$genre_taxonomy        = apply_filters( 'jlg_summary_genre_taxonomy', 'jlg_game_genre' );
+$has_genre_taxonomy    = ! empty( $genre_taxonomy ) && taxonomy_exists( $genre_taxonomy );
+$default_empty_message = '<p>' . esc_html__( 'Aucun article trouvé pour cette sélection.', 'notation-jlg' ) . '</p>';
+$empty_message         = ! empty( $error_message ) ? $error_message : $default_empty_message;
+$columns_count         = count( $columns );
 
-$active_filter_labels = [];
+$active_filter_labels = array();
 
-if ($current_cat_filter > 0) {
-    $category = get_category($current_cat_filter);
+if ( $current_cat_filter > 0 ) {
+    $category = get_category( $current_cat_filter );
 
-    if ($category && !is_wp_error($category)) {
+    if ( $category && ! is_wp_error( $category ) ) {
         $active_filter_labels[] = sprintf(
             /* translators: %s is the category name. */
-            esc_html__('Catégorie : %s', 'notation-jlg'),
+            esc_html__( 'Catégorie : %s', 'notation-jlg' ),
             $category->name
         );
     }
 }
 
-if ($current_letter_filter !== '') {
+if ( $current_letter_filter !== '' ) {
     $letter_label = $current_letter_filter === '#'
-        ? esc_html__('0-9', 'notation-jlg')
-        : strtoupper($current_letter_filter);
+        ? esc_html__( '0-9', 'notation-jlg' )
+        : strtoupper( $current_letter_filter );
 
     $active_filter_labels[] = sprintf(
         /* translators: %s is the first letter used to filter results. */
-        esc_html__('Lettre : %s', 'notation-jlg'),
+        esc_html__( 'Lettre : %s', 'notation-jlg' ),
         $letter_label
     );
 }
 
-if ($current_genre_filter !== '') {
+if ( $current_genre_filter !== '' ) {
     $genre_display = $current_genre_filter;
 
-    if ($has_genre_taxonomy) {
-        $genre_term = get_term_by('slug', $current_genre_filter, $genre_taxonomy);
+    if ( $has_genre_taxonomy ) {
+        $genre_term = get_term_by( 'slug', $current_genre_filter, $genre_taxonomy );
 
-        if ($genre_term && !is_wp_error($genre_term)) {
+        if ( $genre_term && ! is_wp_error( $genre_term ) ) {
             $genre_display = $genre_term->name;
         }
     }
 
     $active_filter_labels[] = sprintf(
         /* translators: %s is the selected genre. */
-        esc_html__('Genre : %s', 'notation-jlg'),
+        esc_html__( 'Genre : %s', 'notation-jlg' ),
         $genre_display
     );
 }
 
-if (empty($error_message) && !empty($active_filter_labels)) {
-    $message_labels = implode(', ', array_map('esc_html', $active_filter_labels));
-    $empty_message = '<p>' . sprintf(
+if ( empty( $error_message ) && ! empty( $active_filter_labels ) ) {
+    $message_labels = implode( ', ', array_map( 'esc_html', $active_filter_labels ) );
+    $empty_message  = '<p>' . sprintf(
         /* translators: %s is the list of active filters. */
-        esc_html__('Aucun article ne correspond aux filtres : %s.', 'notation-jlg'),
+        esc_html__( 'Aucun article ne correspond aux filtres : %s.', 'notation-jlg' ),
         $message_labels
     ) . '</p>';
 }
 
-if ($columns_count === 0) {
+if ( $columns_count === 0 ) {
     $columns_count = 1;
 }
 
-if (!function_exists('jlg_print_sortable_header')) {
-    function jlg_print_sortable_header($col, $col_info, $current_orderby, $current_order, $table_id, $extra_params = []) {
+if ( ! function_exists( 'jlg_print_sortable_header' ) ) {
+    function jlg_print_sortable_header( $col, $col_info, $current_orderby, $current_order, $table_id, $extra_params = array() ) {
         $base_url = '';
-        if (isset($extra_params['base_url'])) {
-            $base_url = esc_url_raw($extra_params['base_url']);
-            unset($extra_params['base_url']);
+        if ( isset( $extra_params['base_url'] ) ) {
+            $base_url = esc_url_raw( $extra_params['base_url'] );
+            unset( $extra_params['base_url'] );
         }
 
-        if (!isset($col_info['sortable']) || !$col_info['sortable']) {
-            echo '<th>' . esc_html($col_info['label']) . '</th>';
+        if ( ! isset( $col_info['sortable'] ) || ! $col_info['sortable'] ) {
+            echo '<th>' . esc_html( $col_info['label'] ) . '</th>';
             return;
         }
 
         $sort_key = $col;
-        if (isset($col_info['sort']['key'])) {
+        if ( isset( $col_info['sort']['key'] ) ) {
             $sort_key = $col_info['sort']['key'];
-        } elseif (isset($col_info['key'])) {
+        } elseif ( isset( $col_info['key'] ) ) {
             $sort_key = $col_info['key'];
         }
 
-        $sort_key = sanitize_key($sort_key);
-        $new_order = ($current_orderby === $sort_key && $current_order === 'ASC') ? 'DESC' : 'ASC';
-        $args = [
+        $sort_key  = sanitize_key( $sort_key );
+        $new_order = ( $current_orderby === $sort_key && $current_order === 'ASC' ) ? 'DESC' : 'ASC';
+        $args      = array(
             'orderby' => $sort_key,
             'order'   => $new_order,
-        ];
+        );
 
-        if (!empty($extra_params) && is_array($extra_params)) {
-            $filtered_params = array_filter($extra_params, function($value) {
-                if ($value === null || $value === '') {
-                    return false;
-                }
+        if ( ! empty( $extra_params ) && is_array( $extra_params ) ) {
+            $filtered_params = array_filter(
+                $extra_params,
+                function ( $value ) {
+					if ( $value === null || $value === '' ) {
+						return false;
+					}
 
-                if ($value === 0 || $value === '0') {
-                    return false;
-                }
+					if ( $value === 0 || $value === '0' ) {
+						return false;
+					}
 
-                return true;
-            });
+					return true;
+				}
+            );
 
-            if (!empty($filtered_params)) {
-                $args = array_merge($filtered_params, $args);
+            if ( ! empty( $filtered_params ) ) {
+                $args = array_merge( $filtered_params, $args );
             }
         }
 
-        if ($base_url !== '') {
-            $url = add_query_arg($args, remove_query_arg('paged', $base_url));
+        if ( $base_url !== '' ) {
+            $url = add_query_arg( $args, remove_query_arg( 'paged', $base_url ) );
         } else {
-            $url = add_query_arg($args);
+            $url = add_query_arg( $args );
         }
-        $url = remove_query_arg('paged', $url);
+        $url = remove_query_arg( 'paged', $url );
 
-        if (!empty($table_id)) {
+        if ( ! empty( $table_id ) ) {
             $url .= '#' . $table_id;
         }
 
         $indicator = '';
-        $is_active = ($current_orderby === $sort_key || $current_orderby === $col);
-        if (!$is_active && isset($col_info['sort']['aliases']) && is_array($col_info['sort']['aliases'])) {
-            foreach ($col_info['sort']['aliases'] as $alias) {
-                if ($current_orderby === sanitize_key($alias)) {
+        $is_active = ( $current_orderby === $sort_key || $current_orderby === $col );
+        if ( ! $is_active && isset( $col_info['sort']['aliases'] ) && is_array( $col_info['sort']['aliases'] ) ) {
+            foreach ( $col_info['sort']['aliases'] as $alias ) {
+                if ( $current_orderby === sanitize_key( $alias ) ) {
                     $is_active = true;
                     break;
                 }
             }
         }
 
-        if ($is_active) {
+        if ( $is_active ) {
             $indicator = $current_order === 'ASC'
-                ? esc_html__(' ▲', 'notation-jlg')
-                : esc_html__(' ▼', 'notation-jlg');
+                ? esc_html__( ' ▲', 'notation-jlg' )
+                : esc_html__( ' ▼', 'notation-jlg' );
         }
 
         $class = 'sortable';
-        if ($is_active) {
-            $class .= ' sorted ' . strtolower($current_order);
+        if ( $is_active ) {
+            $class .= ' sorted ' . strtolower( $current_order );
         }
 
-        echo '<th class="' . esc_attr($class) . '">';
-        echo '<a href="' . esc_url($url) . '">' . esc_html($col_info['label']) . $indicator . '</a>';
+        echo '<th class="' . esc_attr( $class ) . '">';
+        echo '<a href="' . esc_url( $url ) . '">' . esc_html( $col_info['label'] ) . $indicator . '</a>';
         echo '</th>';
     }
 }
 
-if (!function_exists('jlg_render_genre_badges')) {
-    function jlg_render_genre_badges($terms) {
-        if (empty($terms) || is_wp_error($terms)) {
+if ( ! function_exists( 'jlg_render_genre_badges' ) ) {
+    function jlg_render_genre_badges( $terms ) {
+        if ( empty( $terms ) || is_wp_error( $terms ) ) {
             return '';
         }
 
-        $badges = [];
+        $badges = array();
 
-        foreach ($terms as $term) {
-            if (!($term instanceof WP_Term)) {
+        foreach ( $terms as $term ) {
+            if ( ! ( $term instanceof WP_Term ) ) {
                 continue;
             }
 
-            $badges[] = '<span class="jlg-genre-badge">' . esc_html($term->name) . '</span>';
+            $badges[] = '<span class="jlg-genre-badge">' . esc_html( $term->name ) . '</span>';
         }
 
-        if (empty($badges)) {
+        if ( empty( $badges ) ) {
             return '';
         }
 
-        return '<div class="jlg-genre-badges">' . implode('', $badges) . '</div>';
+        return '<div class="jlg-genre-badges">' . implode( '', $badges ) . '</div>';
     }
 }
 
-if (!empty($active_filter_labels)) {
+if ( ! empty( $active_filter_labels ) ) {
     echo '<div class="jlg-active-filters" aria-live="polite">';
-    foreach ($active_filter_labels as $label) {
-        echo '<span class="jlg-active-filter-badge">' . esc_html($label) . '</span>';
+    foreach ( $active_filter_labels as $label ) {
+        echo '<span class="jlg-active-filter-badge">' . esc_html( $label ) . '</span>';
     }
     echo '</div>';
 }
 
-if ($layout === 'grid') :
+if ( $layout === 'grid' ) :
     ?>
     <div class="jlg-summary-grid-wrapper">
-        <?php if ($query instanceof WP_Query && $query->have_posts()) :
-            while ($query->have_posts()) : $query->the_post();
-                $post_id = get_the_ID();
-                $game_title = JLG_Helpers::get_game_title($post_id);
-                $score_data = JLG_Helpers::get_resolved_average_score($post_id);
-                $cover_url = get_post_meta($post_id, '_jlg_cover_image_url', true);
-                if (empty($cover_url)) {
-                    $cover_url = get_the_post_thumbnail_url($post_id, 'medium_large');
+        <?php
+        if ( $query instanceof WP_Query && $query->have_posts() ) :
+            while ( $query->have_posts() ) :
+				$query->the_post();
+                $post_id    = get_the_ID();
+                $game_title = JLG_Helpers::get_game_title( $post_id );
+                $score_data = JLG_Helpers::get_resolved_average_score( $post_id );
+                $cover_url  = get_post_meta( $post_id, '_jlg_cover_image_url', true );
+                if ( empty( $cover_url ) ) {
+                    $cover_url = get_the_post_thumbnail_url( $post_id, 'medium_large' );
                 }
                 /* translators: Abbreviation meaning that the average score is not available. */
                 $score_display = $score_data['formatted'] ?? '';
-                if ($score_display === '') {
-                    $score_display = __('N/A', 'notation-jlg');
+                if ( $score_display === '' ) {
+                    $score_display = __( 'N/A', 'notation-jlg' );
                 }
-                $genre_terms = $has_genre_taxonomy ? get_the_terms($post_id, $genre_taxonomy) : [];
-                $genre_badges_html = jlg_render_genre_badges($genre_terms);
+                $genre_terms       = $has_genre_taxonomy ? get_the_terms( $post_id, $genre_taxonomy ) : array();
+                $genre_badges_html = jlg_render_genre_badges( $genre_terms );
                 ?>
                 <a href="<?php the_permalink(); ?>" class="jlg-game-card">
-                    <div class="jlg-game-card-score"><?php echo esc_html($score_display); ?></div>
-                    <?php if ($cover_url) : ?>
-                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php echo esc_attr($game_title); ?>" loading="lazy">
+                    <div class="jlg-game-card-score"><?php echo esc_html( $score_display ); ?></div>
+                    <?php if ( $cover_url ) : ?>
+                        <img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $game_title ); ?>" loading="lazy">
                     <?php endif; ?>
                     <div class="jlg-game-card-title">
-                        <span><?php echo esc_html($game_title); ?></span>
+                        <span><?php echo esc_html( $game_title ); ?></span>
                     </div>
-                    <?php if ($genre_badges_html !== '') : ?>
-                        <?php echo wp_kses_post($genre_badges_html); ?>
+                    <?php if ( $genre_badges_html !== '' ) : ?>
+                        <?php echo wp_kses_post( $genre_badges_html ); ?>
                     <?php endif; ?>
                 </a>
-            <?php endwhile;
+				<?php
+            endwhile;
         else :
-            echo wp_kses_post($empty_message);
-        endif; ?>
+            echo wp_kses_post( $empty_message );
+        endif;
+        ?>
     </div>
-<?php
+	<?php
 else :
     ?>
     <div class="jlg-summary-table-wrapper">
@@ -244,128 +251,131 @@ else :
             <thead>
                 <tr>
                     <?php
-                    $header_extra_params = [
+                    $header_extra_params = array(
                         'cat_filter'    => $current_cat_filter,
                         'letter_filter' => $current_letter_filter,
                         'genre_filter'  => $current_genre_filter,
                         'base_url'      => $base_url,
-                    ];
+                    );
                     ?>
                     <?php
-                    foreach ($columns as $col) {
-                        if (!isset($available_columns[$col])) {
+                    foreach ( $columns as $col ) {
+                        if ( ! isset( $available_columns[ $col ] ) ) {
                             continue;
                         }
-                        jlg_print_sortable_header($col, $available_columns[$col], $current_orderby, $current_order, $table_id, $header_extra_params);
+                        jlg_print_sortable_header( $col, $available_columns[ $col ], $current_orderby, $current_order, $table_id, $header_extra_params );
                     }
                     ?>
                 </tr>
             </thead>
             <tbody>
-                <?php if ($query instanceof WP_Query && $query->have_posts()) :
-                    while ($query->have_posts()) : $query->the_post();
-                        $post_id = get_the_ID();
-                        $genre_terms = $has_genre_taxonomy ? get_the_terms($post_id, $genre_taxonomy) : [];
-                        $genre_badges_html = jlg_render_genre_badges($genre_terms);
+                <?php
+                if ( $query instanceof WP_Query && $query->have_posts() ) :
+                    while ( $query->have_posts() ) :
+						$query->the_post();
+                        $post_id           = get_the_ID();
+                        $genre_terms       = $has_genre_taxonomy ? get_the_terms( $post_id, $genre_taxonomy ) : array();
+                        $genre_badges_html = jlg_render_genre_badges( $genre_terms );
                         ?>
                         <tr>
                             <?php
-                            foreach ($columns as $col) {
-                                if (!isset($available_columns[$col])) {
+                            foreach ( $columns as $col ) {
+                                if ( ! isset( $available_columns[ $col ] ) ) {
                                     continue;
                                 }
-                                echo '<td data-label="' . esc_attr($available_columns[$col]['label']) . '">';
+                                echo '<td data-label="' . esc_attr( $available_columns[ $col ]['label'] ) . '">';
 
-                                switch ($col) {
+                                switch ( $col ) {
                                     case 'titre':
-                                        $game_title = JLG_Helpers::get_game_title($post_id);
-                                        echo '<a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a>';
-                                        if ($genre_badges_html !== '') {
-                                            echo wp_kses_post($genre_badges_html);
+                                        $game_title = JLG_Helpers::get_game_title( $post_id );
+                                        echo '<a href="' . esc_url( get_permalink() ) . '">' . esc_html( $game_title ) . '</a>';
+                                        if ( $genre_badges_html !== '' ) {
+                                            echo wp_kses_post( $genre_badges_html );
                                         }
                                         break;
                                     case 'date':
-                                        echo esc_html(get_the_date());
+                                        echo esc_html( get_the_date() );
                                         break;
                                     case 'note':
-                                        $score_data = JLG_Helpers::get_resolved_average_score($post_id);
+                                        $score_data = JLG_Helpers::get_resolved_average_score( $post_id );
                                         /* translators: Abbreviation meaning that the average score is not available. */
                                         $score_display = $score_data['formatted'] ?? '';
-                                        if ($score_display === '') {
-                                            $score_display = __('N/A', 'notation-jlg');
+                                        if ( $score_display === '' ) {
+                                            $score_display = __( 'N/A', 'notation-jlg' );
                                         }
-                                        echo '<strong>' . esc_html($score_display) . '</strong> ';
+                                        echo '<strong>' . esc_html( $score_display ) . '</strong> ';
                                         printf(
                                             /* translators: %s: Maximum possible rating value. */
-                                            esc_html__('/ %s', 'notation-jlg'),
+                                            esc_html__( '/ %s', 'notation-jlg' ),
                                             10
                                         );
                                         break;
                                     case 'developpeur':
-                                        $developer = get_post_meta($post_id, '_jlg_developpeur', true) ?: __('-', 'notation-jlg');
-                                        echo esc_html($developer);
+                                        $developer = get_post_meta( $post_id, '_jlg_developpeur', true ) ?: __( '-', 'notation-jlg' );
+                                        echo esc_html( $developer );
                                         break;
                                     case 'editeur':
-                                        $publisher = get_post_meta($post_id, '_jlg_editeur', true) ?: __('-', 'notation-jlg');
-                                        echo esc_html($publisher);
+                                        $publisher = get_post_meta( $post_id, '_jlg_editeur', true ) ?: __( '-', 'notation-jlg' );
+                                        echo esc_html( $publisher );
                                         break;
                                 }
                                 echo '</td>';
                             }
                             ?>
                         </tr>
-                    <?php endwhile;
+						<?php
+                    endwhile;
                 else :
                     ?>
                     <tr>
-                        <td colspan="<?php echo esc_attr($columns_count); ?>"><?php echo wp_kses_post($empty_message); ?></td>
+                        <td colspan="<?php echo esc_attr( $columns_count ); ?>"><?php echo wp_kses_post( $empty_message ); ?></td>
                     </tr>
                 <?php endif; ?>
             </tbody>
         </table>
     </div>
-<?php
+	<?php
 endif;
 
-if ($query instanceof WP_Query) {
-    $total_pages = intval($query->max_num_pages);
+if ( $query instanceof WP_Query ) {
+    $total_pages = intval( $query->max_num_pages );
 } else {
     $total_pages = 0;
 }
 
-if ($query instanceof WP_Query) {
+if ( $query instanceof WP_Query ) {
     wp_reset_postdata();
 }
 
-if ($total_pages > 1) {
-    $pagination_args = [
-        'base'      => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
+if ( $total_pages > 1 ) {
+    $pagination_args = array(
+        'base'      => str_replace( 999999999, '%#%', esc_url( get_pagenum_link( 999999999 ) ) ),
         'format'    => '?paged=%#%',
-        'current'   => max(1, intval($paged)),
+        'current'   => max( 1, intval( $paged ) ),
         'total'     => $total_pages,
-        'prev_text' => __('« Précédent', 'notation-jlg'),
-        'next_text' => __('Suivant »', 'notation-jlg'),
-        'add_args'  => [
+        'prev_text' => __( '« Précédent', 'notation-jlg' ),
+        'next_text' => __( 'Suivant »', 'notation-jlg' ),
+        'add_args'  => array(
             'orderby' => $current_orderby,
             'order'   => $current_order,
-        ],
-    ];
+        ),
+    );
 
-    if ($current_cat_filter > 0) {
+    if ( $current_cat_filter > 0 ) {
         $pagination_args['add_args']['cat_filter'] = $current_cat_filter;
     }
 
-    if ($current_letter_filter !== '') {
+    if ( $current_letter_filter !== '' ) {
         $pagination_args['add_args']['letter_filter'] = $current_letter_filter;
     }
 
-    if ($current_genre_filter !== '') {
+    if ( $current_genre_filter !== '' ) {
         $pagination_args['add_args']['genre_filter'] = $current_genre_filter;
     }
 
-    $pagination_links = paginate_links($pagination_args);
+    $pagination_links = paginate_links( $pagination_args );
 
-    if (!empty($pagination_links) && !empty($table_id)) {
+    if ( ! empty( $pagination_links ) && ! empty( $table_id ) ) {
         $pagination_links = preg_replace(
             '/href="([^"]+)"/i',
             'href="$1#' . $table_id . '"',
@@ -373,7 +383,7 @@ if ($total_pages > 1) {
         );
     }
 
-    if (!empty($pagination_links)) {
+    if ( ! empty( $pagination_links ) ) {
         echo '<nav class="jlg-pagination">' . $pagination_links . '</nav>';
     }
 }

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -1,23 +1,25 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 echo $widget_args['before_widget'];
 
-if (!empty($title)) {
-    echo $widget_args['before_title'] . esc_html($title) . $widget_args['after_title'];
+if ( ! empty( $title ) ) {
+    echo $widget_args['before_title'] . esc_html( $title ) . $widget_args['after_title'];
 }
 
-if ($latest_reviews->have_posts()) {
+if ( $latest_reviews->have_posts() ) {
     echo '<ul>';
-    while ($latest_reviews->have_posts()) {
+    while ( $latest_reviews->have_posts() ) {
         $latest_reviews->the_post();
-        $post_id = get_the_ID();
-        $game_title = JLG_Helpers::get_game_title($post_id);
-        echo '<li><a href="' . esc_url(get_permalink()) . '">' . esc_html($game_title) . '</a></li>';
+        $post_id    = get_the_ID();
+        $game_title = JLG_Helpers::get_game_title( $post_id );
+        echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( $game_title ) . '</a></li>';
     }
     echo '</ul>';
 } else {
-    echo '<p>' . esc_html__('Aucun test trouvé.', 'notation-jlg') . '</p>';
+    echo '<p>' . esc_html__( 'Aucun test trouvé.', 'notation-jlg' ) . '</p>';
 }
 wp_reset_postdata();
 

--- a/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
+++ b/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
@@ -1,23 +1,29 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 // Variables disponibles : $post_id
 $post_id = $post_id ?? get_the_ID();
-if (!$post_id) return;
+if ( ! $post_id ) {
+	return;
+}
 
-$average_score = JLG_Helpers::get_average_score_for_post($post_id);
-if ($average_score === null) return;
+$average_score = JLG_Helpers::get_average_score_for_post( $post_id );
+if ( $average_score === null ) {
+	return;
+}
 
-$options = JLG_Helpers::get_plugin_options();
-$score_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
+$options     = JLG_Helpers::get_plugin_options();
+$score_color = JLG_Helpers::calculate_color_from_note( $average_score, $options );
 ?>
 
 <div class="jlg-thumbnail-score" style="
-    background-color: <?php echo esc_attr($score_color); ?>;
-    color: <?php echo esc_attr($options['thumb_text_color'] ?? '#ffffff'); ?>;
-    font-size: <?php echo max(0, absint($options['thumb_font_size'] ?? 14)); ?>px;
-    padding: <?php echo max(0, absint($options['thumb_padding'] ?? 8)); ?>px;
-    border-radius: <?php echo max(0, absint($options['thumb_border_radius'] ?? 4)); ?>px;
+    background-color: <?php echo esc_attr( $score_color ); ?>;
+    color: <?php echo esc_attr( $options['thumb_text_color'] ?? '#ffffff' ); ?>;
+    font-size: <?php echo max( 0, absint( $options['thumb_font_size'] ?? 14 ) ); ?>px;
+    padding: <?php echo max( 0, absint( $options['thumb_padding'] ?? 8 ) ); ?>px;
+    border-radius: <?php echo max( 0, absint( $options['thumb_border_radius'] ?? 4 ) ); ?>px;
     font-weight: bold;
     line-height: 1;
     display: inline-block;
@@ -27,12 +33,12 @@ $score_color = JLG_Helpers::calculate_color_from_note($average_score, $options);
     position: relative;
     z-index: 10;
 ">
-    <?php echo esc_html(number_format_i18n($average_score, 1)); ?>
+    <?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?>
     <span style="font-size: 0.8em; opacity: 0.9;">
         <?php
         printf(
             /* translators: %s: Maximum rating value displayed with the thumbnail score. */
-            esc_html__('/%s', 'notation-jlg'),
+            esc_html__( '/%s', 'notation-jlg' ),
             10
         );
         ?>

--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -1,58 +1,70 @@
 <?php
 /**
  * Désinstallation du plugin Notation JLG
- * 
+ *
  * Ce fichier est exécuté lors de la suppression du plugin
  * pour nettoyer la base de données si l'utilisateur le souhaite.
  */
 
 // Sécurité : vérifier que c'est WordPress qui appelle ce fichier
-if (!defined('WP_UNINSTALL_PLUGIN')) {
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit;
 }
 
-if (function_exists('wp_clear_scheduled_hook')) {
-    wp_clear_scheduled_hook('jlg_process_v5_migration');
+if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+    wp_clear_scheduled_hook( 'jlg_process_v5_migration' );
 }
 
-delete_option('jlg_migration_v5_queue');
-delete_option('jlg_migration_v5_scan_state');
-delete_option('jlg_migration_v5_completed');
+delete_option( 'jlg_migration_v5_queue' );
+delete_option( 'jlg_migration_v5_scan_state' );
+delete_option( 'jlg_migration_v5_completed' );
 
 // Option pour vérifier si l'utilisateur veut supprimer les données
-$delete_data = get_option('jlg_notation_delete_data_on_uninstall', false);
+$delete_data = get_option( 'jlg_notation_delete_data_on_uninstall', false );
 
-if ($delete_data) {
+if ( $delete_data ) {
     global $wpdb;
-    
+
     // Supprimer les options du plugin
-    delete_option('notation_jlg_settings');
-    delete_option('jlg_notation_version');
-    delete_option('jlg_migration_v5_completed');
-    delete_option('jlg_migration_v5_scan_state');
-    delete_option('jlg_platforms_list');
-    delete_option('jlg_notation_delete_data_on_uninstall');
-    
+    delete_option( 'notation_jlg_settings' );
+    delete_option( 'jlg_notation_version' );
+    delete_option( 'jlg_migration_v5_completed' );
+    delete_option( 'jlg_migration_v5_scan_state' );
+    delete_option( 'jlg_platforms_list' );
+    delete_option( 'jlg_notation_delete_data_on_uninstall' );
+
     // Supprimer toutes les métadonnées des posts
-    $meta_keys = [
-        '_note_cat1', '_note_cat2', '_note_cat3', 
-        '_note_cat4', '_note_cat5', '_note_cat6',
+    $meta_keys = array(
+        '_note_cat1',
+		'_note_cat2',
+		'_note_cat3',
+        '_note_cat4',
+		'_note_cat5',
+		'_note_cat6',
         '_jlg_average_score',
-        '_jlg_tagline_fr', '_jlg_tagline_en',
-        '_jlg_points_forts', '_jlg_points_faibles',
-        '_jlg_developpeur', '_jlg_editeur',
-        '_jlg_date_sortie', '_jlg_plateformes',
-        '_jlg_cover_image_url', '_jlg_version',
-        '_jlg_pegi', '_jlg_temps_de_jeu',
-        '_jlg_user_ratings', '_jlg_user_rating_avg',
-        '_jlg_user_rating_count', '_jlg_user_rating_ips'
-    ];
-    
-    foreach ($meta_keys as $meta_key) {
-        $wpdb->delete($wpdb->postmeta, ['meta_key' => $meta_key]);
+        '_jlg_tagline_fr',
+		'_jlg_tagline_en',
+        '_jlg_points_forts',
+		'_jlg_points_faibles',
+        '_jlg_developpeur',
+		'_jlg_editeur',
+        '_jlg_date_sortie',
+		'_jlg_plateformes',
+        '_jlg_cover_image_url',
+		'_jlg_version',
+        '_jlg_pegi',
+		'_jlg_temps_de_jeu',
+        '_jlg_user_ratings',
+		'_jlg_user_rating_avg',
+        '_jlg_user_rating_count',
+		'_jlg_user_rating_ips',
+    );
+
+    foreach ( $meta_keys as $meta_key ) {
+        $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $meta_key ) );
     }
-    
+
     // Nettoyer les transients éventuels
-    $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_jlg_%'");
-    $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_jlg_%'");
+    $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_jlg_%'" );
+    $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_jlg_%'" );
 }


### PR DESCRIPTION
## Summary
- add a project phpcs.xml.dist configuring the WordPress-Extra standard with project-specific exclusions
- update development dependencies to WordPress Coding Standards 3.2
- run phpcbf to align all plugin PHP files with the configured coding standard and add inline ignores where needed
- document the new composer cs workflow in the contributor README

## Testing
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68dc34cc960c832ea25eb35092e26a03