### PR TITLE
Handle abortable requests in game explorer

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -292,8 +292,9 @@
         payload.set(getRequestKey(config, 'paged'), config.state.paged);
 
         activeRequestController?.abort();
-        activeRequestController = new AbortController();
-        const requestController = activeRequestController;
+
+        const requestController = new AbortController();
+        activeRequestController = requestController;
 
         fetch(ajaxUrl, {
             method: 'POST',
@@ -351,7 +352,11 @@
                 }
             })
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
+                const isAbortError = (typeof DOMException !== 'undefined'
+                    && error instanceof DOMException
+                    && error.name === 'AbortError')
+                    || (error && error.name === 'AbortError');
+                if (isAbortError) {
                     return;
                 }
                 if (refs.resultsNode) {


### PR DESCRIPTION
## Summary
- ensure any pending game explorer requests are aborted before launching a new fetch
- attach the current abort controller signal to fetch and safely ignore abort errors to avoid UI regressions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7f10cb88832eab5df0f150fb6c6e