### PR TITLE
Add search filter support to Game Explorer shortcode

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -44,6 +44,14 @@
 .jlg-game-info-box dd{margin:0;color:var(--jlg-secondary-text-color);}
 .jlg-game-info-box .platforms-list span{display:inline-block;background:var(--jlg-border-color);padding:3px 8px;border-radius:4px;font-size:0.9em;margin:2px;}
 
+/* Game Explorer */
+.jlg-game-explorer .jlg-ge-search{display:flex;flex-direction:column;gap:4px;flex:1 1 240px;min-width:220px;}
+.jlg-game-explorer .jlg-ge-search label{font-size:0.875rem;font-weight:500;color:var(--jlg-ge-text-muted,var(--jlg-secondary-text-color,#4b5563));}
+.jlg-game-explorer .jlg-ge-search input[type="search"]{width:100%;padding:0.45rem 0.75rem;border-radius:0.5rem;border:1px solid var(--jlg-ge-card-border,var(--jlg-border-color,#d1d5db));background-color:var(--jlg-ge-card-bg,var(--jlg-bg-color,#fff));color:var(--jlg-ge-text,var(--jlg-main-text-color,#111827));transition:box-shadow .2s ease,border-color .2s ease;}
+.jlg-game-explorer .jlg-ge-search input[type="search"]::placeholder{color:var(--jlg-ge-text-muted,var(--jlg-secondary-text-color,#6b7280));opacity:0.85;}
+.jlg-game-explorer .jlg-ge-search input[type="search"]:focus{outline:2px solid var(--jlg-ge-accent,var(--jlg-score-gradient-1,#2563eb));outline-offset:2px;box-shadow:0 0 0 2px rgba(37,99,235,0.15);}
+@media (max-width:640px){.jlg-game-explorer .jlg-ge-search{flex-basis:100%;min-width:100%;}}
+
 /* Summary Display */
 .jlg-summary-filters{margin-bottom:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:flex;flex-direction:column;gap:12px;}
 .jlg-summary-letter-filter{display:flex;flex-wrap:wrap;gap:6px;align-items:center;}

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -164,6 +164,10 @@
         if (refs.availabilitySelect) {
             refs.availabilitySelect.value = state.availability || '';
         }
+
+        if (refs.searchInput) {
+            refs.searchInput.value = state.search || '';
+        }
     }
 
     function setResultsBusyState(resultsNode, isBusy) {
@@ -348,6 +352,7 @@
             categorySelect: container.querySelector('[data-role="category"]'),
             platformSelect: container.querySelector('[data-role="platform"]'),
             availabilitySelect: container.querySelector('[data-role="availability"]'),
+            searchInput: container.querySelector('[data-role="search"]'),
             resetButton: container.querySelector('[data-role="reset"]'),
         };
 
@@ -421,6 +426,23 @@
                 writeConfig(container, config);
                 refreshResults(container, config, refs);
             });
+        }
+
+        if (refs.searchInput) {
+            const handleSearchUpdate = () => {
+                const newValue = refs.searchInput.value || '';
+                if (newValue === config.state.search) {
+                    return;
+                }
+
+                config.state.search = newValue;
+                config.state.paged = 1;
+                writeConfig(container, config);
+                refreshResults(container, config, refs);
+            };
+
+            refs.searchInput.addEventListener('input', handleSearchUpdate);
+            refs.searchInput.addEventListener('change', handleSearchUpdate);
         }
 
         if (refs.resetButton) {

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -34,11 +34,13 @@ if ( $config_json === false ) {
 $has_category_filter     = ! empty( $filters_enabled['category'] ) && ! empty( $categories_list );
 $has_platform_filter     = ! empty( $filters_enabled['platform'] ) && ! empty( $platforms_list );
 $has_availability_filter = ! empty( $filters_enabled['availability'] );
-$has_filters             = $has_category_filter || $has_platform_filter || $has_availability_filter;
+$has_search_filter       = ! empty( $filters_enabled['search'] );
+$has_filters             = $has_category_filter || $has_platform_filter || $has_availability_filter || $has_search_filter;
 $letter_active           = isset( $current_filters['letter'] ) ? $current_filters['letter'] : '';
 $category_active         = isset( $current_filters['category'] ) ? $current_filters['category'] : '';
 $platform_active         = isset( $current_filters['platform'] ) ? $current_filters['platform'] : '';
 $availability_active     = isset( $current_filters['availability'] ) ? $current_filters['availability'] : '';
+$search_active           = isset( $current_filters['search'] ) ? $current_filters['search'] : '';
 ?>
 
 <div
@@ -187,6 +189,21 @@ $availability_active     = isset( $current_filters['availability'] ) ? $current_
                         </option>
                     <?php endforeach; ?>
                 </select>
+            <?php endif; ?>
+
+            <?php if ( $has_search_filter ) : ?>
+                <div class="jlg-ge-search">
+                    <label for="<?php echo esc_attr( $container_id ); ?>-search">
+                        <?php esc_html_e( 'Rechercher un jeu', 'notation-jlg' ); ?>
+                    </label>
+                    <input
+                        type="search"
+                        id="<?php echo esc_attr( $container_id ); ?>-search"
+                        data-role="search"
+                        value="<?php echo esc_attr( $search_active ); ?>"
+                        placeholder="<?php echo esc_attr__( 'Rechercher…', 'notation-jlg' ); ?>"
+                    >
+                </div>
             <?php endif; ?>
 
             <button type="button" class="jlg-ge-reset" data-role="reset">

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerSearchFilterTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerSearchFilterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512) {
+        return json_encode($data, $options, $depth);
+    }
+}
+
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+
+class ShortcodeGameExplorerSearchFilterTest extends TestCase
+{
+    public function test_search_filter_renders_and_exports_state(): void
+    {
+        $search_value = 'Metroid';
+
+        $output = JLG_Frontend::get_template_html('shortcode-game-explorer', [
+            'atts' => [
+                'id' => 'explorer-test',
+                'posts_per_page' => 9,
+            ],
+            'filters_enabled' => [
+                'search' => true,
+            ],
+            'current_filters' => [
+                'search' => $search_value,
+            ],
+            'config_payload' => [
+                'atts' => [
+                    'id' => 'explorer-test',
+                    'posts_per_page' => 9,
+                    'columns' => 3,
+                    'score_position' => 'bottom-right',
+                    'filters' => 'search',
+                    'categorie' => '',
+                    'plateforme' => '',
+                    'lettre' => '',
+                ],
+                'state' => [
+                    'orderby' => 'date',
+                    'order' => 'DESC',
+                    'letter' => '',
+                    'category' => '',
+                    'platform' => '',
+                    'availability' => '',
+                    'search' => $search_value,
+                    'paged' => 1,
+                    'total_items' => 0,
+                ],
+            ],
+            'games' => [],
+            'pagination' => [
+                'current' => 1,
+                'total' => 0,
+            ],
+            'total_items' => 0,
+        ]);
+
+        $this->assertStringContainsString('data-role="search"', $output, 'The search input should be rendered when enabled.');
+        $this->assertStringContainsString('id="explorer-test-search"', $output, 'The search input should use the container identifier.');
+        $this->assertStringContainsString(htmlspecialchars($search_value, ENT_QUOTES), $output, 'The search input should reflect the current search value.');
+
+        $this->assertMatchesRegularExpression(
+            '/<label[^>]+for="explorer-test-search"[^>]*>[^<]*Rechercher un jeu[^<]*<\/label>/u',
+            $output,
+            'The search input should have an accessible label.'
+        );
+
+        preg_match('/data-config="([^"]+)"/', $output, $matches);
+        $this->assertNotEmpty($matches, 'The component should expose its configuration.');
+
+        $config = json_decode(htmlspecialchars_decode($matches[1], ENT_QUOTES), true);
+        $this->assertIsArray($config, 'The configuration payload should be valid JSON.');
+        $this->assertSame($search_value, $config['state']['search'] ?? null, 'Search state should be exported in the configuration payload.');
+    }
+}


### PR DESCRIPTION
## Summary
- render a labelled search field in the Game Explorer shortcode when the search filter is enabled
- connect the search input to the explorer state management and refresh logic on the front end
- style the search control for desktop/mobile layouts and add coverage ensuring the field and config are emitted

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dd2ee42afc832e853605a81eb30bfd