### PR TITLE
Enable GET navigation for Game Explorer filters

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -58,7 +58,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - `[jlg_points_forts_faibles]` - Points positifs et négatifs
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
 - `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les en-têtes permettent désormais de trier par titre, date, note moyenne ainsi que par métadonnées développeur/éditeur via les paramètres `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
-- `[jlg_game_explorer]` - Game Explorer interactif affichant vos tests sous forme de cartes. Attributs disponibles : `posts_per_page` (nombre d'entrées par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `availability`), `categorie`, `plateforme` et `lettre` pour préfiltrer le rendu.
+- `[jlg_game_explorer]` - Game Explorer interactif affichant vos tests sous forme de cartes. Attributs disponibles : `posts_per_page` (nombre d'entrées par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `availability`), `categorie`, `plateforme` et `lettre` pour préfiltrer le rendu. La navigation (lettres, filtres, tri et pagination) fonctionne désormais également sans JavaScript via des requêtes GET accessibles.
 
 ### Utilisation dans les widgets et blocs
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -55,7 +55,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * `[jlg_points_forts_faibles]` - Points positifs et négatifs
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs
 * `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les entêtes sont triables par titre, date, note moyenne et métadonnées développeur/éditeur via `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
-* `[jlg_game_explorer]` - Game Explorer interactif avec cartes et filtres dynamiques. Attributs : `posts_per_page` (nombre d'articles par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `availability`), `categorie`, `plateforme` et `lettre` pour forcer un filtrage initial.
+* `[jlg_game_explorer]` - Game Explorer interactif avec cartes et filtres dynamiques. Attributs : `posts_per_page` (nombre d'articles par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `availability`), `categorie`, `plateforme` et `lettre` pour forcer un filtrage initial. La navigation (lettres, filtres, tri et pagination) reste pleinement fonctionnelle sans JavaScript grâce à des requêtes GET accessibles.
 
 == Utilisation dans les widgets et blocs ==
 

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -485,7 +485,10 @@
         }
 
         if (refs.resetButton) {
-            refs.resetButton.addEventListener('click', () => {
+            refs.resetButton.addEventListener('click', (event) => {
+                if (event && typeof event.preventDefault === 'function') {
+                    event.preventDefault();
+                }
                 config.state = Object.assign({}, defaultState);
                 config.state.paged = 1;
                 writeConfig(container, config);

--- a/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/includes/shortcodes/class-jlg-shortcode-game-explorer.php
@@ -749,6 +749,16 @@ class JLG_Shortcode_Game_Explorer {
 
         $request = self::extract_request_params( $request, $request_keys );
 
+        if ( isset( $request['orderby'] ) && is_string( $request['orderby'] ) && strpos( $request['orderby'], '|' ) !== false ) {
+            $parts = array_map( 'trim', explode( '|', $request['orderby'] ) );
+            if ( isset( $parts[0] ) && $parts[0] !== '' ) {
+                $request['orderby'] = $parts[0];
+            }
+            if ( isset( $parts[1] ) && $parts[1] !== '' ) {
+                $request['order'] = $parts[1];
+            }
+        }
+
         $options        = JLG_Helpers::get_plugin_options();
         $posts_per_page = isset( $atts['posts_per_page'] ) ? (int) $atts['posts_per_page'] : $defaults['posts_per_page'];
         if ( $posts_per_page < 1 ) {

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -41,6 +41,84 @@ $category_active         = isset( $current_filters['category'] ) ? $current_filt
 $platform_active         = isset( $current_filters['platform'] ) ? $current_filters['platform'] : '';
 $availability_active     = isset( $current_filters['availability'] ) ? $current_filters['availability'] : '';
 $search_active           = isset( $current_filters['search'] ) ? $current_filters['search'] : '';
+$request_keys            = is_array( $request_keys ) ? $request_keys : array();
+$namespaced_keys         = array(
+    'orderby'      => isset( $request_keys['orderby'] ) ? $request_keys['orderby'] : 'orderby',
+    'order'        => isset( $request_keys['order'] ) ? $request_keys['order'] : 'order',
+    'letter'       => isset( $request_keys['letter'] ) ? $request_keys['letter'] : 'letter',
+    'category'     => isset( $request_keys['category'] ) ? $request_keys['category'] : 'category',
+    'platform'     => isset( $request_keys['platform'] ) ? $request_keys['platform'] : 'platform',
+    'availability' => isset( $request_keys['availability'] ) ? $request_keys['availability'] : 'availability',
+    'search'       => isset( $request_keys['search'] ) ? $request_keys['search'] : 'search',
+    'paged'        => isset( $request_keys['paged'] ) ? $request_keys['paged'] : 'paged',
+);
+
+$active_query_params = array();
+
+if ( $sort_key !== '' ) {
+    $active_query_params[ $namespaced_keys['orderby'] ] = $sort_key . '|' . $sort_order;
+}
+
+if ( $sort_order !== '' ) {
+    $active_query_params[ $namespaced_keys['order'] ] = $sort_order;
+}
+
+$filter_values = array(
+    'letter'       => $letter_active,
+    'category'     => $category_active,
+    'platform'     => $platform_active,
+    'availability' => $availability_active,
+    'search'       => $search_active,
+);
+
+foreach ( $filter_values as $filter_key => $filter_value ) {
+    if ( $filter_value === '' || ! isset( $namespaced_keys[ $filter_key ] ) ) {
+        continue;
+    }
+
+    $active_query_params[ $namespaced_keys[ $filter_key ] ] = (string) $filter_value;
+}
+
+if ( isset( $pagination['current'] ) && (int) $pagination['current'] > 1 && isset( $namespaced_keys['paged'] ) ) {
+    $active_query_params[ $namespaced_keys['paged'] ] = (string) (int) $pagination['current'];
+}
+
+$prepare_hidden_params = static function( array $exclude = array(), array $overrides = array() ) use ( $active_query_params ) {
+    $params = $active_query_params;
+
+    foreach ( $exclude as $exclude_key ) {
+        unset( $params[ $exclude_key ] );
+    }
+
+    foreach ( $overrides as $key => $value ) {
+        if ( $value === null ) {
+            unset( $params[ $key ] );
+            continue;
+        }
+
+        $params[ $key ] = (string) $value;
+    }
+
+    return $params;
+};
+
+$render_hidden_inputs = static function( array $params ) {
+    foreach ( $params as $name => $value ) {
+        $value_string = (string) $value;
+
+        if ( $value_string === '' ) {
+            continue;
+        }
+
+        printf(
+            '<input type="hidden" name="%1$s" value="%2$s">',
+            esc_attr( $name ),
+            esc_attr( $value_string )
+        );
+    }
+};
+
+$reset_url = remove_query_arg( array_values( $namespaced_keys ) );
 ?>
 
 <div
@@ -56,69 +134,103 @@ $search_active           = isset( $current_filters['search'] ) ? $current_filter
         <div class="jlg-ge-toolbar__left">
             <?php if ( ! empty( $filters_enabled['letter'] ) && ! empty( $letters ) ) : ?>
                 <nav class="jlg-ge-letter-nav" aria-label="<?php esc_attr_e( 'Filtrer par lettre', 'notation-jlg' ); ?>">
-                    <ul>
-                        <li>
-                            <?php
-                            $all_letters_classes = array();
-                            if ( $letter_active === '' ) {
-                                $all_letters_classes[] = 'is-active';
-                            }
-                            ?>
-                            <button
-                                type="button"
-                                class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
-                                data-letter=""
-                                aria-pressed="<?php echo esc_attr( $letter_active === '' ? 'true' : 'false' ); ?>"
-                            >
-                                <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
-                            </button>
-                        </li>
+                    <form method="get" class="jlg-ge-letter-nav__form">
                         <?php
-                        foreach ( $letters as $letter_item ) :
-                            $value     = isset( $letter_item['value'] ) ? $letter_item['value'] : '';
-                            $enabled   = ! empty( $letter_item['enabled'] );
-                            $is_active = ( $value !== '' && $value === $letter_active );
-                            ?>
+                        $letter_hidden_inputs = $prepare_hidden_params(
+                            array(
+                                $namespaced_keys['letter'],
+                                $namespaced_keys['paged'],
+                            )
+                        );
+                        $render_hidden_inputs( $letter_hidden_inputs );
+                        ?>
+                        <ul>
                             <li>
                                 <?php
-                                $letter_button_classes = array();
-                                if ( $is_active ) {
-                                    $letter_button_classes[] = 'is-active';
+                                $all_letters_classes = array();
+                                if ( $letter_active === '' ) {
+                                    $all_letters_classes[] = 'is-active';
                                 }
                                 ?>
                                 <button
-                                    type="button"
-                                    data-letter="<?php echo esc_attr( $value ); ?>"
-                                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
-                                    <?php disabled( ! $enabled ); ?>
-                                    aria-pressed="<?php echo esc_attr( $is_active ? 'true' : 'false' ); ?>"
+                                    type="submit"
+                                    class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $all_letters_classes ) ) ); ?>"
+                                    data-letter=""
+                                    name="<?php echo esc_attr( $namespaced_keys['letter'] ); ?>"
+                                    value=""
+                                    aria-pressed="<?php echo esc_attr( $letter_active === '' ? 'true' : 'false' ); ?>"
                                 >
-                                    <?php echo esc_html( $letter_item['label'] ?? $value ); ?>
+                                    <?php esc_html_e( 'Tous', 'notation-jlg' ); ?>
                                 </button>
                             </li>
-                        <?php endforeach; ?>
-                    </ul>
+                            <?php
+                            foreach ( $letters as $letter_item ) :
+                                $value     = isset( $letter_item['value'] ) ? $letter_item['value'] : '';
+                                $enabled   = ! empty( $letter_item['enabled'] );
+                                $is_active = ( $value !== '' && $value === $letter_active );
+                                ?>
+                                <li>
+                                    <?php
+                                    $letter_button_classes = array();
+                                    if ( $is_active ) {
+                                        $letter_button_classes[] = 'is-active';
+                                    }
+                                    ?>
+                                    <button
+                                        type="submit"
+                                        data-letter="<?php echo esc_attr( $value ); ?>"
+                                        class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $letter_button_classes ) ) ); ?>"
+                                        name="<?php echo esc_attr( $namespaced_keys['letter'] ); ?>"
+                                        value="<?php echo esc_attr( $value ); ?>"
+                                        <?php disabled( ! $enabled ); ?>
+                                        aria-pressed="<?php echo esc_attr( $is_active ? 'true' : 'false' ); ?>"
+                                    >
+                                        <?php echo esc_html( $letter_item['label'] ?? $value ); ?>
+                                    </button>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </form>
                 </nav>
             <?php endif; ?>
         </div>
         <div class="jlg-ge-toolbar__right">
             <div class="jlg-ge-sort">
-                <label for="<?php echo esc_attr( $container_id ); ?>-sort">
-                    <?php esc_html_e( 'Trier par', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-sort" data-role="sort">
+                <form method="get" class="jlg-ge-sort__form">
                     <?php
-                    foreach ( $sort_options as $option ) :
-                        $value          = isset( $option['value'] ) ? $option['value'] : '';
-                        $option_orderby = isset( $option['orderby'] ) ? $option['orderby'] : '';
-                        $option_order   = isset( $option['order'] ) ? $option['order'] : '';
-                        $selected       = ( $option_orderby === $sort_key && $option_order === $sort_order );
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected ); ?>>
-                            <?php echo esc_html( $option['label'] ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
+                    $sort_hidden_inputs = $prepare_hidden_params(
+                        array(
+                            $namespaced_keys['orderby'],
+                            $namespaced_keys['order'],
+                            $namespaced_keys['paged'],
+                        )
+                    );
+                    $render_hidden_inputs( $sort_hidden_inputs );
+                    ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-sort">
+                        <?php esc_html_e( 'Trier par', 'notation-jlg' ); ?>
+                    </label>
+                    <select
+                        id="<?php echo esc_attr( $container_id ); ?>-sort"
+                        name="<?php echo esc_attr( $namespaced_keys['orderby'] ); ?>"
+                        data-role="sort"
+                    >
+                        <?php
+                        foreach ( $sort_options as $option ) :
+                            $value          = isset( $option['value'] ) ? $option['value'] : '';
+                            $option_orderby = isset( $option['orderby'] ) ? $option['orderby'] : '';
+                            $option_order   = isset( $option['order'] ) ? $option['order'] : '';
+                            $selected       = ( $option_orderby === $sort_key && $option_order === $sort_order );
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected ); ?>>
+                                <?php echo esc_html( $option['label'] ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit" class="jlg-ge-sort__submit">
+                        <?php esc_html_e( 'Appliquer', 'notation-jlg' ); ?>
+                    </button>
+                </form>
             </div>
             <div class="jlg-ge-count">
                 <?php
@@ -135,80 +247,112 @@ $search_active           = isset( $current_filters['search'] ) ? $current_filter
 
     <?php if ( $has_filters ) : ?>
         <div class="jlg-ge-filters" data-role="filters">
-            <?php if ( $has_category_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-category" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-category" data-role="category">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les catégories', 'notation-jlg' ); ?>
-                    </option>
-                    <?php
-                    foreach ( $categories_list as $category ) :
-                        $value = isset( $category['value'] ) ? (string) $category['value'] : '';
-                        $label = isset( $category['label'] ) ? $category['label'] : $value;
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $category_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_platform_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-platform" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par plateforme', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-platform" data-role="platform">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les plateformes', 'notation-jlg' ); ?>
-                    </option>
-                    <?php
-                    foreach ( $platforms_list as $platform ) :
-                        $value = isset( $platform['value'] ) ? (string) $platform['value'] : '';
-                        $label = isset( $platform['label'] ) ? $platform['label'] : $value;
-                        ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $platform_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_availability_filter ) : ?>
-                <label for="<?php echo esc_attr( $container_id ); ?>-availability" class="screen-reader-text">
-                    <?php esc_html_e( 'Filtrer par disponibilité', 'notation-jlg' ); ?>
-                </label>
-                <select id="<?php echo esc_attr( $container_id ); ?>-availability" data-role="availability">
-                    <option value="">
-                        <?php esc_html_e( 'Toutes les sorties', 'notation-jlg' ); ?>
-                    </option>
-                    <?php foreach ( $availability_options as $value => $label ) : ?>
-                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $availability_active, $value ); ?>>
-                            <?php echo esc_html( $label ); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php endif; ?>
-
-            <?php if ( $has_search_filter ) : ?>
-                <div class="jlg-ge-search">
-                    <label for="<?php echo esc_attr( $container_id ); ?>-search">
-                        <?php esc_html_e( 'Rechercher un jeu', 'notation-jlg' ); ?>
+            <form method="get" class="jlg-ge-filters__form">
+                <?php
+                $filters_hidden_inputs = $prepare_hidden_params(
+                    array(
+                        $namespaced_keys['category'],
+                        $namespaced_keys['platform'],
+                        $namespaced_keys['availability'],
+                        $namespaced_keys['search'],
+                        $namespaced_keys['paged'],
+                    )
+                );
+                $render_hidden_inputs( $filters_hidden_inputs );
+                ?>
+                <?php if ( $has_category_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-category" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par catégorie', 'notation-jlg' ); ?>
                     </label>
-                    <input
-                        type="search"
-                        id="<?php echo esc_attr( $container_id ); ?>-search"
-                        data-role="search"
-                        value="<?php echo esc_attr( $search_active ); ?>"
-                        placeholder="<?php echo esc_attr__( 'Rechercher…', 'notation-jlg' ); ?>"
+                    <select
+                        id="<?php echo esc_attr( $container_id ); ?>-category"
+                        name="<?php echo esc_attr( $namespaced_keys['category'] ); ?>"
+                        data-role="category"
                     >
-                </div>
-            <?php endif; ?>
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les catégories', 'notation-jlg' ); ?>
+                        </option>
+                        <?php
+                        foreach ( $categories_list as $category ) :
+                            $value = isset( $category['value'] ) ? (string) $category['value'] : '';
+                            $label = isset( $category['label'] ) ? $category['label'] : $value;
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $category_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
 
-            <button type="button" class="jlg-ge-reset" data-role="reset">
-                <?php esc_html_e( 'Réinitialiser', 'notation-jlg' ); ?>
-            </button>
+                <?php if ( $has_platform_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-platform" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par plateforme', 'notation-jlg' ); ?>
+                    </label>
+                    <select
+                        id="<?php echo esc_attr( $container_id ); ?>-platform"
+                        name="<?php echo esc_attr( $namespaced_keys['platform'] ); ?>"
+                        data-role="platform"
+                    >
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les plateformes', 'notation-jlg' ); ?>
+                        </option>
+                        <?php
+                        foreach ( $platforms_list as $platform ) :
+                            $value = isset( $platform['value'] ) ? (string) $platform['value'] : '';
+                            $label = isset( $platform['label'] ) ? $platform['label'] : $value;
+                            ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $platform_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
+
+                <?php if ( $has_availability_filter ) : ?>
+                    <label for="<?php echo esc_attr( $container_id ); ?>-availability" class="screen-reader-text">
+                        <?php esc_html_e( 'Filtrer par disponibilité', 'notation-jlg' ); ?>
+                    </label>
+                    <select
+                        id="<?php echo esc_attr( $container_id ); ?>-availability"
+                        name="<?php echo esc_attr( $namespaced_keys['availability'] ); ?>"
+                        data-role="availability"
+                    >
+                        <option value="">
+                            <?php esc_html_e( 'Toutes les sorties', 'notation-jlg' ); ?>
+                        </option>
+                        <?php foreach ( $availability_options as $value => $label ) : ?>
+                            <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $availability_active, $value ); ?>>
+                                <?php echo esc_html( $label ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                <?php endif; ?>
+
+                <?php if ( $has_search_filter ) : ?>
+                    <div class="jlg-ge-search">
+                        <label for="<?php echo esc_attr( $container_id ); ?>-search">
+                            <?php esc_html_e( 'Rechercher un jeu', 'notation-jlg' ); ?>
+                        </label>
+                        <input
+                            type="search"
+                            id="<?php echo esc_attr( $container_id ); ?>-search"
+                            name="<?php echo esc_attr( $namespaced_keys['search'] ); ?>"
+                            data-role="search"
+                            value="<?php echo esc_attr( $search_active ); ?>"
+                            placeholder="<?php echo esc_attr__( 'Rechercher…', 'notation-jlg' ); ?>"
+                        >
+                    </div>
+                <?php endif; ?>
+
+                <div class="jlg-ge-filters__actions">
+                    <button type="submit" class="jlg-ge-filters__submit">
+                        <?php esc_html_e( 'Appliquer les filtres', 'notation-jlg' ); ?>
+                    </button>
+                    <a class="jlg-ge-reset" data-role="reset" href="<?php echo esc_url( $reset_url ); ?>">
+                        <?php esc_html_e( 'Réinitialiser', 'notation-jlg' ); ?>
+                    </a>
+                </div>
+            </form>
         </div>
     <?php endif; ?>
 
@@ -223,11 +367,16 @@ $search_active           = isset( $current_filters['search'] ) ? $current_filter
         echo JLG_Frontend::get_template_html(
             'game-explorer-fragment',
             array(
-				'games'       => $games,
-				'message'     => isset( $message ) ? $message : '',
-				'pagination'  => $pagination,
-				'total_items' => $total_items,
-			)
+                                'games'           => $games,
+                                'message'         => isset( $message ) ? $message : '',
+                                'pagination'      => $pagination,
+                                'total_items'     => $total_items,
+                                'current_filters' => $current_filters,
+                                'request_keys'    => $request_keys,
+                                'sort_key'        => $sort_key,
+                                'sort_order'      => $sort_order,
+                                'query_params'    => $active_query_params,
+                        )
         );
         ?>
     </div>


### PR DESCRIPTION
## Summary
- replace the Game Explorer letter, filter, sort, and pagination controls with GET-based forms so navigation works without JavaScript
- update the shortcode context and fragment template to propagate query parameters and split combined sort values on the server
- document the no-JavaScript fallback for the Game Explorer

## Testing
- php -l plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
- php -l plugin-notation-jeux_V4/templates/game-explorer-fragment.php


------
https://chatgpt.com/codex/tasks/task_e_68dda24300bc832e9556945e99fd8063