### PR TITLE
Respect reduced motion preference for frontend animations

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -30,6 +30,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 - **API RAWG** : Remplissage automatique des informations de jeu
 - **SEO optimisé** : Support schema.org pour les rich snippets Google
 - **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
+- **Accessibilité renforcée** : Les animations respectent la préférence système *réduire les mouvements*
 - **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 - **Responsive** : Parfaitement adapté mobile et tablette
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -27,6 +27,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 * **API RAWG** : Remplissage automatique des informations de jeu
 * **SEO optimisé** : Support schema.org pour les rich snippets Google
 * **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
+* **Accessibilité renforcée** : Les animations respectent la préférence système "réduire les mouvements"
 * **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 * **Responsive** : Parfaitement adapté mobile et tablette
 

--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -36,6 +36,53 @@
 .review-box-jlg.jlg-animate.is-in-view .score-circle,
 .review-box-jlg.jlg-animate.is-in-view .global-score-text{transform:scale(1);opacity:1;}
 
+@media (prefers-reduced-motion: reduce) {
+    /* Respect de la préférence utilisateur en supprimant les animations utilitaires */
+    .jlg-animate,
+    .jlg-animate * {
+        animation: none !important;
+    }
+
+    .review-box-jlg.jlg-animate .rating-bar,
+    .review-box-jlg.jlg-animate.is-in-view .rating-bar {
+        width: var(--rating-percent, 0%);
+        transition: none !important;
+    }
+
+    .review-box-jlg.jlg-animate .score-circle,
+    .review-box-jlg.jlg-animate .global-score-text,
+    .review-box-jlg.jlg-animate.is-in-view .score-circle,
+    .review-box-jlg.jlg-animate.is-in-view .global-score-text {
+        opacity: 1;
+        transform: none !important;
+        transition: none !important;
+    }
+
+    .jlg-summary-letter-filter button,
+    .jlg-summary-filters input[type="submit"],
+    .jlg-game-card,
+    .jlg-game-card img,
+    .jlg-user-star,
+    .jlg-lang-flag {
+        transition: none !important;
+    }
+
+    .jlg-game-card,
+    .jlg-game-card:hover,
+    .jlg-game-card:focus-visible,
+    .jlg-game-card img,
+    .jlg-game-card:hover img,
+    .jlg-game-card:focus-visible img,
+    .jlg-user-star,
+    .jlg-user-star:hover,
+    .jlg-user-star.hover,
+    .jlg-lang-flag,
+    .jlg-lang-flag:hover,
+    .jlg-lang-flag:focus-visible {
+        transform: none !important;
+    }
+}
+
 /* Game Info */
 .jlg-game-info-box{background-color:var(--jlg-bar-bg-color);border-left:4px solid var(--jlg-score-gradient-1);padding:20px;margin:32px auto;max-width:650px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;border-radius:8px;}
 .jlg-game-info-box h3{margin-top:0;color:var(--jlg-main-text-color);}

--- a/plugin-notation-jeux_V4/assets/js/jlg-animations.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-animations.js
@@ -1,4 +1,8 @@
 document.addEventListener("DOMContentLoaded", function() {
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        return;
+    }
+
     const animatedElements = document.querySelectorAll('.jlg-animate');
 
     if (!animatedElements.length || !('IntersectionObserver' in window)) {


### PR DESCRIPTION
## Summary
- skip IntersectionObserver animations when the user requests reduced motion
- neutralise frontend transitions for animated utilities via a prefers-reduced-motion media query
- document the accessibility improvement in the plugin readme files

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2ee09e4c832ea84349f6fc629d78