### PR TITLE
Improve accessibility of user rating widget

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -93,9 +93,11 @@
 .jlg-user-rating-block{max-width:650px;margin:32px auto;text-align:center;color:var(--jlg-user-rating-text-color);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-user-rating-block.is-loading{opacity:.6;cursor:wait;pointer-events:none;}
 .jlg-user-rating-title{font-size:1.2rem;font-weight:600;color:var(--jlg-main-text-color);margin-bottom:12px;}
-.jlg-user-rating-stars{display:inline-flex;gap:5px;cursor:pointer;margin-bottom:12px;}
-.jlg-user-rating-block.has-voted .jlg-user-rating-stars{cursor:default;}
-.jlg-user-star{font-size:28px;color:#52525b;transition:color .2s,transform .2s;}
+.jlg-user-rating-stars{display:inline-flex;gap:5px;margin-bottom:12px;}
+.jlg-user-star{font-size:28px;color:#52525b;transition:color .2s,transform .2s;background:0 0;border:0;padding:4px;line-height:1;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;border-radius:50%;appearance:none;-webkit-appearance:none;background-color:transparent;}
+.jlg-user-star:focus{outline:none;}
+.jlg-user-star:focus-visible{outline:2px solid var(--jlg-user-rating-star-color);outline-offset:3px;}
+.jlg-user-rating-block.has-voted .jlg-user-star{cursor:default;}
 .jlg-user-rating-block.has-voted .jlg-user-star:hover,
 .jlg-user-rating-block.has-voted .jlg-user-star.hover{color:#52525b;transform:none;}
 .jlg-user-star:hover,

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -11,14 +11,27 @@ if ( $has_voted ) {
 ?>
 ">
     <div class="jlg-user-rating-title"><?php esc_html_e( 'Votre avis nous intéresse !', 'notation-jlg' ); ?></div>
-    <div class="jlg-user-rating-stars" data-post-id="<?php echo esc_attr( $post_id ); ?>">
-        <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-            <span class="jlg-user-star 
-            <?php
-            if ( $has_voted && $i <= $user_vote ) {
-				echo esc_attr( 'selected' );}
-			?>
-            " data-value="<?php echo esc_attr( $i ); ?>">★</span>
+    <div
+        class="jlg-user-rating-stars"
+        data-post-id="<?php echo esc_attr( $post_id ); ?>"
+        role="radiogroup"
+        aria-label="<?php echo esc_attr__( 'Choisissez une note', 'notation-jlg' ); ?>"
+    >
+        <?php for ( $i = 1; $i <= 5; $i++ ) :
+            $is_selected      = $has_voted && $i <= $user_vote;
+            $is_checked_radio = $has_voted && intval( $user_vote ) === $i;
+            ?>
+            <button
+                type="button"
+                class="jlg-user-star<?php echo $is_selected ? ' selected' : ''; ?>"
+                data-value="<?php echo esc_attr( $i ); ?>"
+                role="radio"
+                aria-checked="<?php echo $is_checked_radio ? 'true' : 'false'; ?>"
+                aria-label="<?php
+                    /* translators: 1: Selected rating value. 2: Maximum possible rating. */
+                    echo esc_attr( sprintf( __( 'Attribuer %1$s sur %2$s', 'notation-jlg' ), number_format_i18n( $i ), number_format_i18n( 5 ) ) );
+                ?>"
+            >★</button>
         <?php endfor; ?>
     </div>
     <div class="jlg-user-rating-summary">
@@ -28,7 +41,7 @@ if ( $has_voted ) {
         $votes_display   = ! empty( $count ) ? intval( $count ) : 0;
         /* translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes. */
         $summary_template = __(
-            'Note moyenne : <strong class="jlg-user-rating-avg-value">%1$s</strong> sur %2$s (<span class="jlg-user-rating-count-value">%3$s</span> votes)',
+            'Note moyenne : <strong class="jlg-user-rating-avg-value" aria-live="polite" aria-atomic="true">%1$s</strong> sur %2$s (<span class="jlg-user-rating-count-value">%3$s</span> votes)',
             'notation-jlg'
         );
 
@@ -40,16 +53,20 @@ if ( $has_voted ) {
                 esc_html( number_format_i18n( $votes_display ) )
             ),
             array(
-                'strong' => array( 'class' => array() ),
+                'strong' => array(
+                    'class'       => array(),
+                    'aria-live'   => array(),
+                    'aria-atomic' => array(),
+                ),
                 'span'   => array( 'class' => array() ),
             )
         );
         ?>
     </div>
-    <div class="jlg-rating-message">
+    <div class="jlg-rating-message" role="status" aria-live="polite" aria-atomic="true">
     <?php
     if ( $has_voted ) {
-		esc_html_e( 'Merci pour votre vote !', 'notation-jlg' );}
-	?>
+                esc_html_e( 'Merci pour votre vote !', 'notation-jlg' );}
+        ?>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- render user rating stars as a radiogroup of buttons with live feedback messaging
- enhance the rating script to manage aria-checked state updates and support keyboard activation
- update star styles to preserve the visual design while exposing clear focus outlines

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd0f09c028832e8d6bb45d8b667c06