### PR TITLE
Fix animation class spacing and add regression test

### DIFF
--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -16,12 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $options = JLG_Helpers::get_plugin_options();
 ?>
 
-<div class="review-box-jlg 
-<?php
-if ( $options['enable_animations'] ) {
-	echo 'jlg-animate';}
-?>
-">
+<div class="review-box-jlg<?php echo $options['enable_animations'] ? ' jlg-animate' : ''; ?>">
     <div class="global-score-wrapper">
         <?php if ( $options['score_layout'] === 'circle' ) : ?>
             <div class="score-circle">

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../includes/class-jlg-helpers.php';
 require_once __DIR__ . '/../includes/class-jlg-frontend.php';
 require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-all-in-one.php';
+require_once __DIR__ . '/../includes/shortcodes/class-jlg-shortcode-rating-block.php';
 
 if (!function_exists('esc_attr__')) {
     function esc_attr__($text, $domain = 'default') {
@@ -158,6 +159,30 @@ class ShortcodeAllInOneRenderTest extends TestCase
         } finally {
             unset($GLOBALS['jlg_test_filters']['jlg_rated_post_types']);
         }
+    }
+
+    public function test_render_adds_animation_class_when_enabled(): void
+    {
+        $post_id = 2004;
+        $this->seedPost($post_id);
+        $this->setPluginOptions([
+            'score_layout'      => 'text',
+            'visual_theme'      => 'dark',
+            'score_gradient_1'  => '#336699',
+            'score_gradient_2'  => '#9933cc',
+            'color_high'        => '#22c55e',
+            'color_low'         => '#ef4444',
+            'tagline_font_size' => 18,
+            'enable_animations' => 1,
+        ]);
+
+        $shortcode = new JLG_Shortcode_Rating_Block();
+        $output = $shortcode->render([
+            'post_id' => (string) $post_id,
+        ]);
+
+        $this->assertNotSame('', $output);
+        $this->assertStringContainsString('class="review-box-jlg jlg-animate"', $output);
     }
 
     private function seedPost(int $post_id, string $post_type = 'post'): void


### PR DESCRIPTION
## Summary
- ensure the rating block template always inserts the animation class with a leading space
- add a PHPUnit regression test covering the animated class when the option is enabled

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dd2edcc970832eb96868081240ebbc