### PR TITLE
Fix rating block animation class and add regression test

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -16,12 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 $options = JLG_Helpers::get_plugin_options();
 ?>
 
-<div class="review-box-jlg 
 <?php
-if ( $options['enable_animations'] ) {
-	echo 'jlg-animate';}
+$classes = array( 'review-box-jlg' );
+
+if ( ! empty( $options['enable_animations'] ) ) {
+        $classes[] = 'jlg-animate';
+}
+
+$class_attribute = implode( ' ', array_map( 'sanitize_html_class', $classes ) );
 ?>
-">
+<div class="<?php echo esc_attr( $class_attribute ); ?>">
     <div class="global-score-wrapper">
         <?php if ( $options['score_layout'] === 'circle' ) : ?>
             <div class="score-circle">

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
 require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-all-in-one.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-rating-block.php';
 
 if (!function_exists('esc_attr__')) {
     function esc_attr__($text, $domain = 'default') {
@@ -68,9 +69,9 @@ class ShortcodeAllInOneRenderTest extends TestCase
         ]);
 
         $this->assertNotSame('', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
-        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr">/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
+        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr"[^>]*>/', $output);
         $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="en"[^>]*>/', $output);
         $scripts = $GLOBALS['jlg_test_scripts'] ?? [];
         $this->assertArrayHasKey('jlg-all-in-one', $scripts['enqueued'] ?? [], 'Main All-in-One script should be enqueued.');
@@ -83,6 +84,31 @@ class ShortcodeAllInOneRenderTest extends TestCase
         $this->assertNotEmpty($inline_scripts, 'Inline settings should be attached to the All-in-One script handle.');
         $this->assertStringContainsString('window.jlgAllInOneSettings', $inline_scripts[0]['code'] ?? '', 'Inline settings should initialize the global settings object.');
         $this->assertMatchesRegularExpression('/style=\"[^\"]*--jlg-aio-score-gradient: [^;]+;?/i', $output);
+    }
+
+    public function test_render_adds_animation_class_when_enabled(): void
+    {
+        $post_id = 2004;
+        $this->seedPost($post_id);
+        $this->setPluginOptions([
+            'score_layout'      => 'text',
+            'visual_theme'      => 'dark',
+            'score_gradient_1'  => '#336699',
+            'score_gradient_2'  => '#9933cc',
+            'color_high'        => '#22c55e',
+            'color_low'         => '#ef4444',
+            'tagline_font_size' => 18,
+            'enable_animations' => 1,
+        ]);
+
+        $shortcode = new JLG_Shortcode_Rating_Block();
+        $output = $shortcode->render([
+            'post_id' => (string) $post_id,
+        ]);
+
+        $this->assertNotSame('', $output);
+        $this->assertMatchesRegularExpression('/<div class="review-box-jlg jlg-animate"/i', $output);
+        $this->assertStringNotContainsString('review-box-jlggjlg-animate', $output);
     }
 
     public function test_circle_layout_renders_border_and_glow_variables(): void


### PR DESCRIPTION
## Summary
- build the rating block root class attribute via sanitized tokens to ensure proper spacing when animations are enabled
- update the all-in-one shortcode render test expectations to match current markup and cover the rating block animation class regression

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dd20466988832ea93533dc5e40f64a