### PR TITLE
Improve accessibility for tagline language toggles

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -118,5 +118,7 @@
 .jlg-tagline-block{background-color:var(--jlg-tagline-bg-color);color:var(--jlg-tagline-text-color);font-size:var(--jlg-tagline-font-size);padding:20px 25px;border-radius:8px;margin:32px auto;max-width:650px;text-align:center;position:relative;box-sizing:border-box;}
 .jlg-tagline-text{font-style:italic;}
 .jlg-tagline-flags{position:absolute;top:8px;right:12px;}
-.jlg-lang-flag{width:24px;height:auto;cursor:pointer;opacity:.5;transition:opacity .2s ease-in-out;margin-left:5px;}
+.jlg-lang-flag{display:inline-flex;align-items:center;justify-content:center;width:auto;height:auto;padding:0;margin-left:5px;border:0;background:transparent;opacity:.5;transition:opacity .2s ease-in-out,transform .2s ease-in-out;border-radius:4px;cursor:pointer;}
+.jlg-lang-flag img{width:24px;height:auto;display:block;pointer-events:none;}
 .jlg-lang-flag.active{opacity:1;}
+.jlg-lang-flag:focus-visible{outline:2px solid var(--jlg-tagline-text-color, currentColor);outline-offset:2px;}

--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -62,14 +62,27 @@
 }
 
 .jlg-aio-flag {
-    width: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
     height: auto;
+    padding: 0;
+    border: 0;
+    background: transparent;
     cursor: pointer;
     opacity: 0.4;
-    transition: all 0.2s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
     filter: grayscale(50%);
+    border-radius: 4px;
+}
+
+.jlg-aio-flag img {
+    width: 24px;
+    height: auto;
     display: block;
     min-height: 18px;
+    pointer-events: none;
 }
 
 .jlg-aio-flag.active {
@@ -81,6 +94,11 @@
 .jlg-aio-flag:hover {
     opacity: 0.8;
     filter: grayscale(0%);
+}
+
+.jlg-aio-flag:focus-visible {
+    outline: 2px solid var(--jlg-aio-tagline-color, #111827);
+    outline-offset: 2px;
 }
 
 .jlg-aio-rating {

--- a/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-all-in-one.js
@@ -59,25 +59,47 @@
             return;
         }
 
+        const activateFlag = (flag) => {
+            if (flag.classList.contains('active')) {
+                return;
+            }
+
+            const selectedLang = flag.dataset.lang;
+
+            flags.forEach((innerFlag) => {
+                const isActive = innerFlag === flag;
+                innerFlag.classList.toggle('active', isActive);
+                innerFlag.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+
+            taglines.forEach((tagline) => {
+                const matchesSelection = tagline.dataset.lang === selectedLang;
+
+                if (matchesSelection) {
+                    tagline.removeAttribute('hidden');
+                    tagline.setAttribute('aria-hidden', 'false');
+                    tagline.style.display = '';
+                } else {
+                    tagline.setAttribute('hidden', '');
+                    tagline.setAttribute('aria-hidden', 'true');
+                    tagline.style.display = 'none';
+                }
+            });
+        };
+
         flags.forEach((flag) => {
-            flag.addEventListener('click', () => {
-                const selectedLang = flag.dataset.lang;
+            flag.addEventListener('click', (event) => {
+                event.preventDefault();
+                activateFlag(flag);
+            });
 
-                flags.forEach((innerFlag) => {
-                    innerFlag.classList.toggle('active', innerFlag === flag);
-                });
+            flag.addEventListener('keydown', (event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') {
+                    return;
+                }
 
-                taglines.forEach((tagline) => {
-                    const matchesSelection = tagline.dataset.lang === selectedLang;
-
-                    tagline.style.display = matchesSelection ? 'block' : 'none';
-
-                    if (matchesSelection) {
-                        tagline.removeAttribute('hidden');
-                    } else {
-                        tagline.setAttribute('hidden', '');
-                    }
-                });
+                event.preventDefault();
+                activateFlag(flag);
             });
         });
     };

--- a/plugin-notation-jeux_V4/assets/js/tagline-switcher.js
+++ b/plugin-notation-jeux_V4/assets/js/tagline-switcher.js
@@ -1,16 +1,48 @@
 jQuery(document).ready(function($) {
-    $('.jlg-tagline-flags .jlg-lang-flag').on('click', function() {
-        var selectedLang = $(this).data('lang');
-        var taglineBlock = $(this).closest('.jlg-tagline-block');
+    var KEY_ENTER = 13;
+    var KEY_SPACE = 32;
 
-        if ($(this).hasClass('active')) {
+    var toggleTagline = function($trigger) {
+        var selectedLang = $trigger.data('lang');
+        var $taglineBlock = $trigger.closest('.jlg-tagline-block');
+
+        if ($trigger.hasClass('active')) {
             return;
         }
 
-        taglineBlock.find('.jlg-lang-flag').removeClass('active');
-        $(this).addClass('active');
+        var $triggers = $taglineBlock.find('.jlg-lang-flag');
+        $triggers.removeClass('active').attr('aria-pressed', 'false');
+        $trigger.addClass('active').attr('aria-pressed', 'true');
 
-        taglineBlock.find('.jlg-tagline-text').hide();
-        taglineBlock.find('.jlg-tagline-text[data-lang="' + selectedLang + '"]').fadeIn(300);
+        $taglineBlock.find('.jlg-tagline-text').each(function() {
+            var $tagline = $(this);
+            var matchesSelection = $tagline.data('lang') === selectedLang;
+
+            $tagline.stop(true, true);
+
+            if (matchesSelection) {
+                $tagline.attr('aria-hidden', 'false').removeAttr('hidden').hide().fadeIn(300);
+            } else {
+                $tagline.attr('aria-hidden', 'true').attr('hidden', 'hidden').hide();
+            }
+        });
+    };
+
+    $('.jlg-tagline-flags').each(function() {
+        var $container = $(this);
+
+        $container.on('click', '.jlg-lang-flag', function(event) {
+            event.preventDefault();
+            toggleTagline($(this));
+        });
+
+        $container.on('keydown', '.jlg-lang-flag', function(event) {
+            if (event.which !== KEY_ENTER && event.which !== KEY_SPACE) {
+                return;
+            }
+
+            event.preventDefault();
+            toggleTagline($(this));
+        });
     });
 });

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -24,25 +24,35 @@ $data_attributes  = sprintf(
     <div class="jlg-aio-header">
         <?php if ( $has_dual_tagline ) : ?>
         <div class="jlg-aio-flags">
-            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>"
+            <button
+                type="button"
                 class="jlg-aio-flag active"
                 data-lang="fr"
-                alt="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>">
-            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>"
+                aria-pressed="true"
+                aria-label="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>"
+            >
+                <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>" alt="">
+            </button>
+            <button
+                type="button"
                 class="jlg-aio-flag"
                 data-lang="en"
-                alt="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>">
+                aria-pressed="false"
+                aria-label="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>"
+            >
+                <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>" alt="">
+            </button>
         </div>
         <?php endif; ?>
 
         <?php if ( ! empty( $tagline_fr ) ) : ?>
-        <div class="jlg-aio-tagline" data-lang="fr">
+        <div class="jlg-aio-tagline" data-lang="fr" aria-hidden="false">
             <?php echo wp_kses_post( $tagline_fr ); ?>
         </div>
         <?php endif; ?>
 
         <?php if ( ! empty( $tagline_en ) ) : ?>
-        <div class="jlg-aio-tagline" data-lang="en"<?php echo $has_dual_tagline ? ' style="display:none;" hidden' : ''; ?>>
+        <div class="jlg-aio-tagline" data-lang="en"<?php echo $has_dual_tagline ? ' hidden aria-hidden="true"' : ' aria-hidden="false"'; ?>>
             <?php echo wp_kses_post( $tagline_en ); ?>
         </div>
         <?php endif; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-tagline.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-tagline.php
@@ -11,38 +11,36 @@ $default_lang = $has_fr ? 'fr' : 'en';
 <div class="jlg-tagline-block">
     <?php if ( $has_fr && $has_en ) : ?>
         <div class="jlg-tagline-flags">
-            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>" data-lang="fr" class="jlg-lang-flag 
-            <?php
-            if ( $default_lang == 'fr' ) {
-				echo 'active';}
-			?>
-            " alt="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>">
-            <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>" data-lang="en" class="jlg-lang-flag 
-            <?php
-            if ( $default_lang == 'en' ) {
-				echo 'active';}
-			?>
-            " alt="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>">
+            <?php $is_fr_active = ( $default_lang === 'fr' ); ?>
+            <button
+                type="button"
+                class="jlg-lang-flag<?php echo $is_fr_active ? ' active' : ''; ?>"
+                data-lang="fr"
+                aria-pressed="<?php echo $is_fr_active ? 'true' : 'false'; ?>"
+                aria-label="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>"
+            >
+                <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>" alt="">
+            </button>
+            <?php $is_en_active = ( $default_lang === 'en' ); ?>
+            <button
+                type="button"
+                class="jlg-lang-flag<?php echo $is_en_active ? ' active' : ''; ?>"
+                data-lang="en"
+                aria-pressed="<?php echo $is_en_active ? 'true' : 'false'; ?>"
+                aria-label="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>"
+            >
+                <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>" alt="">
+            </button>
         </div>
     <?php endif; ?>
 
     <?php if ( $has_fr ) : ?>
-        <div class="jlg-tagline-text" data-lang="fr" 
-        <?php
-        if ( $default_lang !== 'fr' ) {
-			echo 'style="display:none;"';}
-		?>
-        >
+        <div class="jlg-tagline-text" data-lang="fr"<?php echo $default_lang === 'fr' ? ' aria-hidden="false"' : ' hidden aria-hidden="true"'; ?>>
             "<?php echo wp_kses_post( $tagline_fr ); ?>"
         </div>
     <?php endif; ?>
     <?php if ( $has_en ) : ?>
-        <div class="jlg-tagline-text" data-lang="en" 
-        <?php
-        if ( $default_lang !== 'en' ) {
-			echo 'style="display:none;"';}
-		?>
-        >
+        <div class="jlg-tagline-text" data-lang="en"<?php echo $default_lang === 'en' ? ' aria-hidden="false"' : ' hidden aria-hidden="true"'; ?>>
             "<?php echo wp_kses_post( $tagline_en ); ?>"
         </div>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- replace the flag images used as language toggles with accessible buttons in the tagline templates
- update the tagline switcher scripts to support keyboard activation, aria-pressed, and hidden state management
- refresh the front-end styles to cover the new button focus states and remove pointer cursors from decorative icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0f15afa8832e85b35d7f4cb3848a