### PR TITLE
Allow admin metaboxes on helper-defined post types

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-metaboxes.php
@@ -12,6 +12,28 @@ class JLG_Admin_Metaboxes {
         add_action( 'admin_notices', array( $this, 'display_validation_errors' ) );
     }
 
+    private function get_allowed_post_types() {
+        if ( class_exists( 'JLG_Helpers' ) && method_exists( 'JLG_Helpers', 'get_allowed_post_types' ) ) {
+            $post_types = JLG_Helpers::get_allowed_post_types();
+
+            if ( is_array( $post_types ) ) {
+                $post_types = array_values(
+                    array_unique(
+                        array_filter(
+                            array_map( 'sanitize_key', $post_types )
+                        )
+                    )
+                );
+
+                if ( ! empty( $post_types ) ) {
+                    return $post_types;
+                }
+            }
+        }
+
+        return array( 'post' );
+    }
+
     private function get_error_transient_key() {
         if ( $this->error_transient_key === '' ) {
             $user_id                   = get_current_user_id();
@@ -39,7 +61,9 @@ class JLG_Admin_Metaboxes {
 
     public function register_metaboxes( $post_type, $post = null ) {
         // Vérifier qu'on est bien sur un post
-        if ( $post_type !== 'post' ) {
+        $allowed_post_types = $this->get_allowed_post_types();
+
+        if ( ! in_array( $post_type, $allowed_post_types, true ) ) {
             return;
         }
 
@@ -64,7 +88,13 @@ class JLG_Admin_Metaboxes {
 
     public function render_notation_metabox( $post ) {
         // Vérification de sécurité
-        if ( ! $post || $post->post_type !== 'post' ) {
+        if ( ! $post ) {
+            return;
+        }
+
+        $allowed_post_types = $this->get_allowed_post_types();
+
+        if ( ! in_array( $post->post_type, $allowed_post_types, true ) ) {
             return;
         }
 
@@ -115,7 +145,13 @@ class JLG_Admin_Metaboxes {
 
     public function render_details_metabox( $post ) {
         // Vérification de sécurité
-        if ( ! $post || $post->post_type !== 'post' ) {
+        if ( ! $post ) {
+            return;
+        }
+
+        $allowed_post_types = $this->get_allowed_post_types();
+
+        if ( ! in_array( $post->post_type, $allowed_post_types, true ) ) {
             return;
         }
 
@@ -240,7 +276,10 @@ class JLG_Admin_Metaboxes {
         }
 
         // Vérifier le type de post
-        if ( get_post_type( $post_id ) !== 'post' ) {
+        $allowed_post_types = $this->get_allowed_post_types();
+        $post_type          = get_post_type( $post_id );
+
+        if ( ! in_array( $post_type, $allowed_post_types, true ) ) {
             return;
         }
 

--- a/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/admin/class-jlg-admin-metaboxes.php';
+
+class AdminMetaboxesAllowedPostTypesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_filters'] = [];
+        $GLOBALS['jlg_test_meta_boxes'] = [];
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_meta_updates'] = [];
+        $GLOBALS['jlg_test_transients'] = [];
+        $_POST = [];
+
+        JLG_Helpers::flush_plugin_options_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['jlg_test_filters'],
+            $GLOBALS['jlg_test_meta_boxes'],
+            $GLOBALS['jlg_test_posts'],
+            $GLOBALS['jlg_test_meta'],
+            $GLOBALS['jlg_test_meta_updates'],
+            $GLOBALS['jlg_test_transients']
+        );
+        $_POST = [];
+
+        JLG_Helpers::flush_plugin_options_cache();
+
+        parent::tearDown();
+    }
+
+    public function test_register_metaboxes_respects_allowed_post_types(): void
+    {
+        add_filter('jlg_rated_post_types', static function ($types) {
+            $types[] = 'jlg_review';
+
+            return $types;
+        });
+
+        $post_id = 123;
+        $post = new WP_Post([
+            'ID'        => $post_id,
+            'post_type' => 'jlg_review',
+        ]);
+
+        $metaboxes = new JLG_Admin_Metaboxes();
+        $metaboxes->register_metaboxes('jlg_review', $post);
+
+        $this->assertCount(2, $GLOBALS['jlg_test_meta_boxes']);
+        $this->assertSame('notation_jlg_metabox', $GLOBALS['jlg_test_meta_boxes'][0]['id']);
+        $this->assertSame('jlg_review', $GLOBALS['jlg_test_meta_boxes'][0]['screen']);
+        $this->assertSame('jlg_review', $GLOBALS['jlg_test_meta_boxes'][1]['screen']);
+    }
+
+    public function test_save_meta_data_persists_notes_and_details_for_allowed_types(): void
+    {
+        add_filter('jlg_rated_post_types', static function ($types) {
+            $types[] = 'jlg_review';
+
+            return $types;
+        });
+
+        $post_id = 456;
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'        => $post_id,
+            'post_type' => 'jlg_review',
+        ]);
+        $GLOBALS['jlg_test_meta'][$post_id] = [];
+
+        $_POST = [
+            'jlg_notation_nonce' => 'nonce',
+            '_note_cat1'         => '9.5',
+            '_note_cat2'         => '8.0',
+            'jlg_details_nonce'  => 'nonce',
+            'jlg_game_title'     => 'Custom Review Game',
+            'jlg_developpeur'    => 'Studio Test',
+            'jlg_editeur'        => 'Publisher Test',
+            'jlg_date_sortie'    => '2024-05-01',
+            'jlg_version'        => '1.0',
+            'jlg_pegi'           => 'PEGI 16',
+            'jlg_temps_de_jeu'   => '20h',
+            'jlg_cover_image_url'=> 'https://example.com/cover.jpg',
+            'jlg_tagline_fr'     => 'Un jeu exceptionnel',
+            'jlg_tagline_en'     => 'An exceptional game',
+            'jlg_points_forts'   => "Gameplay solide\nUnivers riche",
+            'jlg_points_faibles' => "Quelques bugs\nMenus confus",
+            'jlg_plateformes'    => ['PC', 'Xbox One'],
+        ];
+
+        $metaboxes = new JLG_Admin_Metaboxes();
+        $metaboxes->save_meta_data($post_id);
+
+        $saved_meta = $GLOBALS['jlg_test_meta'][$post_id];
+
+        $this->assertSame(9.5, $saved_meta['_note_cat1']);
+        $this->assertSame(8.0, $saved_meta['_note_cat2']);
+        $this->assertSame('Custom Review Game', $saved_meta['_jlg_game_title']);
+        $this->assertSame('Studio Test', $saved_meta['_jlg_developpeur']);
+        $this->assertSame('Publisher Test', $saved_meta['_jlg_editeur']);
+        $this->assertSame('2024-05-01', $saved_meta['_jlg_date_sortie']);
+        $this->assertSame('1.0', $saved_meta['_jlg_version']);
+        $this->assertSame('PEGI 16', $saved_meta['_jlg_pegi']);
+        $this->assertSame('20h', $saved_meta['_jlg_temps_de_jeu']);
+        $this->assertSame('https://example.com/cover.jpg', $saved_meta['_jlg_cover_image_url']);
+        $this->assertSame('Un jeu exceptionnel', $saved_meta['_jlg_tagline_fr']);
+        $this->assertSame('An exceptional game', $saved_meta['_jlg_tagline_en']);
+        $this->assertSame(['PC', 'Xbox One'], $saved_meta['_jlg_plateformes']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -179,6 +179,24 @@ if (!function_exists('add_action')) {
     }
 }
 
+if (!function_exists('add_meta_box')) {
+    function add_meta_box($id, $title, $callback, $screen, $context = 'advanced', $priority = 'default', $callback_args = null) {
+        if (!isset($GLOBALS['jlg_test_meta_boxes'])) {
+            $GLOBALS['jlg_test_meta_boxes'] = [];
+        }
+
+        $GLOBALS['jlg_test_meta_boxes'][] = [
+            'id'            => $id,
+            'title'         => $title,
+            'callback'      => $callback,
+            'screen'        => $screen,
+            'context'       => $context,
+            'priority'      => $priority,
+            'callback_args' => $callback_args,
+        ];
+    }
+}
+
 if (!function_exists('add_shortcode')) {
     function add_shortcode($tag, $callback) {
         // No-op stub for shortcode registration during tests.
@@ -789,6 +807,12 @@ if (!function_exists('sanitize_text_field')) {
         $filtered = filter_var($str, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 
         return is_string($filtered) ? trim($filtered) : '';
+    }
+}
+
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($str) {
+        return sanitize_text_field($str);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a helper that resolves the allowed metabox post types with a safe fallback
- gate all admin metabox entry points behind the resolved list instead of the hard-coded post type
- cover the behaviour with PHPUnit tests and add the required test doubles

## Testing
- vendor/bin/phpunit --filter AdminMetaboxesAllowedPostTypesTest

------
https://chatgpt.com/codex/tasks/task_e_68dc43ca393c832e8434270614b726be