### PR TITLE
Adjust block widths for Gutenberg alignments

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -10,6 +10,12 @@
     max-width: 650px;
     box-shadow: 0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -2px rgba(0,0,0,.05);
 }
+.wp-block-notation-jlg-rating-block.alignwide .review-box-jlg,
+.wp-block-notation-jlg-rating-block.alignfull .review-box-jlg {
+    max-width: none;
+    width: 100%;
+    margin: 32px 0;
+}
 .review-box-jlg hr { border:0; height:1px; background-color: var(--jlg-border-color); margin:24px 0; }
 .review-box-jlg .global-score-wrapper { text-align:center; margin-bottom:24px; }
 .review-box-jlg .score-value {

--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -8,6 +8,12 @@
     max-width: 750px;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04);
 }
+.wp-block-notation-jlg-all-in-one.alignwide .jlg-all-in-one-block,
+.wp-block-notation-jlg-all-in-one.alignfull .jlg-all-in-one-block {
+    max-width: none;
+    width: 100%;
+    margin: 40px 0;
+}
 
 .jlg-all-in-one-block.style-moderne {
     background: linear-gradient(


### PR DESCRIPTION
## Summary
- allow the rating block to fill wide and full alignments in Gutenberg by removing the default max-width constraint within those contexts
- extend the same wide/full alignment handling to the all-in-one block while keeping the legacy shortcode layout unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de66465e94832e9439fd7363642ab9