### PR TITLE
Fix duplicate closing tags in flag SVGs

### DIFF
--- a/plugin-notation-jeux_V4/assets/flags/fr.svg
+++ b/plugin-notation-jeux_V4/assets/flags/fr.svg
@@ -3,4 +3,3 @@
   <rect width="1" height="2" x="1" fill="#FFFFFF"/>
   <rect width="1" height="2" x="2" fill="#EF4135"/>
 </svg>
-</svg>

--- a/plugin-notation-jeux_V4/assets/flags/gb.svg
+++ b/plugin-notation-jeux_V4/assets/flags/gb.svg
@@ -8,4 +8,3 @@
   <path d="M30,0 v30 M0,15 h60" stroke="#FFFFFF" stroke-width="10"/>
   <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/>
 </svg>
-</svg>


### PR DESCRIPTION
## Summary
- remove the redundant closing </svg> tag from the French flag asset
- remove the redundant closing </svg> tag from the UK flag asset so each file ends cleanly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4f759394832e8fafc47969bf96ca