### PR TITLE
Add accessible aria-pressed state to summary letter filters

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -248,10 +248,14 @@ jQuery(document).ready(function($) {
             $letterButtons.each(function() {
                 var $button = $(this);
                 var buttonLetter = ($button.attr('data-letter') || '').toString();
-                if (buttonLetter === activeLetter) {
-                    $button.addClass('is-active');
+                var isActive = buttonLetter === activeLetter;
+
+                $button.toggleClass('is-active', isActive);
+
+                if (isActive) {
+                    $button.attr('aria-pressed', 'true');
                 } else {
-                    $button.removeClass('is-active');
+                    $button.attr('aria-pressed', 'false');
                 }
             });
         }
@@ -462,7 +466,8 @@ jQuery(document).ready(function($) {
         $wrapper.on('click', '.jlg-summary-letter-filter [data-letter]', function(event) {
             event.preventDefault();
 
-            var letter = ($(this).attr('data-letter') || '').toString();
+            var $button = $(this);
+            var letter = ($button.attr('data-letter') || '').toString();
             var currentState = getCurrentState($wrapper);
 
             if (letter === currentState.letter_filter && letter !== '') {
@@ -474,14 +479,10 @@ jQuery(document).ready(function($) {
                 paged: 1,
             });
 
-            var $form = $wrapper.find('.jlg-summary-filters form');
-            if ($form.length) {
-                $form.find('input[name="letter_filter"]').val(letter);
-                var letterInput = getRequestKey($wrapper, 'letter_filter');
-                if (letterInput !== 'letter_filter') {
-                    $form.find('input[name="' + letterInput + '"]').val(letter);
-                }
-            }
+            updateState($wrapper, {
+                letter_filter: letter,
+                paged: nextState.paged,
+            });
 
             var url = buildUrlFromState($wrapper, nextState);
 
@@ -501,6 +502,7 @@ jQuery(document).ready(function($) {
 
             performAjax($wrapper, nextState, url);
         });
+        updateState($wrapper, getCurrentState($wrapper));
     });
 
     window.addEventListener('popstate', function() {

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -78,31 +78,37 @@ $letters = range( 'A', 'Z' );
             <div class="jlg-summary-letter-filter" role="group" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
                 <?php
                 $all_letters_classes = array();
+                $all_letters_pressed = 'false';
                 if ( $current_letter_filter === '' ) {
                     $all_letters_classes[] = 'is-active';
+                    $all_letters_pressed   = 'true';
                 }
                 ?>
-                <button type="button" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>" data-letter="">
+                <button type="button" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>" data-letter="" aria-pressed="<?php echo esc_attr( $all_letters_pressed ); ?>">
                     <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                 </button>
                 <?php foreach ( $letters as $letter ) : ?>
                     <?php
                     $letter_button_classes = array();
+                    $letter_button_pressed = 'false';
                     if ( $current_letter_filter === $letter ) {
                         $letter_button_classes[] = 'is-active';
+                        $letter_button_pressed   = 'true';
                     }
                     ?>
-                    <button type="button" data-letter="<?php echo esc_attr( $letter ); ?>" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>">
+                    <button type="button" data-letter="<?php echo esc_attr( $letter ); ?>" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>" aria-pressed="<?php echo esc_attr( $letter_button_pressed ); ?>">
                         <?php echo esc_html( $letter ); ?>
                     </button>
                 <?php endforeach; ?>
                 <?php
                 $numeric_button_classes = array();
+                $numeric_button_pressed = 'false';
                 if ( $current_letter_filter === '#' ) {
                     $numeric_button_classes[] = 'is-active';
+                    $numeric_button_pressed   = 'true';
                 }
                 ?>
-                <button type="button" data-letter="#" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $numeric_button_classes ) ) ); ?>">
+                <button type="button" data-letter="#" class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $numeric_button_classes ) ) ); ?>" aria-pressed="<?php echo esc_attr( $numeric_button_pressed ); ?>">
                     <?php esc_html_e( '0-9', 'notation-jlg' ); ?>
                 </button>
             </div>

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -68,9 +68,15 @@ class ShortcodeAllInOneRenderTest extends TestCase
         ]);
 
         $this->assertNotSame('', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"/i', $output);
-        $this->assertMatchesRegularExpression('/<img[^>]+class="jlg-aio-flag"[^>]+data-lang="en"/i', $output);
-        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr">/i', $output);
+        $this->assertMatchesRegularExpression(
+            '/<button[^>]+class="jlg-aio-flag active"[^>]+data-lang="fr"[^>]*>\\s*<img[^>]+>/i',
+            $output
+        );
+        $this->assertMatchesRegularExpression(
+            '/<button[^>]+class="jlg-aio-flag"[^>]+data-lang="en"[^>]*>\\s*<img[^>]+>/i',
+            $output
+        );
+        $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="fr"[^>]*>/i', $output);
         $this->assertMatchesRegularExpression('/<div class="jlg-aio-tagline" data-lang="en"[^>]*>/', $output);
         $scripts = $GLOBALS['jlg_test_scripts'] ?? [];
         $this->assertArrayHasKey('jlg-all-in-one', $scripts['enqueued'] ?? [], 'Main All-in-One script should be enqueued.');

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummaryTemplateTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummaryTemplateTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_dropdown_categories')) {
+    function wp_dropdown_categories($args = array())
+    {
+        $defaults = array(
+            'name' => 'cat_filter',
+            'id' => '',
+            'class' => '',
+        );
+
+        $args = array_merge($defaults, is_array($args) ? $args : array());
+
+        printf(
+            '<select name="%s" id="%s" class="%s"></select>',
+            esc_attr($args['name']),
+            esc_attr($args['id']),
+            esc_attr($args['class'])
+        );
+
+        return '';
+    }
+}
+
+class ShortcodeSummaryTemplateTest extends TestCase
+{
+    public function test_active_letter_button_sets_aria_pressed_attribute()
+    {
+        $atts = JLG_Shortcode_Summary_Display::get_default_atts();
+        $atts['id'] = 'table-test';
+        $atts['posts_per_page'] = 5;
+        $atts['letter_filter'] = 'C';
+
+        $query = null;
+        $paged = 1;
+        $orderby = 'date';
+        $order = 'DESC';
+        $colonnes = array('titre');
+        $colonnes_disponibles = array();
+        $cat_filter = 0;
+        $letter_filter = 'C';
+        $genre_filter = '';
+        $error_message = '';
+        $request_prefix = '';
+        $request_keys = array();
+
+        $templateFilter = function ($path, $template_name, $args, $located_template, $plugin_template_path) {
+            unset($path, $template_name, $args, $located_template, $plugin_template_path);
+
+            return __DIR__ . '/fixtures/empty-template.php';
+        };
+
+        add_filter('jlg_frontend_template_path', $templateFilter, 10, 5);
+
+        try {
+            ob_start();
+            require dirname(__DIR__) . '/templates/shortcode-summary-display.php';
+            $output = ob_get_clean();
+        } finally {
+            remove_filter('jlg_frontend_template_path', $templateFilter, 10);
+        }
+
+        $this->assertMatchesRegularExpression(
+            '/<button[^>]*data-letter="C"[^>]*aria-pressed="true"/i',
+            $output,
+            'The active letter should expose aria-pressed="true".'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/<button[^>]*data-letter=""[^>]*aria-pressed="false"/i',
+            $output,
+            'The "All" button should expose aria-pressed="false" when another letter is active.'
+        );
+    }
+}

--- a/plugin-notation-jeux_V4/tests/fixtures/empty-template.php
+++ b/plugin-notation-jeux_V4/tests/fixtures/empty-template.php
@@ -1,0 +1,2 @@
+<?php
+// Empty template used in unit tests to bypass nested includes.


### PR DESCRIPTION
## Summary
- set server-rendered `aria-pressed` attributes on summary letter filter buttons for all choices
- keep the client-side summary table script in sync with the active letter filter, including toggling `aria-pressed`
- cover the behaviour with a dedicated template test and align the all-in-one render assertions with current markup

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd204da8f0832e82e991025278351e