### PR TITLE
Add cover image handling to RAWG admin search

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
+++ b/plugin-notation-jeux_V4/assets/js/jlg-admin-api.js
@@ -155,7 +155,27 @@ jQuery(document).ready(function($) {
             $('#jlg_developpeur').val(gameData.developers);
             $('#jlg_editeur').val(gameData.publishers);
             $('#jlg_date_sortie').val(gameData.release_date);
-            $('#jlg_cover_image_url').val(gameData.cover_image);
+            var coverImage = '';
+            if (typeof gameData.cover_image === 'string') {
+                coverImage = gameData.cover_image.trim();
+            }
+
+            if (coverImage) {
+                var isValidCoverUrl = false;
+
+                try {
+                    var parsedCover = new URL(coverImage, window.location.origin);
+                    if (parsedCover.protocol === 'http:' || parsedCover.protocol === 'https:') {
+                        isValidCoverUrl = true;
+                    }
+                } catch (error) {
+                    isValidCoverUrl = false;
+                }
+
+                if (isValidCoverUrl) {
+                    $('#jlg_cover_image_url').val(coverImage);
+                }
+            }
             if (gameData.pegi) {
                 $('#jlg_pegi').val(gameData.pegi);
             }

--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -224,6 +224,14 @@ class JLG_Admin_Ajax {
             $pegi = $raw_game['esrb_rating']['name'];
         }
 
+        $cover_image = '';
+
+        if ( ! empty( $raw_game['background_image'] ) && is_string( $raw_game['background_image'] ) ) {
+            $cover_image = $raw_game['background_image'];
+        } elseif ( ! empty( $raw_game['background_image_additional'] ) && is_string( $raw_game['background_image_additional'] ) ) {
+            $cover_image = $raw_game['background_image_additional'];
+        }
+
         return array(
             'name'         => $raw_game['name'] ?? '',
             'release_date' => $raw_game['released'] ?? '',
@@ -231,6 +239,7 @@ class JLG_Admin_Ajax {
             'publishers'   => $publishers,
             'platforms'    => $platforms,
             'pegi'         => $pegi,
+            'cover_image'  => $cover_image,
         );
     }
 
@@ -242,6 +251,7 @@ class JLG_Admin_Ajax {
             'publishers'   => '',
             'platforms'    => array(),
             'pegi'         => '',
+            'cover_image'  => '',
         );
 
         $game = array_merge( $defaults, $game );
@@ -280,6 +290,18 @@ class JLG_Admin_Ajax {
             $sanitized_pegi = JLG_Validator::sanitize_pegi( $game['pegi'] );
             $game['pegi']   = $sanitized_pegi !== null ? $sanitized_pegi : '';
         }
+
+        $cover_image = '';
+
+        if ( is_string( $game['cover_image'] ) ) {
+            $sanitized_cover = esc_url_raw( $game['cover_image'] );
+
+            if ( is_string( $sanitized_cover ) && $sanitized_cover !== '' && filter_var( $sanitized_cover, FILTER_VALIDATE_URL ) ) {
+                $cover_image = $sanitized_cover;
+            }
+        }
+
+        $game['cover_image'] = $cover_image;
 
         return $game;
     }

--- a/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminAjaxSearchTest.php
@@ -87,6 +87,7 @@ class AdminAjaxSearchTest extends TestCase
                         [
                             'name' => 'Elden Ring',
                             'released' => '2022-02-25',
+                            'background_image' => 'https://example.com/elden-ring.jpg',
                             'developers' => [
                                 ['name' => 'FromSoftware'],
                             ],
@@ -130,6 +131,8 @@ class AdminAjaxSearchTest extends TestCase
             $this->assertSame(['Bandai Namco Entertainment'], $game['publishers']);
             $this->assertSame(['PC', 'PlayStation 5'], $game['platforms']);
             $this->assertSame('', $game['pegi']);
+            $this->assertArrayHasKey('cover_image', $game);
+            $this->assertSame('https://example.com/elden-ring.jpg', $game['cover_image']);
 
             $this->assertArrayHasKey('pagination', $exception->data);
             $this->assertSame(2, $exception->data['pagination']['current_page']);
@@ -162,6 +165,7 @@ class AdminAjaxSearchTest extends TestCase
             $this->assertArrayHasKey('games', $exception->data);
             $this->assertNotEmpty($exception->data['games']);
             $this->assertSame('The "Legend" & Co. - Résultat simulé', $exception->data['games'][0]['name']);
+            $this->assertSame('', $exception->data['games'][0]['cover_image']);
         }
     }
 }

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -479,6 +479,49 @@ class FrontendGameExplorerAjaxTest extends TestCase
         $this->assertSame('middle-right', $overrideResponse['config']['atts']['score_position'] ?? null);
     }
 
+    public function test_handle_game_explorer_sort_injects_cover_image_into_markup(): void
+    {
+        $this->configureOptions();
+        $this->primeSnapshot($this->buildSnapshotWithPosts());
+
+        $this->registerPost(101, 'Alpha Quest', 'Alpha content for the cover test.', '2023-01-01 10:00:00');
+        $this->registerPost(202, 'Beta Strike', 'Beta content for the cover test.', '2023-01-05 11:30:00');
+
+        $GLOBALS['jlg_test_meta'] = [
+            101 => [
+                '_jlg_average_score'   => 8.9,
+                '_jlg_cover_image_url' => 'https://example.com/alpha-cover.jpg',
+                '_jlg_date_sortie'     => '2023-02-14',
+                '_jlg_developpeur'     => 'Studio Alpha',
+                '_jlg_editeur'         => 'Publisher A',
+                '_jlg_plateformes'     => ['PC', 'PlayStation 5'],
+            ],
+            202 => [
+                '_jlg_average_score'   => 7.2,
+                '_jlg_cover_image_url' => '',
+                '_jlg_date_sortie'     => '2022-11-10',
+                '_jlg_developpeur'     => 'Studio Beta',
+                '_jlg_editeur'         => 'Publisher B',
+                '_jlg_plateformes'     => ['PC'],
+            ],
+        ];
+
+        $payload = $this->dispatchExplorerAjax([
+            'nonce'          => 'nonce-jlg_game_explorer',
+            'container_id'   => 'cover-test',
+            'posts_per_page' => '6',
+            'columns'        => '3',
+            'filters'        => 'letter,category,platform,availability,search',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'paged'          => '1',
+        ]);
+
+        $this->assertArrayHasKey('html', $payload);
+        $this->assertStringContainsString('src="https://example.com/alpha-cover.jpg"', $payload['html']);
+        $this->assertStringContainsString('Visuel indisponible', $payload['html']);
+    }
+
     private function dispatchExplorerAjax(array $post): array
     {
         $_POST = $post;


### PR DESCRIPTION
## Summary
- extract RAWG cover artwork from API responses and expose it in normalized results
- validate and normalize the cover URL before returning it to the admin UI
- update the admin picker to keep any existing cover value unless a valid URL is received and add coverage for the injected artwork markup

## Testing
- `composer test` *(fails: ShortcodeSummarySortingTest::test_letter_filter_buttons_submit_namespaced_values)*
- `./vendor/bin/phpunit tests/AdminAjaxSearchTest.php tests/FrontendGameExplorerAjaxTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68dda2146f00832eb82042856ae36d6e