### PR TITLE
Refactor game explorer filters into GET form

### DIFF
--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -765,8 +765,25 @@ class JLG_Shortcode_Game_Explorer {
         $filters_enabled = self::normalize_filters( $atts['filters'] );
         $score_position  = JLG_Helpers::normalize_game_explorer_score_position( $atts['score_position'] ?? '' );
 
-        $orderby = ( isset( $request['orderby'] ) && is_string( $request['orderby'] ) ) ? sanitize_key( $request['orderby'] ) : 'date';
-        $order   = isset( $request['order'] ) ? strtoupper( sanitize_text_field( $request['order'] ) ) : 'DESC';
+        $raw_orderby = isset( $request['orderby'] ) && is_string( $request['orderby'] ) ? $request['orderby'] : '';
+        $raw_order   = isset( $request['order'] ) ? (string) $request['order'] : '';
+
+        if ( strpos( $raw_orderby, '|' ) !== false ) {
+            $parts = array_map( 'trim', explode( '|', $raw_orderby ) );
+            if ( isset( $parts[0] ) && $parts[0] !== '' ) {
+                $raw_orderby = $parts[0];
+            }
+            if ( isset( $parts[1] ) && $parts[1] !== '' ) {
+                $raw_order = $parts[1];
+            }
+        }
+
+        $orderby = $raw_orderby !== '' ? sanitize_key( $raw_orderby ) : 'date';
+        if ( $orderby === '' ) {
+            $orderby = 'date';
+        }
+
+        $order = $raw_order !== '' ? strtoupper( sanitize_text_field( $raw_order ) ) : 'DESC';
         if ( ! in_array( $order, array( 'ASC', 'DESC' ), true ) ) {
             $order = 'DESC';
         }

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -52,165 +52,184 @@ $search_active           = isset( $current_filters['search'] ) ? $current_filter
     data-total-items="<?php echo esc_attr( $total_items ); ?>"
     data-request-prefix="<?php echo esc_attr( $request_prefix ); ?>"
 >
-    <div class="jlg-ge-toolbar">
-        <div class="jlg-ge-toolbar__left">
-            <?php if ( ! empty( $filters_enabled['letter'] ) && ! empty( $letters ) ) : ?>
-                <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
-                    <ul>
-                        <li>
-                            <?php
-                            $all_letters_classes = array();
-                            if ( $letter_active === '' ) {
-                                $all_letters_classes[] = 'is-active';
-                            }
-                            ?>
-                            <button
-                                type="button"
-                                class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
-                                data-letter=""
-                                aria-pressed="<?php echo esc_attr( $letter_active === '' ? 'true' : 'false' ); ?>"
-                            >
-                                <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
-                            </button>
-                        </li>
-                        <?php
-                        foreach ( $letters as $letter_item ) :
-                            $value     = isset( $letter_item['value'] ) ? $letter_item['value'] : '';
-                            $enabled   = ! empty( $letter_item['enabled'] );
-                            $is_active = ( $value !== '' && $value === $letter_active );
-                            ?>
+    <noscript>
+        <p><?php esc_html_e( 'JavaScript est désactivé. Utilisez les filtres du formulaire et validez pour mettre à jour la liste des jeux.', 'notation-jlg' ); ?></p>
+    </noscript>
+
+    <form method="get" class="jlg-ge-form" data-role="form">
+        <input type="hidden" name="orderby" value="<?php echo esc_attr( $sort_key . '|' . $sort_order ); ?>" data-role="orderby-input">
+        <input type="hidden" name="order" value="<?php echo esc_attr( $sort_order ); ?>" data-role="order-input">
+        <input type="hidden" name="letter" value="<?php echo esc_attr( $letter_active ); ?>" data-role="letter-input">
+        <input type="hidden" name="paged" value="<?php echo esc_attr( isset( $pagination['current'] ) ? max( 1, (int) $pagination['current'] ) : 1 ); ?>" data-role="paged-input">
+
+        <div class="jlg-ge-toolbar">
+            <div class="jlg-ge-toolbar__left">
+                <?php if ( ! empty( $filters_enabled['letter'] ) && ! empty( $letters ) ) : ?>
+                    <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
+                        <ul>
                             <li>
                                 <?php
-                                $letter_button_classes = array();
-                                if ( $is_active ) {
-                                    $letter_button_classes[] = 'is-active';
+                                $all_letters_classes = array();
+                                if ( $letter_active === '' ) {
+                                    $all_letters_classes[] = 'is-active';
                                 }
                                 ?>
                                 <button
-                                    type="button"
-                                    data-letter="<?php echo esc_attr( $value ); ?>"
-                                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
-                                    <?php disabled( ! $enabled ); ?>
-                                    aria-pressed="<?php echo esc_attr( $is_active ? 'true' : 'false' ); ?>"
+                                    type="submit"
+                                    name="letter"
+                                    value=""
+                                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
+                                    data-letter=""
+                                    aria-pressed="<?php echo esc_attr( $letter_active === '' ? 'true' : 'false' ); ?>"
                                 >
-                                    <?php echo esc_html( $letter_item['label'] ?? $value ); ?>
+                                    <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                                 </button>
                             </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </nav>
-            <?php endif; ?>
-        </div>
-        <div class="jlg-ge-toolbar__right">
-            <div class="jlg-ge-sort">
-                <label for="<?php echo esc_attr( $container_id ); ?>-sort">
-                    <?php esc_html_e( 'Trier par', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-sort" data-role="sort">
-                    <?php
-                    foreach ( $sort_options as $option ) :
-                        $value          = isset( $option['value'] ) ? $option['value'] : '';
-                        $option_orderby = isset( $option['orderby'] ) ? $option['orderby'] : '';
-                        $option_order   = isset( $option['order'] ) ? $option['order'] : '';
-                        $selected       = ( $option_orderby === $sort_key && $option_order === $sort_order );
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected ); ?>>
-                            <?php echo esc_html( $option['label'] ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
+                            <?php
+                            foreach ( $letters as $letter_item ) :
+                                $value     = isset( $letter_item['value'] ) ? $letter_item['value'] : '';
+                                $enabled   = ! empty( $letter_item['enabled'] );
+                                $is_active = ( $value !== '' && $value === $letter_active );
+                                ?>
+                                <li>
+                                    <?php
+                                    $letter_button_classes = array();
+                                    if ( $is_active ) {
+                                        $letter_button_classes[] = 'is-active';
+                                    }
+                                    ?>
+                                    <button
+                                        type="submit"
+                                        name="letter"
+                                        value="<?php echo esc_attr( $value ); ?>"
+                                        data-letter="<?php echo esc_attr( $value ); ?>"
+                                        class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
+                                        <?php disabled( ! $enabled ); ?>
+                                        aria-pressed="<?php echo esc_attr( $is_active ? 'true' : 'false' ); ?>"
+                                    >
+                                        <?php echo esc_html( $letter_item['label'] ?? $value ); ?>
+                                    </button>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </nav>
+                <?php endif; ?>
             </div>
-            <div class="jlg-ge-count">
-                <?php
-                $formatted_total_items = number_format_i18n( $total_items );
-
-                printf(
-                    esc_html( _n( '%s jeu', '%s jeux', $total_items, 'notation-jlg' ) ),
-                    $formatted_total_items
-                );
-                ?>
-            </div>
-        </div>
-    </div>
-
-    <?php if ( $has_filters ) : ?>
-        <div class="jlg-ge-filters" data-role="filters">
-            <?php if ( $has_category_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-category" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-category" data-role="category">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les catégories', 'notation-jlg' ); ?>
-                    </option>
-                    <?php
-                    foreach ( $categories_list as $category ) :
-                        $value = isset( $category['value'] ) ? (string) $category['value'] : '';
-                        $label = isset( $category['label'] ) ? $category['label'] : $value;
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $category_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_platform_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-platform" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par plateforme', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-platform" data-role="platform">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les plateformes', 'notation-jlg' ); ?>
-                    </option>
-                    <?php
-                    foreach ( $platforms_list as $platform ) :
-                        $value = isset( $platform['value'] ) ? (string) $platform['value'] : '';
-                        $label = isset( $platform['label'] ) ? $platform['label'] : $value;
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $platform_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_availability_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-availability" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par disponibilité', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-availability" data-role="availability">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les sorties', 'notation-jlg' ); ?>
-                    </option>
-                    <?php foreach ( $availability_options as $value => $label ) : ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $availability_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_search_filter ) : ?>
-                <div class="jlg-ge-search">
-                    <label for="<?php echo esc_attr( $container_id ); ?>-search">
-                        <?php esc_html_e( 'Rechercher un jeu', 'notation-jlg' ); ?>
+            <div class="jlg-ge-toolbar__right">
+                <div class="jlg-ge-sort">
+                    <label for="<?php echo esc_attr( $container_id ); ?>-sort">
+                        <?php esc_html_e( 'Trier par', 'notation-jlg' ); ?>
                     </label>
-                    <input
-                        type="search"
-                        id="<?php echo esc_attr( $container_id ); ?>-search"
-                        data-role="search"
-                        value="<?php echo esc_attr( $search_active ); ?>"
-                        placeholder="<?php echo esc_attr__( 'Rechercher…', 'notation-jlg' ); ?>"
-                    >
+                    <select id="<?php echo esc_attr( $container_id ); ?>-sort" name="orderby" data-role="sort">
+                        <?php
+                        foreach ( $sort_options as $option ) :
+                            $value          = isset( $option['value'] ) ? $option['value'] : '';
+                            $option_orderby = isset( $option['orderby'] ) ? $option['orderby'] : '';
+                            $option_order   = isset( $option['order'] ) ? $option['order'] : '';
+                            $selected       = ( $option_orderby === $sort_key && $option_order === $sort_order );
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" data-order="<?php echo esc_attr( $option_order ); ?>" <?php selected( $selected ); ?>>
+                                <?php echo esc_html( $option['label'] ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
                 </div>
-            <?php endif; ?>
+                <div class="jlg-ge-count">
+                    <?php
+                    $formatted_total_items = number_format_i18n( $total_items );
 
-            <button type="button" class="jlg-ge-reset" data-role="reset">
-                <?php esc_html_e( 'Réinitialiser', 'notation-jlg' ); ?>
-            </button>
+                    printf(
+                        esc_html( _n( '%s jeu', '%s jeux', $total_items, 'notation-jlg' ) ),
+                        $formatted_total_items
+                    );
+                    ?>
+                </div>
+            </div>
         </div>
-    <?php endif; ?>
+
+        <?php if ( $has_filters ) : ?>
+            <div class="jlg-ge-filters" data-role="filters">
+                <?php if ( $has_category_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-category" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
+                    </label>
+                    <select id="<?php echo esc_attr( $container_id ); ?>-category" name="category" data-role="category">
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les catégories', 'notation-jlg' ); ?>
+                        </option>
+                        <?php
+                        foreach ( $categories_list as $category ) :
+                            $value = isset( $category['value'] ) ? (string) $category['value'] : '';
+                            $label = isset( $category['label'] ) ? $category['label'] : $value;
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $category_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
+
+                <?php if ( $has_platform_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-platform" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par plateforme', 'notation-jlg' ); ?>
+                    </label>
+                    <select id="<?php echo esc_attr( $container_id ); ?>-platform" name="platform" data-role="platform">
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les plateformes', 'notation-jlg' ); ?>
+                        </option>
+                        <?php
+                        foreach ( $platforms_list as $platform ) :
+                            $value = isset( $platform['value'] ) ? (string) $platform['value'] : '';
+                            $label = isset( $platform['label'] ) ? $platform['label'] : $value;
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $platform_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
+
+                <?php if ( $has_availability_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-availability" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par disponibilité', 'notation-jlg' ); ?>
+                    </label>
+                    <select id="<?php echo esc_attr( $container_id ); ?>-availability" name="availability" data-role="availability">
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les sorties', 'notation-jlg' ); ?>
+                        </option>
+                        <?php foreach ( $availability_options as $value => $label ) : ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $availability_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
+
+                <?php if ( $has_search_filter ) : ?>
+                    <div class="jlg-ge-search">
+                        <label for="<?php echo esc_attr( $container_id ); ?>-search">
+                            <?php esc_html_e( 'Rechercher un jeu', 'notation-jlg' ); ?>
+                        </label>
+                        <input
+                            type="search"
+                            id="<?php echo esc_attr( $container_id ); ?>-search"
+                            name="search"
+                            data-role="search"
+                            value="<?php echo esc_attr( $search_active ); ?>"
+                            placeholder="<?php echo esc_attr__( 'Rechercher…', 'notation-jlg' ); ?>"
+                        >
+                    </div>
+                <?php endif; ?>
+
+                <button type="reset" class="jlg-ge-reset" data-role="reset">
+                    <?php esc_html_e( 'Réinitialiser', 'notation-jlg' ); ?>
+                </button>
+                <button type="submit" class="screen-reader-text jlg-ge-submit">
+                    <?php esc_html_e( 'Appliquer les filtres', 'notation-jlg' ); ?>
+                </button>
+            </div>
+        <?php endif; ?>
+    </form>
 
     <div
         class="jlg-ge-results"


### PR DESCRIPTION
## Summary
- wrap the game explorer toolbar and filters in a GET form with named inputs, letter submit buttons, and a noscript fallback message
- update the front-end script to sync with the form controls while keeping AJAX refreshes and to keep pagination/order state in hidden inputs
- allow combined order parameters in the shortcode handler and add a regression test that asserts the rendered form exposes the expected field names

## Testing
- vendor/bin/phpunit tests/FrontendGameExplorerAjaxTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dd91b5c168832e9e96f6a4dce9b1bb