### PR TITLE
Fix user rating class spacing and add render test

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -4,12 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div class="jlg-user-rating-block 
-<?php
-if ( $has_voted ) {
-	echo esc_attr( 'has-voted' );}
-?>
-">
+<div class="jlg-user-rating-block<?php echo $has_voted ? ' has-voted' : ''; ?>">
     <div class="jlg-user-rating-title"><?php esc_html_e( 'Votre avis nous intéresse !', 'notation-jlg' ); ?></div>
     <div
         class="jlg-user-rating-stars"

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -68,9 +68,9 @@ class ShortcodeAllInOneRenderTest extends TestCase
         ]);
 
         $this->assertNotSame('', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
-        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr">/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
+        $this->assertMatchesRegularExpression('/<button[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
+        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr"[^>]*>/', $output);
         $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="en"[^>]*>/', $output);
         $scripts = $GLOBALS['jlg_test_scripts'] ?? [];
         $this->assertArrayHasKey('jlg-all-in-one', $scripts['enqueued'] ?? [], 'Main All-in-One script should be enqueued.');

--- a/plugin-notation-jeux_V4/tests/ShortcodeUserRatingRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeUserRatingRenderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-jlg-helpers.php';
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-user-rating.php';
+
+class ShortcodeUserRatingRenderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_posts']         = [];
+        $GLOBALS['jlg_test_meta']          = [];
+        $GLOBALS['jlg_test_options']       = [];
+        $GLOBALS['jlg_test_current_post_id'] = 0;
+        $GLOBALS['jlg_test_filters']       = [];
+        $_COOKIE                           = [];
+
+        JLG_Helpers::flush_plugin_options_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['jlg_test_posts'],
+            $GLOBALS['jlg_test_meta'],
+            $GLOBALS['jlg_test_options'],
+            $GLOBALS['jlg_test_current_post_id'],
+            $GLOBALS['jlg_test_filters']
+        );
+
+        $_COOKIE = [];
+
+        parent::tearDown();
+    }
+
+    public function test_render_adds_has_voted_class_when_user_has_voted(): void
+    {
+        $post_id = 1401;
+        $token   = 'ABCDEF1234567890ABCDEF1234567890';
+        $hash    = hash('sha256', $token);
+
+        $_COOKIE['jlg_user_rating_token'] = $token;
+
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'           => $post_id,
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+            'post_content' => '[notation_utilisateurs_jlg]',
+        ]);
+
+        $GLOBALS['jlg_test_meta'][$post_id] = [
+            '_jlg_user_rating_avg'   => '4.2',
+            '_jlg_user_rating_count' => '11',
+            '_jlg_user_ratings'      => [
+                $hash    => 5,
+                '__meta' => [
+                    'version'    => 2,
+                    'timestamps' => [
+                        $hash => current_time('timestamp'),
+                    ],
+                ],
+            ],
+        ];
+
+        $defaults = JLG_Helpers::get_default_settings();
+        $GLOBALS['jlg_test_options']['notation_jlg_settings'] = array_merge($defaults, [
+            'user_rating_enabled' => 1,
+        ]);
+        JLG_Helpers::flush_plugin_options_cache();
+
+        $GLOBALS['jlg_test_current_post_id'] = $post_id;
+
+        $shortcode = new JLG_Shortcode_User_Rating();
+        $output    = $shortcode->render();
+
+        $this->assertNotSame('', $output);
+        $this->assertStringContainsString('class="jlg-user-rating-block has-voted"', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the user rating shortcode only appends the has-voted class with a leading space when needed to avoid concatenation issues
- add a dedicated render test that covers the has-voted scenario and align existing All-In-One render expectations with the current template markup

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd204a36b0832e912f44dedc5fce39