### PR TITLE
Avoid rendering score suffix for unrated games

### DIFF
--- a/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-frontend.php
@@ -1617,6 +1617,8 @@ class JLG_Frontend {
                 'platforms_list'       => array(),
                 'availability_options' => array(),
                 'base_url'             => '',
+                'request_prefix'       => '',
+                'request_keys'         => array(),
                 'total_items'          => 0,
                 'config_payload'       => array(),
                 'message'              => '',

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -1018,6 +1018,7 @@ class JLG_Shortcode_Game_Explorer {
 
                 $score_data    = JLG_Helpers::get_resolved_average_score( $post_id );
                 $score_value   = isset( $score_data['value'] ) ? $score_data['value'] : null;
+                $has_score     = is_numeric( $score_value );
                 $score_display = isset( $score_data['formatted'] ) && $score_data['formatted'] !== ''
                     ? $score_data['formatted']
                     : esc_html__( 'N/A', 'notation-jlg' );
@@ -1067,6 +1068,7 @@ class JLG_Shortcode_Game_Explorer {
                     'title'              => $title,
                     'permalink'          => get_permalink( $post_id ),
                     'score_value'        => $score_value,
+                    'has_score'          => $has_score,
                     'score_display'      => $score_display,
                     'score_color'        => $score_color,
                     'cover_url'          => $cover_url,

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -30,6 +30,9 @@ if ( empty( $games ) ) {
         $title               = isset( $game['title'] ) ? $game['title'] : '';
         $score_display       = isset( $game['score_display'] ) ? $game['score_display'] : '';
         $score_color         = isset( $game['score_color'] ) ? $game['score_color'] : '';
+        $has_score           = isset( $game['has_score'] )
+            ? (bool) $game['has_score']
+            : ( isset( $game['score_value'] ) && is_numeric( $game['score_value'] ) );
         $cover_url           = isset( $game['cover_url'] ) ? $game['cover_url'] : '';
         $release_display     = isset( $game['release_display'] ) ? $game['release_display'] : '';
         $developer           = isset( $game['developer'] ) ? $game['developer'] : '';
@@ -50,7 +53,9 @@ if ( empty( $games ) ) {
                 <?php if ( $score_display !== '' ) : ?>
                     <span class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $score_classes ) ) ); ?>" style="--jlg-ge-score-color: <?php echo esc_attr( $score_color ); ?>;">
                         <?php echo esc_html( $score_display ); ?>
-                        <span class="jlg-ge-card__score-outof">/10</span>
+                        <?php if ( $has_score ) : ?>
+                            <span class="jlg-ge-card__score-outof">/10</span>
+                        <?php endif; ?>
                     </span>
                 <?php endif; ?>
             </a>

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512) {
+        return json_encode($data, $options, $depth);
+    }
+}
+
+require_once __DIR__ . '/../includes/class-jlg-frontend.php';
+
+class ShortcodeGameExplorerScoreDisplayTest extends TestCase
+{
+    public function test_does_not_render_outof_suffix_when_score_is_missing(): void
+    {
+        $output = $this->renderExplorerWithGame([
+            'score_display' => 'N/A',
+            'score_value' => null,
+            'has_score' => false,
+        ]);
+
+        $this->assertStringContainsString(
+            'jlg-ge-card__score',
+            $output,
+            'The score container should still be rendered even without a numeric score.'
+        );
+
+        $this->assertStringNotContainsString(
+            'jlg-ge-card__score-outof',
+            $output,
+            'The "/10" suffix should not be displayed when no numeric score is available.'
+        );
+    }
+
+    public function test_renders_outof_suffix_when_score_is_numeric(): void
+    {
+        $output = $this->renderExplorerWithGame([
+            'score_display' => '8.5',
+            'score_value' => 8.5,
+            'has_score' => true,
+        ]);
+
+        $this->assertStringContainsString(
+            '<span class="jlg-ge-card__score-outof">/10</span>',
+            $output,
+            'The "/10" suffix should be rendered when a numeric score is available.'
+        );
+    }
+
+    private function renderExplorerWithGame(array $overrides): string
+    {
+        $game = array_merge(
+            [
+                'post_id' => 123,
+                'title' => 'Test Game',
+                'permalink' => 'https://example.com/game',
+                'score_color' => '#f97316',
+                'score_display' => 'N/A',
+                'score_value' => null,
+                'has_score' => false,
+                'cover_url' => '',
+                'release_display' => '',
+                'developer' => '',
+                'publisher' => '',
+                'platforms' => [],
+                'genre' => '',
+                'availability_label' => '',
+                'availability' => '',
+                'excerpt' => '',
+            ],
+            $overrides
+        );
+
+        return JLG_Frontend::get_template_html('shortcode-game-explorer', [
+            'atts' => [
+                'id' => 'test-explorer',
+                'posts_per_page' => 12,
+                'columns' => 3,
+            ],
+            'config_payload' => [
+                'atts' => [
+                    'id' => 'test-explorer',
+                    'posts_per_page' => 12,
+                    'columns' => 3,
+                    'score_position' => 'bottom-right',
+                    'filters' => '',
+                    'categorie' => '',
+                    'plateforme' => '',
+                    'lettre' => '',
+                ],
+                'state' => [
+                    'orderby' => 'date',
+                    'order' => 'DESC',
+                    'letter' => '',
+                    'category' => '',
+                    'platform' => '',
+                    'availability' => '',
+                    'search' => '',
+                    'paged' => 1,
+                    'total_items' => 1,
+                ],
+            ],
+            'games' => [$game],
+            'pagination' => [
+                'current' => 1,
+                'total' => 1,
+            ],
+            'filters_enabled' => [],
+            'current_filters' => [],
+            'letters' => [],
+            'sort_options' => [],
+            'categories_list' => [],
+            'platforms_list' => [],
+            'availability_options' => [],
+            'total_items' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add an explicit has_score flag when building Game Explorer cards and expose it in the template defaults
- hide the “/10” suffix for cards without a numeric score while keeping the score badge visible
- cover the new behaviour with a PHPUnit test verifying both scored and unscored games

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dda24abd4c832eb5de7f716d4d70e5