### PR TITLE
Improve summary table mobile responsiveness

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -69,7 +69,7 @@
 .jlg-summary-filters input[type="submit"]{padding:8px 12px;border-radius:4px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color);color:var(--jlg-main-text-color);vertical-align:middle;transition:all .2s ease;}
 .jlg-summary-filters input[type="submit"]{background-color:var(--jlg-score-gradient-1);color:#fff;border-color:var(--jlg-score-gradient-1);cursor:pointer;}
 .jlg-summary-filters input[type="submit"]:hover{background-color:var(--jlg-score-gradient-1-hover);border-color:var(--jlg-score-gradient-1-hover);}
-.jlg-summary-table-wrapper{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
+.jlg-summary-table-wrapper{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 .jlg-summary-table{width:100%;border-collapse:collapse;margin:2em 0;font-size:0.9em;color:var(--jlg-table-row-text-color);background-color:var(--jlg-table-row-bg-color);}
 .jlg-summary-table th,.jlg-summary-table td{padding:12px 15px;text-align:left;}
 .jlg-summary-table thead th{background-color:var(--jlg-table-header-bg-color);color:var(--jlg-table-header-text-color);font-weight:600;}
@@ -88,6 +88,21 @@
 .jlg-pagination .page-numbers{padding:8px 12px;margin:0 2px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color-secondary);color:var(--jlg-secondary-text-color);text-decoration:none;border-radius:4px;}
 .jlg-pagination .page-numbers:hover,
 .jlg-pagination .page-numbers.current{background-color:var(--jlg-score-gradient-1);border-color:var(--jlg-score-gradient-1);color:#fff;}
+
+@media (max-width:768px){
+    .jlg-summary-table{border:0;background-color:transparent;}
+    .jlg-summary-table thead{display:none;}
+    .jlg-summary-table tbody tr{display:block;margin-bottom:16px;border:1px solid var(--jlg-border-color);border-radius:10px;overflow:hidden;background-color:var(--jlg-table-row-bg-color);box-shadow:0 4px 10px rgba(0,0,0,.08);}
+    .jlg-summary-table tbody tr:last-child{margin-bottom:0;}
+    .jlg-summary-table td{display:block;padding:12px 18px;border-bottom:1px solid var(--jlg-border-color);text-align:left;}
+    .jlg-summary-table td:last-child{border-bottom:0;}
+    .jlg-summary-table td::before{content:attr(data-label);display:block;font-weight:600;margin-bottom:6px;color:var(--jlg-main-text-color);text-transform:uppercase;letter-spacing:.03em;font-size:0.75rem;opacity:0.85;}
+    .jlg-summary-table td .jlg-genre-badges{justify-content:flex-start;gap:8px;margin-top:4px;}
+    .jlg-summary-table td .jlg-genre-badge{font-size:0.7rem;padding:3px 9px;}
+    .jlg-summary-legend,.jlg-summary-filters{margin-left:auto;margin-right:auto;}
+    .jlg-pagination{display:flex;flex-wrap:wrap;justify-content:center;gap:6px;}
+    .jlg-pagination .page-numbers{display:inline-flex;align-items:center;justify-content:center;min-width:42px;padding:10px;font-size:0.9rem;}
+}
 
 /* User Rating */
 .jlg-user-rating-block{max-width:650px;margin:32px auto;text-align:center;color:var(--jlg-user-rating-text-color);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}

--- a/plugin-notation-jeux_V4/docs/responsive-testing.md
+++ b/plugin-notation-jeux_V4/docs/responsive-testing.md
@@ -1,0 +1,11 @@
+# Contrôle manuel du rendu mobile
+
+Pour valider l'affichage responsive du tableau récapitulatif :
+
+1. Ouvrez une page WordPress contenant le shortcode `[jlg_tableau_recap]` dans votre navigateur.
+2. Activez les outils de développement (F12) puis activez le mode d'émulation mobile avec une largeur maximale de 768 px.
+3. Faites défiler le tableau horizontalement pour confirmer l'apparition de la barre de défilement lorsque nécessaire.
+4. Vérifiez que chaque cellule affiche son libellé via `data-label` au-dessus de la valeur et que les badges conservent une taille lisible.
+5. Parcourez la pagination pour confirmer que les boutons restent accessibles et qu'ils disposent d'un espacement suffisant au toucher.
+
+En cas d'ajustements ultérieurs, répétez ce scénario pour garantir que l'expérience mobile reste optimale.


### PR DESCRIPTION
## Summary
- add touch-friendly horizontal scrolling and responsive mobile card layout for the summary table
- keep pagination buttons and genre badges legible on narrow viewports and document the mobile verification checklist

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd2090c944832e99a8d7912bb2162e