### PR TITLE
Adjust Gutenberg block alignment widths

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -10,6 +10,14 @@
     max-width: 650px;
     box-shadow: 0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -2px rgba(0,0,0,.05);
 }
+
+.wp-block-notation-jlg-rating-block.alignwide .review-box-jlg,
+.wp-block-notation-jlg-rating-block.alignfull .review-box-jlg {
+    max-width: none;
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+}
 .review-box-jlg hr { border:0; height:1px; background-color: var(--jlg-border-color); margin:24px 0; }
 .review-box-jlg .global-score-wrapper { text-align:center; margin-bottom:24px; }
 .review-box-jlg .score-value {

--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -9,6 +9,14 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04);
 }
 
+.wp-block-notation-jlg-all-in-one-block.alignwide .jlg-all-in-one-block,
+.wp-block-notation-jlg-all-in-one-block.alignfull .jlg-all-in-one-block {
+    max-width: none;
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+}
+
 .jlg-all-in-one-block.style-moderne {
     background: linear-gradient(
         135deg,


### PR DESCRIPTION
## Summary
- allow rating block to expand when inserted as a wide or full Gutenberg block
- update all-in-one block styles so wide/full alignments are no longer restricted by legacy max-width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6661129c832e98e8a5e69fc3e6d4