### PR TITLE
Add accessible label for summary category filter

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -111,17 +111,20 @@ $letters = range( 'A', 'Z' );
                 <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'orderby' ) ); ?>" value="<?php echo esc_attr( $current_orderby ); ?>">
                 <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'order' ) ); ?>" value="<?php echo esc_attr( $current_order ); ?>">
                 <input type="hidden" name="<?php echo esc_attr( $resolve_request_key( 'letter_filter' ) ); ?>" value="<?php echo esc_attr( $current_letter_filter ); ?>">
+                <label for="<?php echo esc_attr( $table_id . '_cat_filter' ); ?>" class="screen-reader-text">
+                    <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
+                </label>
                 <?php
                 wp_dropdown_categories(
                     array(
-						'show_option_all' => __( 'Toutes les catégories', 'notation-jlg' ),
-						'orderby'         => 'name',
-						'hide_empty'      => 1,
-						'name'            => $resolve_request_key( 'cat_filter' ),
-						'id'              => $table_id . '_cat_filter',
-						'selected'        => $current_cat_filter,
-						'hierarchical'    => true,
-						'class'           => 'jlg-cat-filter-select',
+                        'show_option_all' => __( 'Toutes les catégories', 'notation-jlg' ),
+                        'orderby'         => 'name',
+                        'hide_empty'      => 1,
+                        'name'            => $resolve_request_key( 'cat_filter' ),
+                        'id'              => $table_id . '_cat_filter',
+                        'selected'        => $current_cat_filter,
+                        'hierarchical'    => true,
+                        'class'           => 'jlg-cat-filter-select',
                     )
                 );
                 ?>

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -192,4 +192,20 @@ class ShortcodeSummarySortingTest extends TestCase
         $this->assertSame('date', $contextTwo['orderby']);
         $this->assertSame('DESC', $contextTwo['order']);
     }
+
+    public function test_render_includes_screen_reader_label_for_category_filter()
+    {
+        $atts = JLG_Shortcode_Summary_Display::get_default_atts();
+        $atts['id'] = 'summary-accessibility';
+
+        $context = JLG_Shortcode_Summary_Display::get_render_context($atts, []);
+
+        $html = JLG_Frontend::get_template_html('shortcode-summary-display', $context);
+
+        $table_id     = $context['atts']['id'] ?? $atts['id'];
+        $expected_for = '<label for="' . esc_attr($table_id . '_cat_filter') . '" class="screen-reader-text">';
+
+        $this->assertStringContainsString($expected_for, $html);
+        $this->assertStringContainsString(esc_html__('Filtrer par catégorie', 'notation-jlg'), $html);
+    }
 }

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -671,6 +671,59 @@ if (!function_exists('esc_attr')) {
     }
 }
 
+if (!function_exists('esc_attr_e')) {
+    function esc_attr_e($text, $domain = 'default') {
+        echo esc_attr(__($text, $domain));
+    }
+}
+
+if (!function_exists('esc_attr__')) {
+    function esc_attr__($text, $domain = 'default') {
+        return esc_attr(__($text, $domain));
+    }
+}
+
+if (!function_exists('wp_dropdown_categories')) {
+    function wp_dropdown_categories($args = []) {
+        $defaults = [
+            'show_option_all' => '',
+            'name'            => 'cat',
+            'id'              => '',
+            'selected'        => 0,
+            'class'           => '',
+            'echo'            => 1,
+        ];
+
+        if (!is_array($args)) {
+            $args = [];
+        }
+
+        $parsed = array_merge($defaults, $args);
+
+        $id_attr = $parsed['id'] !== ''
+            ? ' id="' . esc_attr($parsed['id']) . '"'
+            : '';
+
+        $options = [];
+
+        if ($parsed['show_option_all'] !== '') {
+            $options[] = '<option value="">' . esc_html($parsed['show_option_all']) . '</option>';
+        }
+
+        $selected_value = (int) $parsed['selected'];
+        $selected_attr  = $selected_value > 0 ? ' selected="selected"' : '';
+        $options[]      = '<option value="' . esc_attr((string) $selected_value) . '"' . $selected_attr . '>' . esc_html((string) $selected_value) . '</option>';
+
+        $select = '<select name="' . esc_attr($parsed['name']) . '"' . $id_attr . ' class="' . esc_attr($parsed['class']) . '">' . implode('', $options) . '</select>';
+
+        if (!empty($parsed['echo'])) {
+            echo $select;
+        }
+
+        return $select;
+    }
+}
+
 if (!function_exists('esc_url_raw')) {
     function esc_url_raw($url) {
         if (!is_string($url)) {
@@ -745,6 +798,12 @@ if (!function_exists('wp_parse_url')) {
         }
 
         return parse_url($url);
+    }
+}
+
+if (!function_exists('wp_reset_postdata')) {
+    function wp_reset_postdata() {
+        // No-op stub for tests.
     }
 }
 


### PR DESCRIPTION
## Summary
- add a screen reader label connected to the category dropdown in the summary display template and ensure the text is translated consistently
- extend the summary sorting test to assert the rendered HTML includes the new label
- provide missing WordPress helper stubs (dropdown and escaping helpers) so the template can be rendered inside tests

## Testing
- `vendor/bin/phpunit` *(fails: known assertion in ShortcodeAllInOneRenderTest expecting flag classes on <img> elements)*

------
https://chatgpt.com/codex/tasks/task_e_68dd208db6dc832ea0d9f2e00d26c598