### PR TITLE
Handle RAWG cover images and guard admin import

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
@@ -1,5 +1,18 @@
 jQuery(document).ready(function($) {
     var adminStrings = (typeof jlgAdminApiL10n !== 'undefined') ? jlgAdminApiL10n : {};
+
+    function isValidHttpUrl(value) {
+        if (typeof value !== 'string') {
+            return false;
+        }
+
+        try {
+            var parsed = new URL(value);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        } catch (error) {
+            return false;
+        }
+    }
     function getString(key, fallback) {
         if (adminStrings && Object.prototype.hasOwnProperty.call(adminStrings, key)) {
             return adminStrings[key];
@@ -155,7 +168,11 @@ jQuery(document).ready(function($) {
             $('#jlg_developpeur').val(gameData.developers);
             $('#jlg_editeur').val(gameData.publishers);
             $('#jlg_date_sortie').val(gameData.release_date);
-            $('#jlg_cover_image_url').val(gameData.cover_image);
+            var coverInput = $('#jlg_cover_image_url');
+            var coverUrl = (typeof gameData.cover_image === 'string') ? gameData.cover_image.trim() : '';
+            if (coverUrl && isValidHttpUrl(coverUrl)) {
+                coverInput.val(coverUrl);
+            }
             if (gameData.pegi) {
                 $('#jlg_pegi').val(gameData.pegi);
             }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -224,6 +224,27 @@ class JLG_Admin_Ajax {
             $pegi = $raw_game['esrb_rating']['name'];
         }
 
+        $cover_image = '';
+        $cover_candidates = array();
+
+        if ( ! empty( $raw_game['background_image'] ) ) {
+            $cover_candidates[] = $raw_game['background_image'];
+        }
+
+        if ( ! empty( $raw_game['background_image_additional'] ) ) {
+            $cover_candidates[] = $raw_game['background_image_additional'];
+        }
+
+        foreach ( $cover_candidates as $candidate ) {
+            if ( is_string( $candidate ) ) {
+                $candidate = trim( $candidate );
+                if ( $candidate !== '' ) {
+                    $cover_image = $candidate;
+                    break;
+                }
+            }
+        }
+
         return array(
             'name'         => $raw_game['name'] ?? '',
             'release_date' => $raw_game['released'] ?? '',
@@ -231,6 +252,7 @@ class JLG_Admin_Ajax {
             'publishers'   => $publishers,
             'platforms'    => $platforms,
             'pegi'         => $pegi,
+            'cover_image'  => $cover_image,
         );
     }
 
@@ -242,6 +264,7 @@ class JLG_Admin_Ajax {
             'publishers'   => '',
             'platforms'    => array(),
             'pegi'         => '',
+            'cover_image'  => '',
         );
 
         $game = array_merge( $defaults, $game );
@@ -279,6 +302,17 @@ class JLG_Admin_Ajax {
         if ( $game['pegi'] !== '' ) {
             $sanitized_pegi = JLG_Validator::sanitize_pegi( $game['pegi'] );
             $game['pegi']   = $sanitized_pegi !== null ? $sanitized_pegi : '';
+        }
+
+        if ( $game['cover_image'] !== '' ) {
+            if ( is_scalar( $game['cover_image'] ) ) {
+                $cover_value      = trim( (string) $game['cover_image'] );
+                $sanitized_cover  = esc_url_raw( $cover_value );
+                $is_valid_sanitize = is_string( $sanitized_cover ) && $sanitized_cover !== '' && filter_var( $sanitized_cover, FILTER_VALIDATE_URL );
+                $game['cover_image'] = $is_valid_sanitize ? $sanitized_cover : '';
+            } else {
+                $game['cover_image'] = '';
+            }
         }
 
         return $game;

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -419,6 +419,49 @@ class FrontendGameExplorerAjaxTest extends TestCase
         $this->assertSame('DESC', $contextTwo['sort_order']);
     }
 
+    public function test_handle_game_explorer_sort_injects_cover_image_markup(): void
+    {
+        $this->configureOptions();
+        $this->primeSnapshot($this->buildSnapshotWithPosts());
+
+        $this->registerPost(101, 'Alpha Quest', 'Alpha content for the cover test.', '2023-01-01 10:00:00');
+        $this->registerPost(202, 'Beta Strike', 'Beta content for the cover test.', '2023-01-05 11:30:00');
+
+        $GLOBALS['jlg_test_meta'] = [
+            101 => [
+                '_jlg_average_score'   => 8.5,
+                '_jlg_cover_image_url' => 'https://example.com/alpha.jpg',
+                '_jlg_date_sortie'     => '2023-02-14',
+                '_jlg_developpeur'     => 'Studio Alpha',
+                '_jlg_editeur'         => 'Publisher A',
+                '_jlg_plateformes'     => ['PC', 'PlayStation 5'],
+            ],
+            202 => [
+                '_jlg_average_score'   => 7.2,
+                '_jlg_cover_image_url' => '',
+                '_jlg_date_sortie'     => '2022-11-10',
+                '_jlg_developpeur'     => 'Studio Beta',
+                '_jlg_editeur'         => 'Publisher B',
+                '_jlg_plateformes'     => ['PC'],
+            ],
+        ];
+
+        $response = $this->dispatchExplorerAjax([
+            'nonce'          => 'nonce-jlg_game_explorer',
+            'container_id'   => 'cover-test',
+            'posts_per_page' => '6',
+            'columns'        => '3',
+            'filters'        => 'letter,category,platform,availability,search',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'paged'          => '1',
+        ]);
+
+        $this->assertArrayHasKey('html', $response);
+        $this->assertStringContainsString('https://example.com/alpha.jpg', $response['html']);
+        $this->assertStringContainsString('Visuel indisponible', $response['html']);
+    }
+
     public function test_score_position_modifier_reflects_configuration(): void
     {
         $this->configureOptions();


### PR DESCRIPTION
## Summary
- include RAWG background images in admin search results as a dedicated cover field and sanitize it
- populate the admin metabox cover input only when a valid URL is returned from the API
- add regression coverage ensuring Game Explorer markup outputs the stored cover image

## Testing
- `./vendor/bin/phpunit --filter FrontendGameExplorerAjaxTest`


------
https://chatgpt.com/codex/tasks/task_e_68dda2399d2c832e81dc28f42afba581