### PR TITLE
Enable WordPress color picker for admin color fields

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -117,7 +117,7 @@ programmatiques pour les intégrations avancées.
 Pour vérifier que les options ne peuvent pas injecter de CSS invalide :
 
 1. Dans l'administration WordPress, rendez-vous dans **Notation – JLG > Réglages**.
-2. Dans la section *Tableau Récapitulatif*, saisissez `transparent` pour **Fond des lignes** et `#123456; background:red;` pour **Gradient 1**.
+2. Dans la section *Tableau Récapitulatif*, utilisez le nouveau sélecteur de couleur : saisissez ou collez `transparent` pour **Fond des lignes** et `#123456; background:red;` pour **Gradient 1** (dans le champ texte du picker).
 3. Enregistrez les réglages puis affichez un article utilisant les shortcodes du plugin.
 4. Inspectez le bloc `<style id="jlg-frontend-inline-css">` dans l'entête de la page :
    - La variable `--jlg-table-row-bg-color` doit conserver la valeur sûre `transparent` sans ajouter d'autre règle.

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -113,7 +113,7 @@ Ces points d'extension facilitent la conservation de vos surcharges lors des mis
 Pour valider que des options malicieuses ne génèrent pas de CSS invalide :
 
 1. Dans l'administration WordPress, ouvrez **Notation – JLG > Réglages**.
-2. Dans la section *Tableau Récapitulatif*, saisissez `transparent` dans **Fond des lignes** et `#123456; background:red;` dans **Gradient 1**.
+2. Dans la section *Tableau Récapitulatif*, utilisez le nouveau sélecteur de couleur : saisissez ou collez `transparent` dans **Fond des lignes** et `#123456; background:red;` dans **Gradient 1** (dans le champ texte du picker).
 3. Enregistrez les réglages puis affichez un article utilisant les shortcodes du plugin.
 4. Dans le code source de la page, repérez le bloc `<style id="jlg-frontend-inline-css">` :
    * Vérifiez que `--jlg-table-row-bg-color` reste à `transparent` sans aucune règle supplémentaire.

--- a/plugin-notation-jeux_V4/assets/js/admin-color-picker.js
+++ b/plugin-notation-jeux_V4/assets/js/admin-color-picker.js
@@ -1,0 +1,45 @@
+(function ( $ ) {
+    'use strict';
+
+    var transparentKeyword = 'transparent';
+
+    function initColorPicker( context ) {
+        $( '.jlg-color-picker', context ).each( function () {
+            var $input = $( this );
+            var defaultColor = $input.data( 'default-color' );
+            var allowTransparent = $input.data( 'allow-transparent' ) === true || $input.data( 'allow-transparent' ) === 'true';
+            var pickerOptions = {
+                change: function ( event, ui ) {
+                    if ( ui && ui.color ) {
+                        $input.val( ui.color.toString() );
+                    }
+
+                    $input.trigger( 'change' );
+                },
+                clear: function () {
+                    if ( allowTransparent ) {
+                        $input.val( transparentKeyword );
+                    } else {
+                        $input.val( '' );
+                    }
+
+                    $input.trigger( 'change' );
+                }
+            };
+
+            if ( typeof defaultColor !== 'undefined' && defaultColor !== '' && defaultColor.toString().toLowerCase() !== transparentKeyword ) {
+                pickerOptions.defaultColor = defaultColor;
+            }
+
+            $input.wpColorPicker( pickerOptions );
+
+            if ( allowTransparent && ( typeof $input.val() !== 'string' || $input.val().trim() === '' ) ) {
+                $input.val( transparentKeyword );
+            }
+        } );
+    }
+
+    $( function () {
+        initColorPicker( document );
+    } );
+})( jQuery );

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -358,7 +358,7 @@ class Settings {
         );
 
         // Section 3: Couleurs & Thèmes
-        add_settings_section( 'jlg_colors', '3. 🌈 Couleurs & Thèmes', null, 'notation_jlg_page' );
+        add_settings_section( 'jlg_colors', '3. 🌈 Couleurs & Thèmes', array( $this, 'render_colors_section_intro' ), 'notation_jlg_page' );
         add_settings_field(
             'visual_theme',
             'Thème Visuel Principal',
@@ -744,9 +744,11 @@ class Settings {
             'notation_jlg_page',
             'jlg_table',
             array(
-				'id'   => 'table_row_bg_color',
-				'type' => 'color',
-			)
+                                'id'                => 'table_row_bg_color',
+                                'type'              => 'color',
+                                'allow_transparent' => true,
+                                'desc'              => __( 'Utilisez le sélecteur ou saisissez un code hexadécimal. Tapez "transparent" pour conserver la transparence.', 'notation-jlg' ),
+                        )
         );
         add_settings_field(
             'table_row_text_color',
@@ -777,9 +779,11 @@ class Settings {
             'notation_jlg_page',
             'jlg_table',
             array(
-				'id'   => 'table_zebra_bg_color',
-				'type' => 'color',
-			)
+                                'id'                => 'table_zebra_bg_color',
+                                'type'              => 'color',
+                                'allow_transparent' => true,
+                                'desc'              => __( 'Le bouton "Effacer" définit la valeur sur transparent lorsque c\'est permis.', 'notation-jlg' ),
+                        )
         );
         add_settings_field(
             'table_border_style',
@@ -1007,6 +1011,10 @@ class Settings {
                 'options' => $score_position_options,
             )
         );
+    }
+
+    public function render_colors_section_intro() {
+        echo '<p class="description">' . esc_html__( 'Les champs de couleur utilisent désormais le sélecteur WordPress : choisissez une teinte, collez un code hexadécimal ou tapez "transparent" lorsqu\'il est autorisé.', 'notation-jlg' ) . '</p>';
     }
 
     public function render_field( $args ) {

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -30,7 +30,23 @@ class Assets {
     }
 
     public function enqueue_admin_assets( $hook_suffix ) {
-        if ( $hook_suffix !== 'toplevel_page_notation_jlg_settings' ) {
+        $plugin_page_prefix = 'notation-jlg_page_';
+        $plugin_page_hooks  = array( 'toplevel_page_notation_jlg_settings' );
+
+        $is_plugin_page = in_array( $hook_suffix, $plugin_page_hooks, true ) || strpos( $hook_suffix, $plugin_page_prefix ) === 0;
+
+        if ( $is_plugin_page ) {
+            wp_enqueue_style( 'wp-color-picker' );
+            wp_enqueue_script( 'wp-color-picker' );
+
+            $color_picker_handle = 'jlg-admin-color-picker';
+            $color_picker_src    = JLG_NOTATION_PLUGIN_URL . 'assets/js/admin-color-picker.js';
+            $version             = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
+
+            wp_enqueue_script( $color_picker_handle, $color_picker_src, array( 'jquery', 'wp-color-picker' ), $version, true );
+        }
+
+        if ( ! $is_plugin_page ) {
             return;
         }
 
@@ -52,26 +68,26 @@ class Assets {
             $handle,
             'jlgPlatformsOrder',
             array(
-				'listSelector'     => '#platforms-list',
-				'positionSelector' => '.jlg-platform-position',
-				'handleSelector'   => '.jlg-sort-handle',
-				'rowSelector'      => 'tr[data-key]',
-				'inputSelector'    => 'input[name="platform_order[]"]',
-				'placeholderClass' => 'jlg-sortable-placeholder',
-			)
+                                'listSelector'     => '#platforms-list',
+                                'positionSelector' => '.jlg-platform-position',
+                                'handleSelector'   => '.jlg-sort-handle',
+                                'rowSelector'      => 'tr[data-key]',
+                                'inputSelector'    => 'input[name="platform_order[]"]',
+                                'placeholderClass' => 'jlg-sortable-placeholder',
+                        )
         );
 
         wp_localize_script(
             $handle,
             'jlgPlatformsOrderL10n',
             array(
-				'confirmReset'  => esc_html__( 'Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?', 'notation-jlg' ),
-				'confirmDelete' => esc_html__( 'Êtes-vous sûr de vouloir supprimer la plateforme "%s" ?', 'notation-jlg' ),
-				'nonce'         => wp_create_nonce( 'jlg_platform_action' ),
-				'nonceField'    => 'jlg_platform_nonce',
-				'actionField'   => 'jlg_platform_action',
-				'deleteAction'  => 'delete',
-			)
+                                'confirmReset'  => esc_html__( 'Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?', 'notation-jlg' ),
+                                'confirmDelete' => esc_html__( 'Êtes-vous sûr de vouloir supprimer la plateforme "%s" ?', 'notation-jlg' ),
+                                'nonce'         => wp_create_nonce( 'jlg_platform_action' ),
+                                'nonceField'    => 'jlg_platform_nonce',
+                                'actionField'   => 'jlg_platform_action',
+                                'deleteAction'  => 'delete',
+                        )
         );
 
         wp_enqueue_script( $handle );

--- a/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
+++ b/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
@@ -30,13 +30,38 @@ class FormRenderer {
     }
 
     public static function color_field( $args ) {
-        $options = Helpers::get_plugin_options();
-        printf(
-            '<input type="color" name="%s[%s]" value="%s" />',
-            esc_attr( self::$option_name ),
-            esc_attr( $args['id'] ),
-            esc_attr( $options[ $args['id'] ] ?? '#000000' )
+        $options         = Helpers::get_plugin_options();
+        $defaults        = Helpers::get_default_settings();
+        $field_id        = $args['id'] ?? '';
+        $current_value   = $options[ $field_id ] ?? ( $defaults[ $field_id ] ?? '#000000' );
+        $default_value   = $defaults[ $field_id ] ?? '#000000';
+        $additional      = isset( $args['class'] ) ? explode( ' ', (string) $args['class'] ) : array();
+        $class_names     = array_merge( array( 'jlg-color-picker', 'wp-color-picker' ), $additional );
+        $class_names     = array_filter( array_map( 'sanitize_html_class', $class_names ) );
+        $allow_transparent = ! empty( $args['allow_transparent'] );
+
+        $attributes = array(
+            'type'               => 'text',
+            'class'              => implode( ' ', array_unique( $class_names ) ),
+            'name'               => sprintf( '%s[%s]', self::$option_name, $field_id ),
+            'value'              => $current_value,
+            'data-default-color' => $default_value,
         );
+
+        if ( $allow_transparent ) {
+            $attributes['data-allow-transparent'] = 'true';
+        }
+
+        $attribute_string = '';
+        foreach ( $attributes as $attr => $value ) {
+            if ( $value === '' && $attr !== 'value' ) {
+                continue;
+            }
+
+            $attribute_string .= sprintf( ' %s="%s"', esc_attr( $attr ), esc_attr( $value ) );
+        }
+
+        printf( '<input%s />', $attribute_string );
         self::render_description( $args );
     }
 


### PR DESCRIPTION
## Summary
- load the core WordPress color picker on plugin admin pages and bootstrap a helper script for the custom fields
- render settings color inputs as wp-color-picker fields with default values and transparency hints where applicable
- refresh the documentation to mention the enhanced picker when testing custom colours

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de665da1f0832eba46812a3b0173f3