### PR TITLE
Ensure rating bars respect configured width

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -25,7 +25,7 @@
 .review-box-jlg .rating-label { display:flex; justify-content:space-between; align-items:baseline; margin-bottom:8px; font-size:.9rem; font-weight:500; }
 .review-box-jlg .rating-label span:first-child { font-weight:600; color: var(--jlg-main-text-color); }
 .review-box-jlg .rating-bar-container { background-color: var(--jlg-bar-bg-color); border-radius:9999px; height:10px; width:100%; overflow:hidden; box-shadow:inset 0 2px 4px rgba(0,0,0,.2);}
-.review-box-jlg .rating-bar { height:100%; border-radius:9999px; transition:width .6s cubic-bezier(.25,1,.5,1), background-color .3s ease; background-color: var(--bar-color, var(--jlg-score-gradient-1)); }
+.review-box-jlg .rating-bar { height:100%; border-radius:9999px; transition:width .6s cubic-bezier(.25,1,.5,1), background-color .3s ease; background-color: var(--bar-color, var(--jlg-score-gradient-1)); width:var(--rating-percent,0%); }
 .review-box-jlg .score-circle { width:150px; height:150px; border-radius:50%; display:flex; flex-direction:column; justify-content:center; align-items:center; }
 .review-box-jlg .score-circle .score-value { font-size:3.5rem; background: var(--jlg-main-text-color); -webkit-background-clip:text; background-clip:text; text-shadow:none !important; -webkit-text-fill-color:transparent; color: var(--jlg-main-text-color); }
 .review-box-jlg .score-circle .score-label { font-size:0.8rem; color: var(--jlg-secondary-text-color); }


### PR DESCRIPTION
## Summary
- set the rating bar base width to use the configured percentage so bars render correctly even without animations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0f073450832e80062110a78ecc3e