### PR TITLE
Add aria-pressed handling to summary letter filters

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -248,11 +248,10 @@ jQuery(document).ready(function($) {
             $letterButtons.each(function() {
                 var $button = $(this);
                 var buttonLetter = ($button.attr('data-letter') || '').toString();
-                if (buttonLetter === activeLetter) {
-                    $button.addClass('is-active');
-                } else {
-                    $button.removeClass('is-active');
-                }
+                var isActive = buttonLetter === activeLetter;
+
+                $button.toggleClass('is-active', isActive);
+                $button.attr('aria-pressed', isActive ? 'true' : 'false');
             });
         }
     }

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -77,32 +77,50 @@ $letters = range( 'A', 'Z' );
         <div class="jlg-summary-filters">
             <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
                 <?php
-                $all_letters_classes = array();
-                if ( $current_letter_filter === '' ) {
+                $is_all_letters_active = ( $current_letter_filter === '' );
+                $all_letters_classes    = array();
+                if ( $is_all_letters_active ) {
                     $all_letters_classes[] = 'is-active';
                 }
                 ?>
-                <button type="button" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>" data-letter="">
+                <button
+                    type="button"
+                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
+                    data-letter=""
+                    aria-pressed="<?php echo esc_attr( $is_all_letters_active ? 'true' : 'false' ); ?>"
+                >
                     <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                 </button>
                 <?php foreach ( $letters as $letter ) : ?>
                     <?php
+                    $is_letter_active      = ( $current_letter_filter === $letter );
                     $letter_button_classes = array();
-                    if ( $current_letter_filter === $letter ) {
+                    if ( $is_letter_active ) {
                         $letter_button_classes[] = 'is-active';
                     }
                     ?>
-                    <button type="button" data-letter="<?php echo esc_attr( $letter ); ?>" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>">
+                    <button
+                        type="button"
+                        data-letter="<?php echo esc_attr( $letter ); ?>"
+                        class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
+                        aria-pressed="<?php echo esc_attr( $is_letter_active ? 'true' : 'false' ); ?>"
+                    >
                         <?php echo esc_html( $letter ); ?>
                     </button>
                 <?php endforeach; ?>
                 <?php
+                $is_numeric_active      = ( $current_letter_filter === '#' );
                 $numeric_button_classes = array();
-                if ( $current_letter_filter === '#' ) {
+                if ( $is_numeric_active ) {
                     $numeric_button_classes[] = 'is-active';
                 }
                 ?>
-                <button type="button" data-letter="#" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $numeric_button_classes ) ) ); ?>">
+                <button
+                    type="button"
+                    data-letter="#"
+                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $numeric_button_classes ) ) ); ?>"
+                    aria-pressed="<?php echo esc_attr( $is_numeric_active ? 'true' : 'false' ); ?>"
+                >
                     <?php esc_html_e( '0-9', 'notation-jlg' ); ?>
                 </button>
             </div>

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -68,9 +68,9 @@ class ShortcodeAllInOneRenderTest extends TestCase
         ]);
 
         $this->assertNotSame('', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
-        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr">/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"[^>]+aria-pressed="true"/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag"[^>]+data-lang="en"[^>]+aria-pressed="false"/i', $output);
+        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr"[^>]*>/', $output);
         $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="en"[^>]*>/', $output);
         $scripts = $GLOBALS['jlg_test_scripts'] ?? [];
         $this->assertArrayHasKey('jlg-all-in-one', $scripts['enqueued'] ?? [], 'Main All-in-One script should be enqueued.');

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -70,6 +70,15 @@ if (!function_exists('get_pagenum_link')) {
     }
 }
 
+if (!function_exists('wp_dropdown_categories')) {
+    function wp_dropdown_categories($args = [])
+    {
+        unset($args);
+
+        echo '<select class="jlg-cat-filter-select"></select>';
+    }
+}
+
 class ShortcodeSummarySortingTest extends TestCase
 {
     protected function setUp(): void
@@ -191,5 +200,14 @@ class ShortcodeSummarySortingTest extends TestCase
         $this->assertSame(123, $contextTwo['cat_filter']);
         $this->assertSame('date', $contextTwo['orderby']);
         $this->assertSame('DESC', $contextTwo['order']);
+    }
+
+    public function test_initial_render_marks_active_letter_button_with_aria_pressed()
+    {
+        $context = JLG_Shortcode_Summary_Display::get_render_context([], []);
+        $html    = JLG_Frontend::get_template_html('shortcode-summary-display', $context);
+
+        $this->assertMatchesRegularExpression('/<button\\b[^>]*data-letter=""[^>]*aria-pressed="true"/s', $html);
+        $this->assertMatchesRegularExpression('/<button\\b[^>]*data-letter="A"[^>]*aria-pressed="false"/s', $html);
     }
 }


### PR DESCRIPTION
## Summary
- add aria-pressed attributes to summary letter filter buttons and sync them in JavaScript
- stub wp_dropdown_categories and assert aria-pressed state in summary shortcode tests
- adjust all-in-one shortcode tests to reflect button-based flag markup while verifying accessibility attributes

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dd208b9c58832eac4817ef7961f531