### PR TITLE
Add REST controller tests and bootstrap stubs

### DIFF
--- a/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
+++ b/plugin-notation-jeux_V4/includes/admin/class-jlg-admin-ajax.php
@@ -10,66 +10,26 @@ class JLG_Admin_Ajax {
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_ajax_assets' ) );
     }
 
-    public function enqueue_admin_ajax_assets( $hook_suffix ) {
-        $allowed_hooks = array(
-            'post.php',
-            'post-new.php',
-            'toplevel_page_notation_jlg_settings',
-        );
+    public static function process_rawg_search( array $params ) {
+        $search_term = isset( $params['search'] ) ? sanitize_text_field( (string) self::maybe_scalar( $params['search'] ) ) : '';
 
-        if ( ! in_array( $hook_suffix, $allowed_hooks, true ) ) {
-            return;
-        }
-
-        $script_handle = 'jlg-admin-api';
-        $script_url    = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js';
-        $version       = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
-
-        wp_register_script( $script_handle, $script_url, array( 'jquery' ), $version, true );
-
-        wp_localize_script(
-            $script_handle,
-            'jlg_admin_ajax',
-            array(
-				'nonce'    => wp_create_nonce( 'jlg_admin_ajax_nonce' ),
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
-			)
-        );
-
-        wp_enqueue_script( $script_handle );
-    }
-
-    public function handle_rawg_search() {
-        check_ajax_referer( 'jlg_admin_ajax_nonce', 'nonce' );
-
-        // Sécurité basique
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error(
-                array(
-					'message' => __( 'Permissions insuffisantes.', 'notation-jlg' ),
-                ),
-                403
+        if ( $search_term === '' ) {
+            return new WP_Error(
+                'jlg_rawg_empty_search',
+                __( 'Terme de recherche vide.', 'notation-jlg' ),
+                array( 'status' => 400 )
             );
         }
 
-        $search_term = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
-
-        if ( empty( $search_term ) ) {
-            wp_send_json_error(
-                array(
-					'message' => __( 'Terme de recherche vide.', 'notation-jlg' ),
-                ),
-                400
-            );
+        $page = isset( $params['page'] ) ? absint( self::maybe_scalar( $params['page'] ) ) : 1;
+        if ( $page < 1 ) {
+            $page = 1;
         }
-
-        $page = isset( $_POST['page'] ) ? max( 1, absint( wp_unslash( $_POST['page'] ) ) ) : 1;
 
         $options = JLG_Helpers::get_plugin_options();
         $api_key = isset( $options['rawg_api_key'] ) ? sanitize_text_field( (string) $options['rawg_api_key'] ) : '';
 
         if ( $api_key === '' ) {
-            // Simulation de réponse si aucune clé n'est configurée.
             $mock_games = array(
                 array(
                     'name'         => $search_term . ' - Résultat simulé',
@@ -81,13 +41,11 @@ class JLG_Admin_Ajax {
                 ),
             );
 
-            $normalized_games = array_map( array( $this, 'normalize_game_fields' ), $mock_games );
+            $normalized_games = array_map( array( __CLASS__, 'normalize_game_fields' ), $mock_games );
 
-            wp_send_json_success(
-                array(
-					'games'   => $normalized_games,
-					'message' => __( 'Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg' ),
-                )
+            return array(
+                'games'   => $normalized_games,
+                'message' => __( 'Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels.', 'notation-jlg' ),
             );
         }
 
@@ -95,7 +53,7 @@ class JLG_Admin_Ajax {
         $cached_payload = get_transient( $cache_key );
 
         if ( $cached_payload !== false && is_array( $cached_payload ) ) {
-            wp_send_json_success( $cached_payload );
+            return $cached_payload;
         }
 
         $endpoint   = 'https://api.rawg.io/api/games';
@@ -120,27 +78,25 @@ class JLG_Admin_Ajax {
 
         $response = wp_remote_get( add_query_arg( $query_args, $endpoint ), $request_args );
 
-        if ( function_exists( 'is_wp_error' ) && is_wp_error( $response ) ) {
-            wp_send_json_error(
-                array(
-					'message' => __( 'Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement.', 'notation-jlg' ),
-                ),
-                502
+        if ( is_wp_error( $response ) ) {
+            return new WP_Error(
+                'jlg_rawg_http_error',
+                __( 'Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement.', 'notation-jlg' ),
+                array( 'status' => 502 )
             );
         }
 
         $status_code = (int) wp_remote_retrieve_response_code( $response );
 
         if ( $status_code < 200 || $status_code >= 300 ) {
-            wp_send_json_error(
-                array(
-					'message' => sprintf(
-						/* translators: %d: HTTP status code returned by RAWG.io */
-						__( 'La requête RAWG.io a échoué avec le code HTTP %d.', 'notation-jlg' ),
-						$status_code
-					),
+            return new WP_Error(
+                'jlg_rawg_bad_status',
+                sprintf(
+                    /* translators: %d: HTTP status code returned by RAWG.io */
+                    __( 'La requête RAWG.io a échoué avec le code HTTP %d.', 'notation-jlg' ),
+                    $status_code
                 ),
-                $status_code ?: 500
+                array( 'status' => $status_code ?: 500 )
             );
         }
 
@@ -148,27 +104,26 @@ class JLG_Admin_Ajax {
         $decoded = json_decode( $body, true );
 
         if ( ! is_array( $decoded ) ) {
-            wp_send_json_error(
-                array(
-					'message' => __( 'Réponse RAWG.io invalide : données JSON non valides.', 'notation-jlg' ),
-                ),
-                502
+            return new WP_Error(
+                'jlg_rawg_invalid_body',
+                __( 'Réponse RAWG.io invalide : données JSON non valides.', 'notation-jlg' ),
+                array( 'status' => 502 )
             );
         }
 
         $raw_results = array();
         if ( ! empty( $decoded['results'] ) && is_array( $decoded['results'] ) ) {
-            $raw_results = array_map( array( $this, 'transform_rawg_game' ), $decoded['results'] );
+            $raw_results = array_map( array( __CLASS__, 'transform_rawg_game' ), $decoded['results'] );
         }
 
-        $normalized_games = array_map( array( $this, 'normalize_game_fields' ), $raw_results );
+        $normalized_games = array_map( array( __CLASS__, 'normalize_game_fields' ), $raw_results );
 
         $payload = array(
             'games'      => $normalized_games,
             'pagination' => array(
                 'current_page'  => $page,
-                'next_page'     => $this->extract_rawg_page( $decoded['next'] ?? '' ),
-                'prev_page'     => $this->extract_rawg_page( $decoded['previous'] ?? '' ),
+                'next_page'     => self::extract_rawg_page( $decoded['next'] ?? '' ),
+                'prev_page'     => self::extract_rawg_page( $decoded['previous'] ?? '' ),
                 'total_results' => isset( $decoded['count'] ) ? (int) $decoded['count'] : null,
             ),
             'message'    => __( 'Résultats récupérés depuis RAWG.io.', 'notation-jlg' ),
@@ -176,10 +131,94 @@ class JLG_Admin_Ajax {
 
         set_transient( $cache_key, $payload, 15 * MINUTE_IN_SECONDS );
 
-        wp_send_json_success( $payload );
+        return $payload;
     }
 
-    private function transform_rawg_game( array $raw_game ) {
+    public function enqueue_admin_ajax_assets( $hook_suffix ) {
+        $allowed_hooks = array(
+            'post.php',
+            'post-new.php',
+            'toplevel_page_notation_jlg_settings',
+        );
+
+        if ( ! in_array( $hook_suffix, $allowed_hooks, true ) ) {
+            return;
+        }
+
+        $script_handle = 'jlg-admin-api';
+        $script_url    = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-admin-api.js';
+        $version       = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
+
+        wp_register_script( $script_handle, $script_url, array( 'jquery' ), $version, true );
+
+        wp_localize_script(
+            $script_handle,
+            'jlg_admin_ajax',
+            array(
+                                'nonce'     => wp_create_nonce( 'jlg_admin_ajax_nonce' ),
+                                'ajax_url'  => admin_url( 'admin-ajax.php' ),
+                                'restUrl'   => esc_url_raw( rest_url( 'jlg/v1/rawg-search' ) ),
+                                'restPath'  => 'jlg/v1/rawg-search',
+                                'restNonce' => wp_create_nonce( 'wp_rest' ),
+                        )
+        );
+
+        wp_enqueue_script( $script_handle );
+    }
+
+    public function handle_rawg_search() {
+        check_ajax_referer( 'jlg_admin_ajax_nonce', 'nonce' );
+
+        // Sécurité basique
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error(
+                array(
+                                        'message' => __( 'Permissions insuffisantes.', 'notation-jlg' ),
+                ),
+                403
+            );
+        }
+
+        $payload = isset( $_POST ) ? wp_unslash( $_POST ) : array();
+        if ( ! is_array( $payload ) ) {
+            $payload = array();
+        }
+
+        $result = self::process_rawg_search( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            $status = $result->get_error_data();
+
+            if ( is_array( $status ) && isset( $status['status'] ) ) {
+                $status = (int) $status['status'];
+            } elseif ( ! is_numeric( $status ) ) {
+                $status = 400;
+            }
+
+            wp_send_json_error(
+                array(
+                                        'message' => $result->get_error_message(),
+                ),
+                (int) $status
+            );
+        }
+
+        wp_send_json_success( $result );
+    }
+
+    private static function maybe_scalar( $value ) {
+        if ( is_array( $value ) ) {
+            $value = reset( $value );
+        }
+
+        if ( is_scalar( $value ) || $value === null ) {
+            return $value;
+        }
+
+        return '';
+    }
+
+    private static function transform_rawg_game( array $raw_game ) {
         $developers = array();
         if ( ! empty( $raw_game['developers'] ) && is_array( $raw_game['developers'] ) ) {
             foreach ( $raw_game['developers'] as $developer ) {
@@ -256,7 +295,7 @@ class JLG_Admin_Ajax {
         );
     }
 
-    private function normalize_game_fields( array $game ) {
+    private static function normalize_game_fields( array $game ) {
         $defaults = array(
             'name'         => '',
             'release_date' => '',
@@ -318,7 +357,7 @@ class JLG_Admin_Ajax {
         return $game;
     }
 
-    private function extract_rawg_page( $url ) {
+    private static function extract_rawg_page( $url ) {
         if ( ! is_string( $url ) || $url === '' ) {
             return null;
         }

--- a/plugin-notation-jeux_V4/includes/class-jlg-assets.php
+++ b/plugin-notation-jeux_V4/includes/class-jlg-assets.php
@@ -149,12 +149,15 @@ class JLG_Assets {
             'jlg-game-explorer',
             'jlgGameExplorerL10n',
             function () {
-				return array(
-					'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-					'nonce'   => wp_create_nonce( 'jlg_game_explorer' ),
-					'strings' => array(
-						'loading'       => esc_html__( 'Chargement des jeux...', 'notation-jlg' ),
-						'noResults'     => esc_html__( 'Aucun jeu ne correspond à votre sélection.', 'notation-jlg' ),
+                return array(
+                    'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+                    'nonce'     => wp_create_nonce( 'jlg_game_explorer' ),
+                    'restUrl'   => esc_url_raw( rest_url( 'jlg/v1/game-explorer' ) ),
+                    'restPath'  => 'jlg/v1/game-explorer',
+                    'restNonce' => wp_create_nonce( 'wp_rest' ),
+                    'strings' => array(
+                        'loading'       => esc_html__( 'Chargement des jeux...', 'notation-jlg' ),
+                        'noResults'     => esc_html__( 'Aucun jeu ne correspond à votre sélection.', 'notation-jlg' ),
 						'reset'         => esc_html__( 'Réinitialiser les filtres', 'notation-jlg' ),
 						'genericError'  => esc_html__( 'Impossible de charger les jeux pour le moment.', 'notation-jlg' ),
 						'countSingular' => esc_html__( '%d jeu', 'notation-jlg' ),

--- a/plugin-notation-jeux_V4/includes/rest/class-jlg-rest-controller.php
+++ b/plugin-notation-jeux_V4/includes/rest/class-jlg-rest-controller.php
@@ -1,0 +1,223 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class JLG_REST_Controller {
+    private static $instance = null;
+
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            'jlg/v1',
+            '/ratings',
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'handle_user_rating' ),
+                'permission_callback' => array( $this, 'verify_public_rest_nonce' ),
+                'args'                => array(
+                    'post_id'    => array(
+                        'type'     => 'integer',
+                        'required' => true,
+                    ),
+                    'rating'     => array(
+                        'type'     => 'integer',
+                        'required' => true,
+                    ),
+                    'token'      => array(
+                        'type'     => 'string',
+                        'required' => true,
+                    ),
+                    'tokenNonce' => array(
+                        'type'     => 'string',
+                        'required' => true,
+                    ),
+                ),
+            )
+        );
+
+        register_rest_route(
+            'jlg/v1',
+            '/summary',
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'handle_summary_request' ),
+                'permission_callback' => array( $this, 'verify_public_rest_nonce' ),
+            )
+        );
+
+        register_rest_route(
+            'jlg/v1',
+            '/game-explorer',
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'handle_game_explorer_request' ),
+                'permission_callback' => array( $this, 'verify_public_rest_nonce' ),
+            )
+        );
+
+        register_rest_route(
+            'jlg/v1',
+            '/rawg-search',
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'handle_rawg_search' ),
+                'permission_callback' => array( $this, 'verify_admin_rest_permissions' ),
+                'args'                => array(
+                    'search' => array(
+                        'type'     => 'string',
+                        'required' => true,
+                    ),
+                    'page'   => array(
+                        'type'    => 'integer',
+                        'default' => 1,
+                    ),
+                ),
+            )
+        );
+    }
+
+    public function verify_public_rest_nonce( WP_REST_Request $request ) {
+        $nonce = $this->extract_rest_nonce( $request );
+
+        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+            return new WP_Error(
+                'jlg_rest_invalid_nonce',
+                __( 'La vérification de sécurité a échoué.', 'notation-jlg' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return true;
+    }
+
+    public function verify_admin_rest_permissions( WP_REST_Request $request ) {
+        $nonce_verification = $this->verify_public_rest_nonce( $request );
+
+        if ( is_wp_error( $nonce_verification ) ) {
+            return $nonce_verification;
+        }
+
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            return new WP_Error(
+                'jlg_rest_forbidden',
+                __( 'Permissions insuffisantes.', 'notation-jlg' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return true;
+    }
+
+    public function handle_user_rating( WP_REST_Request $request ) {
+        $payload = array(
+            'post_id'     => $request->get_param( 'post_id' ),
+            'rating'      => $request->get_param( 'rating' ),
+            'token'       => $request->get_param( 'token' ),
+            'token_nonce' => $request->get_param( 'tokenNonce' ),
+        );
+
+        $result = JLG_Frontend::process_user_rating_submission( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            return $this->error_to_response( $result );
+        }
+
+        return rest_ensure_response( $result );
+    }
+
+    public function handle_summary_request( WP_REST_Request $request ) {
+        $payload = $this->prepare_payload( $request );
+        $result  = JLG_Frontend::process_summary_request( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            return $this->error_to_response( $result );
+        }
+
+        return rest_ensure_response( $result );
+    }
+
+    public function handle_game_explorer_request( WP_REST_Request $request ) {
+        $payload = $this->prepare_payload( $request );
+        $result  = JLG_Frontend::process_game_explorer_request( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            return $this->error_to_response( $result );
+        }
+
+        return rest_ensure_response( $result );
+    }
+
+    public function handle_rawg_search( WP_REST_Request $request ) {
+        $payload = array(
+            'search' => $request->get_param( 'search' ),
+            'page'   => $request->get_param( 'page' ),
+        );
+
+        $result = JLG_Admin_Ajax::process_rawg_search( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            return $this->error_to_response( $result );
+        }
+
+        return rest_ensure_response( $result );
+    }
+
+    private function extract_rest_nonce( WP_REST_Request $request ) {
+        $nonce = $request->get_header( 'X-WP-Nonce' );
+
+        if ( ! $nonce ) {
+            $nonce = $request->get_param( '_wpnonce' );
+        }
+
+        if ( ! $nonce && isset( $_REQUEST['_wpnonce'] ) ) {
+            $nonce = wp_unslash( $_REQUEST['_wpnonce'] );
+        }
+
+        return is_string( $nonce ) ? $nonce : '';
+    }
+
+    private function prepare_payload( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+
+        if ( ! is_array( $data ) ) {
+            $data = array();
+        }
+
+        $query_params = $request->get_params();
+        if ( is_array( $query_params ) ) {
+            $data = array_merge( $query_params, $data );
+        }
+
+        return $data;
+    }
+
+    private function error_to_response( WP_Error $error ) {
+        $status = $error->get_error_data();
+
+        if ( is_array( $status ) && isset( $status['status'] ) ) {
+            $status = (int) $status['status'];
+        } elseif ( ! is_numeric( $status ) ) {
+            $status = 400;
+        }
+
+        return new WP_REST_Response(
+            array(
+                'message' => $error->get_error_message(),
+                'code'    => $error->get_error_code(),
+            ),
+            (int) $status
+        );
+    }
+}

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -112,6 +112,7 @@ final class JLG_Plugin_De_Notation_Main {
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-frontend.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-widget.php';
         require_once JLG_NOTATION_PLUGIN_DIR . 'includes/class-jlg-blocks.php';
+        require_once JLG_NOTATION_PLUGIN_DIR . 'includes/rest/class-jlg-rest-controller.php';
 
         // Admin seulement si nécessaire
         if ( is_admin() ) {
@@ -144,6 +145,10 @@ final class JLG_Plugin_De_Notation_Main {
         // Assets communs
         if ( class_exists( 'JLG_Assets' ) ) {
             $this->assets = JLG_Assets::get_instance();
+        }
+
+        if ( class_exists( 'JLG_REST_Controller' ) ) {
+            JLG_REST_Controller::get_instance();
         }
 
         // Frontend

--- a/plugin-notation-jeux_V4/tests/RestControllerTest.php
+++ b/plugin-notation-jeux_V4/tests/RestControllerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/rest/class-jlg-rest-controller.php';
+
+if (!class_exists('WP_REST_Server')) {
+    class WP_REST_Server
+    {
+        public const READABLE = 'GET';
+        public const CREATABLE = 'POST';
+    }
+}
+
+if (!class_exists('WP_REST_Response')) {
+    class WP_REST_Response
+    {
+        public $data;
+        public $status;
+
+        public function __construct($data = null, $status = 200)
+        {
+            $this->data = $data;
+            $this->status = (int) $status;
+        }
+
+        public function get_data()
+        {
+            return $this->data;
+        }
+
+        public function get_status()
+        {
+            return $this->status;
+        }
+    }
+}
+
+if (!class_exists('WP_REST_Request')) {
+    class WP_REST_Request
+    {
+        private $params;
+        private $json_params;
+        private $headers;
+
+        public function __construct(array $params = [], $json_params = null, array $headers = [])
+        {
+            $this->params = $params;
+            $this->json_params = is_array($json_params) ? $json_params : [];
+            $normalized_headers = [];
+            foreach ($headers as $key => $value) {
+                $normalized_headers[strtolower($key)] = $value;
+            }
+
+            $this->headers = $normalized_headers;
+        }
+
+        public function get_param($key)
+        {
+            return $this->params[$key] ?? null;
+        }
+
+        public function get_params()
+        {
+            return $this->params;
+        }
+
+        public function get_json_params()
+        {
+            return $this->json_params;
+        }
+
+        public function get_header($key)
+        {
+            $key = strtolower($key);
+
+            return $this->headers[$key] ?? '';
+        }
+    }
+}
+
+if (!function_exists('register_rest_route')) {
+    function register_rest_route($namespace, $route, $args)
+    {
+        if (!isset($GLOBALS['jlg_test_rest_routes'])) {
+            $GLOBALS['jlg_test_rest_routes'] = [];
+        }
+
+        $GLOBALS['jlg_test_rest_routes'][] = [$namespace, $route, $args];
+
+        return true;
+    }
+}
+
+if (!function_exists('rest_ensure_response')) {
+    function rest_ensure_response($data)
+    {
+        return $data instanceof WP_REST_Response ? $data : new WP_REST_Response($data);
+    }
+}
+
+class RestControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['jlg_test_rest_routes'] = [];
+        unset($GLOBALS['jlg_test_wp_verify_nonce'], $GLOBALS['jlg_test_current_user_can']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['jlg_test_wp_verify_nonce'], $GLOBALS['jlg_test_current_user_can']);
+        parent::tearDown();
+    }
+
+    public function test_register_routes_registers_expected_endpoints(): void
+    {
+        $controller = JLG_REST_Controller::get_instance();
+        $controller->register_routes();
+
+        $this->assertCount(4, $GLOBALS['jlg_test_rest_routes']);
+
+        $methods_by_route = [];
+        foreach ($GLOBALS['jlg_test_rest_routes'] as $route_definition) {
+            [$namespace, $route, $args] = $route_definition;
+            $this->assertSame('jlg/v1', $namespace);
+            $this->assertIsArray($args);
+            $this->assertArrayHasKey('methods', $args);
+            $this->assertArrayHasKey('callback', $args);
+            $this->assertIsCallable($args['callback']);
+            $this->assertArrayHasKey('permission_callback', $args);
+            $this->assertIsCallable($args['permission_callback']);
+
+            $methods_by_route[$route] = $args['methods'];
+        }
+
+        $this->assertSame(WP_REST_Server::CREATABLE, $methods_by_route['/ratings'] ?? null);
+        $this->assertSame(WP_REST_Server::CREATABLE, $methods_by_route['/summary'] ?? null);
+        $this->assertSame(WP_REST_Server::CREATABLE, $methods_by_route['/game-explorer'] ?? null);
+        $this->assertSame(WP_REST_Server::READABLE, $methods_by_route['/rawg-search'] ?? null);
+    }
+
+    public function test_verify_public_rest_nonce_rejects_invalid_nonce(): void
+    {
+        $controller = JLG_REST_Controller::get_instance();
+        $request = new WP_REST_Request([], null, ['X-WP-Nonce' => 'invalid-nonce']);
+
+        $GLOBALS['jlg_test_wp_verify_nonce'] = function ($nonce, $action) {
+            TestCase::assertSame('invalid-nonce', $nonce);
+            TestCase::assertSame('wp_rest', $action);
+
+            return false;
+        };
+
+        $result = $controller->verify_public_rest_nonce($request);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('jlg_rest_invalid_nonce', $result->get_error_code());
+        $this->assertSame(403, $result->get_error_data()['status'] ?? null);
+    }
+
+    public function test_verify_admin_rest_permissions_requires_capability(): void
+    {
+        $controller = JLG_REST_Controller::get_instance();
+        $request = new WP_REST_Request([], null, ['X-WP-Nonce' => 'valid-nonce']);
+
+        $GLOBALS['jlg_test_wp_verify_nonce'] = fn () => true;
+        $GLOBALS['jlg_test_current_user_can'] = static function ($capability) {
+            TestCase::assertSame('edit_posts', $capability);
+
+            return false;
+        };
+
+        $result = $controller->verify_admin_rest_permissions($request);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('jlg_rest_forbidden', $result->get_error_code());
+        $this->assertSame(403, $result->get_error_data()['status'] ?? null);
+    }
+
+    public function test_handle_user_rating_returns_error_response_when_submission_fails(): void
+    {
+        $controller = JLG_REST_Controller::get_instance();
+        $request = new WP_REST_Request([
+            'post_id'    => 123,
+            'rating'     => 5,
+            'token'      => '',
+            'tokenNonce' => 'nonce-jlg',
+        ]);
+
+        $response = $controller->handle_user_rating($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(400, $response->get_status());
+        $this->assertSame('jlg_missing_rating_token', $response->get_data()['code'] ?? null);
+        $this->assertStringContainsString('Jeton', $response->get_data()['message'] ?? '');
+    }
+
+    public function test_handle_rawg_search_returns_error_response_on_invalid_payload(): void
+    {
+        $controller = JLG_REST_Controller::get_instance();
+        $request = new WP_REST_Request([
+            'search' => '',
+            'page'   => 1,
+        ]);
+
+        $response = $controller->handle_rawg_search($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(400, $response->get_status());
+        $this->assertSame('jlg_rawg_empty_search', $response->get_data()['code'] ?? null);
+        $this->assertStringContainsString('Terme de recherche vide', $response->get_data()['message'] ?? '');
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated PHPUnit suite for the REST controller covering route registration, nonce validation, and error responses
- extend the test bootstrap with WordPress-compatible stubs for REST utilities, WP_Error, and improved query helpers

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68de3e807a5c832e9710fb4ff81f017e