### PR TITLE
Enhance admin color picker support

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -30,6 +30,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 - **API RAWG** : Remplissage automatique des informations de jeu
 - **SEO optimisé** : Support schema.org pour les rich snippets Google
 - **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
+- **Sélecteur de couleurs enrichi** : Profitez du color picker WordPress avec saisie libre (y compris `transparent` lorsque pris en charge)
 - **Accessibilité renforcée** : Les animations respectent la préférence système *réduire les mouvements*
 - **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 - **Responsive** : Parfaitement adapté mobile et tablette
@@ -117,7 +118,7 @@ programmatiques pour les intégrations avancées.
 Pour vérifier que les options ne peuvent pas injecter de CSS invalide :
 
 1. Dans l'administration WordPress, rendez-vous dans **Notation – JLG > Réglages**.
-2. Dans la section *Tableau Récapitulatif*, saisissez `transparent` pour **Fond des lignes** et `#123456; background:red;` pour **Gradient 1**.
+2. Dans la section *Tableau Récapitulatif*, utilisez le nouveau sélecteur pour saisir `transparent` dans **Fond des lignes** (le champ accepte la saisie directe) et `#123456; background:red;` pour **Gradient 1**.
 3. Enregistrez les réglages puis affichez un article utilisant les shortcodes du plugin.
 4. Inspectez le bloc `<style id="jlg-frontend-inline-css">` dans l'entête de la page :
    - La variable `--jlg-table-row-bg-color` doit conserver la valeur sûre `transparent` sans ajouter d'autre règle.

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -27,6 +27,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 * **API RAWG** : Remplissage automatique des informations de jeu
 * **SEO optimisé** : Support schema.org pour les rich snippets Google
 * **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
+* **Sélecteur de couleurs enrichi** : Profitez du color picker WordPress avec saisie libre (y compris `transparent` lorsque pris en charge)
 * **Accessibilité renforcée** : Les animations respectent la préférence système "réduire les mouvements"
 * **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 * **Responsive** : Parfaitement adapté mobile et tablette
@@ -113,7 +114,7 @@ Ces points d'extension facilitent la conservation de vos surcharges lors des mis
 Pour valider que des options malicieuses ne génèrent pas de CSS invalide :
 
 1. Dans l'administration WordPress, ouvrez **Notation – JLG > Réglages**.
-2. Dans la section *Tableau Récapitulatif*, saisissez `transparent` dans **Fond des lignes** et `#123456; background:red;` dans **Gradient 1**.
+2. Dans la section *Tableau Récapitulatif*, utilisez le nouveau sélecteur pour saisir `transparent` dans **Fond des lignes** (le champ accepte la saisie directe) et `#123456; background:red;` dans **Gradient 1**.
 3. Enregistrez les réglages puis affichez un article utilisant les shortcodes du plugin.
 4. Dans le code source de la page, repérez le bloc `<style id="jlg-frontend-inline-css">` :
    * Vérifiez que `--jlg-table-row-bg-color` reste à `transparent` sans aucune règle supplémentaire.

--- a/plugin-notation-jeux_V4/assets/js/admin-color-picker.js
+++ b/plugin-notation-jeux_V4/assets/js/admin-color-picker.js
@@ -1,0 +1,81 @@
+(function ($) {
+    'use strict';
+
+    function isTransparent(value) {
+        return typeof value === 'string' && value.toLowerCase().trim() === 'transparent';
+    }
+
+    function initColorPicker($inputs) {
+        if (!$.fn.wpColorPicker || !$inputs.length) {
+            return;
+        }
+
+        $inputs.each(function () {
+            var $field = $(this);
+
+            if ($field.data('jlgColorPickerInit')) {
+                return;
+            }
+
+            $field.data('jlgColorPickerInit', true);
+
+            var allowTransparent = String($field.data('allow-transparent') || '').toLowerCase() === 'true';
+            var defaultColor = $field.data('default-color');
+            var initialValue = $field.val();
+            var pickerOptions = {};
+
+            if (defaultColor && !isTransparent(defaultColor)) {
+                pickerOptions.defaultColor = defaultColor;
+            }
+
+            pickerOptions.change = function (event, ui) {
+                if (allowTransparent && (!ui || !ui.color)) {
+                    $field.val('transparent');
+                    return;
+                }
+
+                if (ui && ui.color) {
+                    $field.val(ui.color.toString());
+                }
+            };
+
+            pickerOptions.clear = function () {
+                if (allowTransparent) {
+                    $field.val('transparent');
+                } else {
+                    $field.val('');
+                }
+
+                $field.trigger('change');
+            };
+
+            $field.wpColorPicker(pickerOptions);
+
+            if (allowTransparent) {
+                var $wrapper = $field.closest('.wp-picker-container');
+
+                if (isTransparent(initialValue)) {
+                    $field.val('transparent');
+                    $field.trigger('change');
+                }
+
+                $wrapper.on('click', '.wp-picker-clear', function () {
+                    $field.val('transparent').trigger('change');
+                });
+
+                $field.on('input', function () {
+                    var current = $field.val();
+                    var picker = $field.data('wp-color-picker');
+
+                    if (isTransparent(current) && picker) {
+                        picker.color = false;
+                    }
+                });
+            }
+        });
+    }
+
+    $(function () {
+        initColorPicker($('.jlg-color-picker'));
+    });
+})(jQuery);

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -352,9 +352,10 @@ class Settings {
             'notation_jlg_page',
             'jlg_layout',
             array(
-				'id'   => 'circle_border_color',
-				'type' => 'color',
-			)
+                'id'   => 'circle_border_color',
+                'type' => 'color',
+                'desc' => 'Cliquez pour ouvrir le sélecteur ou saisissez un code hexadécimal personnalisé.',
+            )
         );
 
         // Section 3: Couleurs & Thèmes
@@ -744,9 +745,11 @@ class Settings {
             'notation_jlg_page',
             'jlg_table',
             array(
-				'id'   => 'table_row_bg_color',
-				'type' => 'color',
-			)
+                'id'                => 'table_row_bg_color',
+                'type'              => 'color',
+                'allow_transparent' => true,
+                'desc'              => 'Le sélecteur accepte aussi "transparent" pour conserver la valeur par défaut.',
+            )
         );
         add_settings_field(
             'table_row_text_color',
@@ -777,9 +780,11 @@ class Settings {
             'notation_jlg_page',
             'jlg_table',
             array(
-				'id'   => 'table_zebra_bg_color',
-				'type' => 'color',
-			)
+                'id'                => 'table_zebra_bg_color',
+                'type'              => 'color',
+                'allow_transparent' => true,
+                'desc'              => 'Utilisez le sélecteur ou saisissez "transparent" pour désactiver la couleur alternée.',
+            )
         );
         add_settings_field(
             'table_border_style',
@@ -1066,12 +1071,36 @@ class Settings {
                     checked( 1, $options[ $args['id'] ] ?? 0, false )
                 );
             } elseif ( $type === 'color' ) {
+                $defaults          = Helpers::get_default_settings();
+                $field_id          = $args['id'];
+                $allow_transparent = ! empty( $args['allow_transparent'] );
+                $default_value     = $defaults[ $field_id ] ?? '#000000';
+                $current_value     = $options[ $field_id ] ?? $default_value;
+                $current_value     = is_string( $current_value ) ? $current_value : ( is_string( $default_value ) ? $default_value : '' );
+                $classes           = array( 'wp-color-picker', 'jlg-color-picker' );
+                $data_attributes   = array();
+
+                if ( $allow_transparent ) {
+                    $classes[] = 'jlg-color-picker--allow-transparent';
+                    $data_attributes['data-allow-transparent'] = 'true';
+                }
+
+                $default_attr_value                  = is_string( $default_value ) ? $default_value : '';
+                $data_attributes['data-default-color'] = $default_attr_value;
+
+                $attributes = '';
+                foreach ( $data_attributes as $attribute => $value ) {
+                    $attributes .= sprintf( ' %s="%s"', esc_attr( $attribute ), esc_attr( $value ) );
+                }
+
                 printf(
-                    '<input type="color" name="%s[%s]" id="%s" value="%s" />',
+                    '<input type="text" class="%s" name="%s[%s]" id="%s" value="%s"%s />',
+                    esc_attr( implode( ' ', $classes ) ),
                     esc_attr( $this->option_name ),
-                    esc_attr( $args['id'] ),
-                    esc_attr( $args['id'] ),
-                    esc_attr( $options[ $args['id'] ] ?? '#000000' )
+                    esc_attr( $field_id ),
+                    esc_attr( $field_id ),
+                    esc_attr( $current_value ),
+                    $attributes
                 );
             } else {
                 // Type text par défaut

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -30,21 +30,39 @@ class Assets {
     }
 
     public function enqueue_admin_assets( $hook_suffix ) {
-        if ( $hook_suffix !== 'toplevel_page_notation_jlg_settings' ) {
+        $plugin_pages = array(
+            'toplevel_page_notation_jlg_settings',
+            'notation-jlg_page_notation_jlg_settings',
+        );
+
+        if ( ! in_array( $hook_suffix, $plugin_pages, true ) ) {
             return;
         }
 
+        $version = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
+
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'wp-color-picker' );
+
+        wp_enqueue_script(
+            'jlg-admin-color-picker',
+            JLG_NOTATION_PLUGIN_URL . 'assets/js/admin-color-picker.js',
+            array( 'wp-color-picker' ),
+            $version,
+            true
+        );
+
         $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'reglages';
+
         if ( $active_tab !== 'plateformes' ) {
             return;
         }
 
         wp_enqueue_script( 'jquery-ui-sortable' );
 
-        $handle  = 'jlg-platforms-order';
-        $src     = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-platforms-order.js';
-        $deps    = array( 'jquery', 'jquery-ui-sortable' );
-        $version = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
+        $handle = 'jlg-platforms-order';
+        $src    = JLG_NOTATION_PLUGIN_URL . 'assets/js/jlg-platforms-order.js';
+        $deps   = array( 'jquery', 'jquery-ui-sortable' );
 
         wp_register_script( $handle, $src, $deps, $version, true );
 

--- a/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
+++ b/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
@@ -30,12 +30,37 @@ class FormRenderer {
     }
 
     public static function color_field( $args ) {
-        $options = Helpers::get_plugin_options();
+        $options           = Helpers::get_plugin_options();
+        $defaults          = Helpers::get_default_settings();
+        $field_id          = $args['id'];
+        $allow_transparent = ! empty( $args['allow_transparent'] );
+        $default_value     = $defaults[ $field_id ] ?? '#000000';
+        $current_value     = $options[ $field_id ] ?? $default_value;
+        $current_value     = is_string( $current_value ) ? $current_value : ( is_string( $default_value ) ? $default_value : '' );
+        $data_attributes   = array();
+
+        $classes = array( 'wp-color-picker', 'jlg-color-picker' );
+        if ( $allow_transparent ) {
+            $classes[] = 'jlg-color-picker--allow-transparent';
+            $data_attributes['data-allow-transparent'] = 'true';
+        }
+
+        $default_attr_value                  = is_string( $default_value ) ? $default_value : '';
+        $data_attributes['data-default-color'] = $default_attr_value;
+
+        $attributes = '';
+        foreach ( $data_attributes as $attribute => $value ) {
+            $attributes .= sprintf( ' %s="%s"', esc_attr( $attribute ), esc_attr( $value ) );
+        }
+
         printf(
-            '<input type="color" name="%s[%s]" value="%s" />',
+            '<input type="text" class="%s" name="%s[%s]" id="%s" value="%s"%s />',
+            esc_attr( implode( ' ', $classes ) ),
             esc_attr( self::$option_name ),
-            esc_attr( $args['id'] ),
-            esc_attr( $options[ $args['id'] ] ?? '#000000' )
+            esc_attr( $field_id ),
+            esc_attr( $field_id ),
+            esc_attr( $current_value ),
+            $attributes
         );
         self::render_description( $args );
     }


### PR DESCRIPTION
## Summary
- load the core WordPress color picker assets on the plugin admin pages and initialize them with a dedicated script
- render settings color fields as wp-color-picker text inputs, preserving defaults and transparent values where allowed
- update documentation to note the richer picker and how to test transparent/color overrides

## Testing
- php -l plugin-notation-jeux_V4/includes/Assets.php
- php -l plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
- php -l plugin-notation-jeux_V4/includes/Admin/Settings.php

------
https://chatgpt.com/codex/tasks/task_e_68de6640c3d0832eb944261171bfa633