### PR TITLE
Improve accessibility of user rating widget

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -93,9 +93,10 @@
 .jlg-user-rating-block{max-width:650px;margin:32px auto;text-align:center;color:var(--jlg-user-rating-text-color);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-user-rating-block.is-loading{opacity:.6;cursor:wait;pointer-events:none;}
 .jlg-user-rating-title{font-size:1.2rem;font-weight:600;color:var(--jlg-main-text-color);margin-bottom:12px;}
-.jlg-user-rating-stars{display:inline-flex;gap:5px;cursor:pointer;margin-bottom:12px;}
-.jlg-user-rating-block.has-voted .jlg-user-rating-stars{cursor:default;}
-.jlg-user-star{font-size:28px;color:#52525b;transition:color .2s,transform .2s;}
+.jlg-user-rating-stars{display:inline-flex;gap:5px;margin-bottom:12px;}
+.jlg-user-star{font-size:28px;color:#52525b;transition:color .2s,transform .2s;background:none;border:0;padding:0;line-height:1;display:inline-flex;align-items:center;justify-content:center;}
+.jlg-user-star:focus{outline:none;}
+.jlg-user-star:focus-visible{outline:2px solid var(--jlg-user-rating-star-color);outline-offset:4px;border-radius:4px;}
 .jlg-user-rating-block.has-voted .jlg-user-star:hover,
 .jlg-user-rating-block.has-voted .jlg-user-star.hover{color:#52525b;transform:none;}
 .jlg-user-star:hover,

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -11,14 +11,19 @@ if ( $has_voted ) {
 ?>
 ">
     <div class="jlg-user-rating-title"><?php esc_html_e( 'Votre avis nous intéresse !', 'notation-jlg' ); ?></div>
-    <div class="jlg-user-rating-stars" data-post-id="<?php echo esc_attr( $post_id ); ?>">
-        <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-            <span class="jlg-user-star 
-            <?php
-            if ( $has_voted && $i <= $user_vote ) {
-				echo esc_attr( 'selected' );}
-			?>
-            " data-value="<?php echo esc_attr( $i ); ?>">★</span>
+    <div class="jlg-user-rating-stars" role="radiogroup" aria-label="<?php esc_attr_e( 'Sélectionnez une note', 'notation-jlg' ); ?>" data-post-id="<?php echo esc_attr( $post_id ); ?>">
+        <?php for ( $i = 1; $i <= 5; $i++ ) :
+            $is_selected     = ( $has_voted && $i <= $user_vote );
+            $is_aria_checked = ( $has_voted && $i === $user_vote );
+            ?>
+            <button
+                type="button"
+                role="radio"
+                class="jlg-user-star<?php echo $is_selected ? esc_attr( ' selected' ) : ''; ?>"
+                data-value="<?php echo esc_attr( $i ); ?>"
+                aria-checked="<?php echo $is_aria_checked ? 'true' : 'false'; ?>"
+                aria-label="<?php echo esc_attr( sprintf( __( 'Donner %1$s sur 5', 'notation-jlg' ), number_format_i18n( $i ) ) ); ?>"
+            >★</button>
         <?php endfor; ?>
     </div>
     <div class="jlg-user-rating-summary">
@@ -46,7 +51,7 @@ if ( $has_voted ) {
         );
         ?>
     </div>
-    <div class="jlg-rating-message">
+    <div class="jlg-rating-message" aria-live="polite">
     <?php
     if ( $has_voted ) {
 		esc_html_e( 'Merci pour votre vote !', 'notation-jlg' );}


### PR DESCRIPTION
## Summary
- replace static star spans with radiogroup buttons and announce rating messages via aria-live
- enhance keyboard interactions and focus management for the rating AJAX workflow
- adjust frontend styles to support focus-visible outlines on the new buttons

## Testing
- php -l plugin-notation-jeux_V4/templates/shortcode-user-rating.php

------
https://chatgpt.com/codex/tasks/task_e_68dd0f12c6f0832ebc3b62cae5c58f09