### PR TITLE
Add debounce to game explorer search refresh

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -7,6 +7,20 @@
     const REQUEST_KEYS = ['orderby', 'order', 'letter', 'category', 'platform', 'availability', 'search', 'paged'];
     const FOCUSABLE_SELECTOR = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+    function debounce(fn, delay = 250) {
+        let timeoutId;
+        return function debounced(...args) {
+            const context = this;
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+            timeoutId = setTimeout(() => {
+                timeoutId = null;
+                fn.apply(context, args);
+            }, delay);
+        };
+    }
+
     function computeRequestKey(prefix, key) {
         return prefix ? key + '__' + prefix : key;
     }
@@ -429,6 +443,9 @@
         }
 
         if (refs.searchInput) {
+            const scheduleSearchRefresh = debounce(() => {
+                refreshResults(container, config, refs);
+            });
             const handleSearchUpdate = () => {
                 const newValue = refs.searchInput.value || '';
                 if (newValue === config.state.search) {
@@ -438,7 +455,7 @@
                 config.state.search = newValue;
                 config.state.paged = 1;
                 writeConfig(container, config);
-                refreshResults(container, config, refs);
+                scheduleSearchRefresh();
             };
 
             refs.searchInput.addEventListener('input', handleSearchUpdate);


### PR DESCRIPTION
## Summary
- add a reusable debounce helper within the game explorer script
- debounce search result refreshes so rapid typing waits 250ms before triggering a request
- ensure change and input events share the debounced search handler for assistive technologies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd69c046b0832ea1c460d33e98fc7b