### PR TITLE
Improve accessibility announcements for game explorer results

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -195,7 +195,13 @@ $availability_active     = isset( $current_filters['availability'] ) ? $current_
         </div>
     <?php endif; ?>
 
-    <div class="jlg-ge-results" data-role="results">
+    <div
+        class="jlg-ge-results"
+        data-role="results"
+        role="status"
+        aria-live="polite"
+        aria-busy="false"
+    >
         <?php
         echo JLG_Frontend::get_template_html(
             'game-explorer-fragment',


### PR DESCRIPTION
## Summary
- add live region attributes to the game explorer results container to surface updates to assistive tech
- toggle aria-busy during AJAX refreshes and focus the updated results to improve announcements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0f0c7f64832ebd03778d86bf272a