### PR TITLE
Add platform tag association management

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
@@ -119,10 +119,12 @@ if (have_posts()) : while (have_posts()) : the_post(); ?&gt;
     <ul style="margin-left:20px;">
         <li>Ajoutez vos propres plateformes depuis l'onglet "Plateformes"</li>
         <li>Réorganisez l'ordre d'affichage par glisser-déposer</li>
+        <li>Associez des tags WordPress à chaque plateforme pour créer des passerelles éditoriales</li>
         <li>Les plateformes personnalisées apparaissent automatiquement dans les metaboxes</li>
         <li>Supprimez les plateformes obsolètes en un clic</li>
         <li>Compatibilité totale avec le shortcode [jlg_fiche_technique]</li>
     </ul>
+    <p style="margin-top:10px;">Une nouvelle section "Tags liés" est disponible sur la page d'administration pour connecter vos plateformes aux bons contenus.</p>
     <p style="margin-top:15px;">
         <a href="<?php echo esc_url($platforms_url); ?>" class="button button-primary">Gérer les plateformes →</a>
     </p>


### PR DESCRIPTION
## Summary
- add persistent option and admin workflow to manage tag associations per platform, including nonce/capability validation
- surface linked tags in the platform table, provide a multi-select form to update mappings, and clear mappings on reset
- expose a helper to retrieve platform tags and document the new admin section for editors

## Testing
- php -l plugin-notation-jeux_V4/includes/admin/class-jlg-admin-platforms.php
- php -l plugin-notation-jeux_V4/includes/class-jlg-helpers.php
- php -l plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php

------
https://chatgpt.com/codex/tasks/task_e_68dc567241e8832ebc3be1c76e0f00bb