### PR TITLE
Complete dynamic rating category migration

### DIFF
--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -274,9 +274,21 @@ class Frontend {
             '_jlg_user_rating_avg',
         );
 
-        foreach ( array_keys( Helpers::get_rating_categories() ) as $category_key ) {
-            $meta_keys[] = '_note_' . $category_key;
+        foreach ( Helpers::get_rating_category_definitions() as $definition ) {
+            if ( ! empty( $definition['meta_key'] ) ) {
+                $meta_keys[] = (string) $definition['meta_key'];
+            }
+
+            if ( ! empty( $definition['legacy_meta_keys'] ) && is_array( $definition['legacy_meta_keys'] ) ) {
+                foreach ( $definition['legacy_meta_keys'] as $legacy_meta_key ) {
+                    if ( $legacy_meta_key !== '' ) {
+                        $meta_keys[] = (string) $legacy_meta_key;
+                    }
+                }
+            }
         }
+
+        $meta_keys = array_values( array_unique( $meta_keys ) );
 
         $has_metadata = false;
 
@@ -1581,6 +1593,8 @@ class Frontend {
                 'average_score'        => null,
                 'scores'               => array(),
                 'categories'           => array(),
+                'category_scores'      => array(),
+                'category_definitions' => array(),
                 'pros_list'            => array(),
                 'cons_list'            => array(),
                 'titre'                => '',

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -145,10 +145,10 @@ class AllInOne {
         }
 
         // Récupération des options et configuration
-        $options    = Helpers::get_plugin_options();
-        $palette    = Helpers::get_color_palette();
-        $categories = Helpers::get_rating_categories();
-        $defaults   = Helpers::get_default_settings();
+        $options               = Helpers::get_plugin_options();
+        $palette               = Helpers::get_color_palette();
+        $category_definitions  = Helpers::get_rating_category_definitions();
+        $defaults              = Helpers::get_default_settings();
 
         // Couleur d'accent (utilise la couleur définie ou celle des options)
         $accent_color = $atts['couleur_accent'] ?: ( $options['score_gradient_1'] ?? '' );
@@ -178,12 +178,14 @@ class AllInOne {
         }
 
         // Récupérer les scores détaillés
-        $scores = array();
+        $category_scores = array();
+        $scores          = array();
         if ( $average_score !== null ) {
-            foreach ( array_keys( $categories ) as $key ) {
-                $score_value = get_post_meta( $post_id, '_note_' . $key, true );
-                if ( $score_value !== '' && is_numeric( $score_value ) ) {
-                    $scores[ $key ] = floatval( $score_value );
+            $category_scores = Helpers::get_category_scores_for_display( $post_id );
+
+            foreach ( $category_scores as $category_score ) {
+                if ( isset( $category_score['id'], $category_score['score'] ) ) {
+                    $scores[ $category_score['id'] ] = (float) $category_score['score'];
                 }
             }
         }
@@ -344,14 +346,15 @@ class AllInOne {
         return Frontend::get_template_html(
             'shortcode-all-in-one',
             array(
-				'options'            => $options,
-				'average_score'      => $average_score,
-				'scores'             => $scores,
-				'categories'         => $categories,
-				'pros_list'          => $pros_list,
-				'cons_list'          => $cons_list,
-				'tagline_fr'         => $tagline_fr,
-				'tagline_en'         => $tagline_en,
+                                'options'            => $options,
+                                'average_score'      => $average_score,
+                                'scores'             => $scores,
+                                'category_scores'    => $category_scores,
+                                'category_definitions' => $category_definitions,
+                                'pros_list'          => $pros_list,
+                                'cons_list'          => $cons_list,
+                                'tagline_fr'         => $tagline_fr,
+                                'tagline_en'         => $tagline_en,
 				'atts'               => $atts,
 				'block_classes'      => $block_classes,
 				'css_variables'      => $css_variables_string,

--- a/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
@@ -48,13 +48,12 @@ class RatingBlock {
             return '';
         }
 
-        $categories = Helpers::get_rating_categories();
-        $scores     = array();
+        $category_scores = Helpers::get_category_scores_for_display( $post_id );
+        $score_map       = array();
 
-        foreach ( array_keys( $categories ) as $key ) {
-            $score_value = get_post_meta( $post_id, '_note_' . $key, true );
-            if ( $score_value !== '' && is_numeric( $score_value ) ) {
-                $scores[ $key ] = floatval( $score_value );
+        foreach ( $category_scores as $category_score ) {
+            if ( isset( $category_score['id'], $category_score['score'] ) ) {
+                $score_map[ $category_score['id'] ] = (float) $category_score['score'];
             }
         }
 
@@ -63,11 +62,12 @@ class RatingBlock {
         return Frontend::get_template_html(
             'shortcode-rating-block',
             array(
-				'options'       => Helpers::get_plugin_options(),
-				'average_score' => $average_score,
-				'scores'        => $scores,
-				'categories'    => $categories,
-			)
+                                'options'       => Helpers::get_plugin_options(),
+                                'average_score' => $average_score,
+                                'scores'        => $score_map,
+                                'category_scores' => $category_scores,
+                                'category_definitions' => Helpers::get_rating_category_definitions(),
+                        )
         );
     }
 }

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -77,6 +77,9 @@ final class JLG_Plugin_De_Notation_Main {
 
     private function __construct() {
         $this->load_dependencies();
+        if ( class_exists( \JLG\Notation\Helpers::class ) ) {
+            \JLG\Notation\Helpers::migrate_legacy_rating_configuration();
+        }
         $this->init_components();
         add_action( 'jlg_process_v5_migration', array( $this, 'process_migration_batch' ) );
         add_action( 'jlg_queue_average_rebuild', array( $this, 'queue_additional_posts_for_migration' ) );
@@ -147,6 +150,10 @@ final class JLG_Plugin_De_Notation_Main {
     public function on_activation() {
         // Migration automatique depuis v4
         $current_version = get_option( 'jlg_notation_version', '4.0' );
+
+        if ( class_exists( \JLG\Notation\Helpers::class ) ) {
+            \JLG\Notation\Helpers::migrate_legacy_rating_configuration();
+        }
 
         if ( version_compare( $current_version, '5.0', '<' ) ) {
             $this->queue_migration_from_v4();

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -12,6 +12,7 @@ $has_tagline      = ( $atts['afficher_tagline'] === 'oui' && ( ! empty( $tagline
 $has_dual_tagline = ( ! empty( $tagline_fr ) && ! empty( $tagline_en ) );
 $show_rating      = ( $atts['afficher_notation'] === 'oui' && $average_score !== null );
 $show_points      = ( $atts['afficher_points'] === 'oui' && ( ! empty( $pros_list ) || ! empty( $cons_list ) ) );
+$category_scores  = isset( $category_scores ) && is_array( $category_scores ) ? $category_scores : array();
 $data_attributes  = sprintf(
     ' data-animations-enabled="%s" data-has-multiple-taglines="%s"',
     esc_attr( $animations_enabled ? 'true' : 'false' ),
@@ -74,11 +75,20 @@ $data_attributes  = sprintf(
         </div>
 
         <div class="jlg-aio-scores-grid">
-            <?php foreach ( $scores as $key => $score_value ) : ?>
-				<?php $bar_color = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options ); ?>
+            <?php foreach ( $category_scores as $category ) : ?>
+                <?php
+                $score_value = isset( $category['score'] ) ? (float) $category['score'] : null;
+
+                if ( $score_value === null ) {
+                    continue;
+                }
+
+                $label     = isset( $category['label'] ) ? $category['label'] : '';
+                $bar_color = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
+                ?>
             <div class="jlg-aio-score-item">
                 <div class="jlg-aio-score-header">
-                    <span class="jlg-aio-score-label"><?php echo esc_html( $categories[ $key ] ); ?></span>
+                    <span class="jlg-aio-score-label"><?php echo esc_html( $label ); ?></span>
                     <span class="jlg-aio-score-number"><?php echo esc_html( number_format_i18n( $score_value, 1 ) ); ?> / 10</span>
                 </div>
                 <div class="jlg-aio-score-bar-bg">

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -34,13 +34,20 @@ $options = \JLG\Notation\Helpers::get_plugin_options();
     <hr>
     
     <div class="rating-breakdown">
-        <?php
-        foreach ( $scores as $key => $score_value ) :
+        <?php foreach ( $category_scores as $category ) : ?>
+            <?php
+            $score_value = isset( $category['score'] ) ? (float) $category['score'] : null;
+
+            if ( $score_value === null ) {
+                continue;
+            }
+
+            $label     = isset( $category['label'] ) ? $category['label'] : '';
             $bar_color = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
-			?>
+            ?>
             <div class="rating-item">
                 <div class="rating-label">
-                    <span><?php echo esc_html( $categories[ $key ] ); ?></span>
+                    <span><?php echo esc_html( $label ); ?></span>
                     <span>
                         <?php
                         $formatted_score_value = esc_html( number_format_i18n( $score_value, 1 ) );
@@ -54,7 +61,7 @@ $options = \JLG\Notation\Helpers::get_plugin_options();
                     </span>
                 </div>
                 <div class="rating-bar-container">
-                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( $score_value * 10 ); ?>%; --bar-color: <?php echo esc_attr( $bar_color ); ?>;"></div>
+                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( $score_value * 10 ); ?>%; --bar-color:<?php echo esc_attr( $bar_color ); ?>;"></div>
                 </div>
             </div>
         <?php endforeach; ?>

--- a/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
@@ -76,10 +76,14 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
         ]);
         $GLOBALS['jlg_test_meta'][$post_id] = [];
 
+        $definitions     = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $first_meta_key  = $definitions[0]['meta_key'] ?? '_note_gameplay';
+        $second_meta_key = $definitions[1]['meta_key'] ?? '_note_graphismes';
+
         $_POST = [
             'jlg_notation_nonce' => 'nonce',
-            '_note_cat1'         => '9.5',
-            '_note_cat2'         => '8.0',
+            $first_meta_key      => '9.5',
+            $second_meta_key     => '8.0',
             'jlg_details_nonce'  => 'nonce',
             'jlg_game_title'     => 'Custom Review Game',
             'jlg_developpeur'    => 'Studio Test',
@@ -101,8 +105,8 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
 
         $saved_meta = $GLOBALS['jlg_test_meta'][$post_id];
 
-        $this->assertSame(9.5, $saved_meta['_note_cat1']);
-        $this->assertSame(8.0, $saved_meta['_note_cat2']);
+        $this->assertSame(9.5, $saved_meta[$first_meta_key]);
+        $this->assertSame(8.0, $saved_meta[$second_meta_key]);
         $this->assertSame('Custom Review Game', $saved_meta['_jlg_game_title']);
         $this->assertSame('Studio Test', $saved_meta['_jlg_developpeur']);
         $this->assertSame('Publisher Test', $saved_meta['_jlg_editeur']);

--- a/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
@@ -11,6 +11,8 @@ class HelpersRatingCacheTest extends TestCase
         $GLOBALS['jlg_test_meta'] = [];
         $GLOBALS['jlg_test_transients'] = [];
         $GLOBALS['jlg_test_actions'] = [];
+
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
     }
 
     public function test_invalidate_average_score_cache_clears_transient_and_meta(): void
@@ -36,7 +38,9 @@ class HelpersRatingCacheTest extends TestCase
         $GLOBALS['jlg_test_meta'][$post_id]['_jlg_average_score'] = 9.1;
         set_transient('jlg_rated_post_ids_v1', [77]);
 
-        \JLG\Notation\Helpers::maybe_handle_rating_meta_change(0, $post_id, '_note_cat1', '9.5');
+        $primary_meta_key = $this->get_primary_rating_meta_key();
+
+        \JLG\Notation\Helpers::maybe_handle_rating_meta_change(0, $post_id, $primary_meta_key, '9.5');
 
         $this->assertArrayNotHasKey('_jlg_average_score', $GLOBALS['jlg_test_meta'][$post_id] ?? []);
         $this->assertFalse(get_transient('jlg_rated_post_ids_v1'));
@@ -65,12 +69,21 @@ class HelpersRatingCacheTest extends TestCase
         ]);
 
         $GLOBALS['jlg_test_posts'][$post_id] = $post;
-        $GLOBALS['jlg_test_meta'][$post_id]['_note_cat1'] = '9.0';
+        $primary_meta_key = $this->get_primary_rating_meta_key();
+
+        $GLOBALS['jlg_test_meta'][$post_id][$primary_meta_key] = '9.0';
 
         set_transient('jlg_rated_post_ids_v1', [123, 456]);
 
         \JLG\Notation\Helpers::maybe_clear_rated_post_ids_cache_for_status_change('draft', 'publish', $post);
 
         $this->assertFalse(get_transient('jlg_rated_post_ids_v1'));
+    }
+    private function get_primary_rating_meta_key(): string
+    {
+        $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $definition  = $definitions[0] ?? [];
+
+        return isset($definition['meta_key']) ? (string) $definition['meta_key'] : '_note_gameplay';
     }
 }

--- a/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
+++ b/plugin-notation-jeux_V4/tests/MigrationScheduleTest.php
@@ -146,14 +146,18 @@ class MigrationScheduleTest extends TestCase
             'complete' => true,
         ]);
 
+        $definitions     = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $first_meta_key  = $definitions[0]['meta_key'] ?? '_note_gameplay';
+        $second_meta_key = $definitions[1]['meta_key'] ?? '_note_graphismes';
+
         $GLOBALS['jlg_test_meta'] = [
             111 => [
-                '_note_cat1' => 8,
-                '_note_cat2' => 6,
+                $first_meta_key  => 8,
+                $second_meta_key => 6,
             ],
             222 => [
-                '_note_cat1' => 9,
-                '_note_cat2' => 7,
+                $first_meta_key  => 9,
+                $second_meta_key => 7,
             ],
         ];
 

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -194,30 +194,28 @@ class ShortcodeAllInOneRenderTest extends TestCase
         ]);
 
         $GLOBALS['jlg_test_meta'][$post_id] = [
-            '_jlg_tagline_fr'      => 'Meilleur jeu de l\'année',
-            '_jlg_tagline_en'      => 'Game of the year contender',
-            '_jlg_points_forts'    => "Univers immersif\nCombats dynamiques",
-            '_jlg_points_faibles'  => "Quêtes répétitives\nQuelques bugs",
-            '_note_cat1'           => 8.5,
-            '_note_cat2'           => 7.0,
-            '_note_cat3'           => 9.0,
-            '_note_cat4'           => 8.0,
+            '_jlg_tagline_fr'     => 'Meilleur jeu de l\'année',
+            '_jlg_tagline_en'     => 'Game of the year contender',
+            '_jlg_points_forts'   => "Univers immersif\nCombats dynamiques",
+            '_jlg_points_faibles' => "Quêtes répétitives\nQuelques bugs",
         ];
+
+        $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $values      = [8.5, 7.0, 9.0, 8.0, 7.5, 6.5];
+
+        foreach ($definitions as $index => $definition) {
+            if (!isset($definition['meta_key'], $values[$index])) {
+                continue;
+            }
+
+            $GLOBALS['jlg_test_meta'][$post_id][$definition['meta_key']] = $values[$index];
+        }
     }
 
     private function setPluginOptions(array $overrides): void
     {
         $defaults = \JLG\Notation\Helpers::get_default_settings();
-        $base = array_merge($defaults, [
-            'label_cat1' => 'Gameplay',
-            'label_cat2' => 'Graphismes',
-            'label_cat3' => 'Bande-son',
-            'label_cat4' => 'Durée de vie',
-            'label_cat5' => 'Scénario',
-            'label_cat6' => 'Originalité',
-        ]);
-
-        $options = array_merge($base, $overrides);
+        $options  = array_merge($defaults, $overrides);
 
         $GLOBALS['jlg_test_options']['notation_jlg_settings'] = $options;
         \JLG\Notation\Helpers::flush_plugin_options_cache();

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllowedPostTypesTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllowedPostTypesTest.php
@@ -84,8 +84,11 @@ class ShortcodeAllowedPostTypesTest extends TestCase
             'post_status' => 'publish',
         ]);
 
+        $definitions      = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $primary_meta_key = $definitions[0]['meta_key'] ?? '_note_gameplay';
+
         $GLOBALS['jlg_test_meta'][$post_id] = [
-            '_note_cat1' => 8.0,
+            $primary_meta_key => 8.0,
         ];
 
         $shortcode = new \JLG\Notation\Shortcodes\RatingBlock();

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -92,16 +92,25 @@ class ShortcodeSummarySortingTest extends TestCase
 
         $GLOBALS['jlg_test_meta'] = [
             101 => [
-                '_note_cat1' => 8,
                 '_jlg_developpeur' => 'Studio A',
-                '_jlg_editeur' => 'Publisher A',
+                '_jlg_editeur'     => 'Publisher A',
             ],
             202 => [
-                '_note_cat1' => 6,
                 '_jlg_developpeur' => 'Studio B',
-                '_jlg_editeur' => 'Publisher B',
+                '_jlg_editeur'     => 'Publisher B',
             ],
         ];
+
+        $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();
+
+        if (!empty($definitions)) {
+            $first_meta_key = $definitions[0]['meta_key'] ?? null;
+
+            if ($first_meta_key) {
+                $GLOBALS['jlg_test_meta'][101][$first_meta_key] = 8;
+                $GLOBALS['jlg_test_meta'][202][$first_meta_key] = 6;
+            }
+        }
     }
 
     protected function tearDown(): void

--- a/plugin-notation-jeux_V4/tests/ShortcodeVisibilityTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeVisibilityTest.php
@@ -61,17 +61,22 @@ class ShortcodeVisibilityTest extends TestCase
         ]);
 
         $GLOBALS['jlg_test_meta'][$post_id] = [
-            '_note_cat1' => '8',
-            '_note_cat2' => '7',
-            '_note_cat3' => '9',
-            '_note_cat4' => '6',
-            '_note_cat5' => '8',
-            '_note_cat6' => '7',
-            '_jlg_tagline_fr' => 'Un super résumé',
-            '_jlg_tagline_en' => 'A great summary',
-            '_jlg_points_forts' => "Point fort 1\nPoint fort 2",
+            '_jlg_tagline_fr'     => 'Un super résumé',
+            '_jlg_tagline_en'     => 'A great summary',
+            '_jlg_points_forts'   => "Point fort 1\nPoint fort 2",
             '_jlg_points_faibles' => "Point faible 1\nPoint faible 2",
         ];
+
+        $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();
+        $values      = ['8', '7', '9', '6', '8', '7'];
+
+        foreach ($definitions as $index => $definition) {
+            if (!isset($definition['meta_key'], $values[$index])) {
+                continue;
+            }
+
+            $GLOBALS['jlg_test_meta'][$post_id][$definition['meta_key']] = $values[$index];
+        }
     }
 
     private function deny_read_permissions(): void

--- a/plugin-notation-jeux_V4/uninstall.php
+++ b/plugin-notation-jeux_V4/uninstall.php
@@ -34,31 +34,65 @@ if ( $delete_data ) {
     delete_option( 'jlg_notation_delete_data_on_uninstall' );
 
     // Supprimer toutes les métadonnées des posts
-    $meta_keys = array(
-        '_note_cat1',
-                '_note_cat2',
-                '_note_cat3',
-        '_note_cat4',
-                '_note_cat5',
-                '_note_cat6',
-        '_jlg_average_score',
-        '_jlg_game_title',
-        '_jlg_tagline_fr',
-                '_jlg_tagline_en',
-        '_jlg_points_forts',
-                '_jlg_points_faibles',
-        '_jlg_developpeur',
-		'_jlg_editeur',
-        '_jlg_date_sortie',
-		'_jlg_plateformes',
-        '_jlg_cover_image_url',
-		'_jlg_version',
-        '_jlg_pegi',
-		'_jlg_temps_de_jeu',
-        '_jlg_user_ratings',
-		'_jlg_user_rating_avg',
-        '_jlg_user_rating_count',
-		'_jlg_user_rating_ips',
+    $category_meta_keys = array();
+
+    if ( ! class_exists( '\\JLG\\Notation\\Helpers' ) ) {
+        $helpers_file = __DIR__ . '/includes/Helpers.php';
+
+        if ( file_exists( $helpers_file ) ) {
+            require_once $helpers_file;
+        }
+    }
+
+    if ( class_exists( '\\JLG\\Notation\\Helpers' ) ) {
+        $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();
+
+        foreach ( $definitions as $definition ) {
+            if ( ! empty( $definition['meta_key'] ) ) {
+                $category_meta_keys[] = (string) $definition['meta_key'];
+            }
+
+            if ( ! empty( $definition['legacy_meta_keys'] ) && is_array( $definition['legacy_meta_keys'] ) ) {
+                foreach ( $definition['legacy_meta_keys'] as $legacy_meta_key ) {
+                    $category_meta_keys[] = (string) $legacy_meta_key;
+                }
+            }
+        }
+    }
+
+    if ( empty( $category_meta_keys ) ) {
+        $category_meta_keys = array(
+            '_note_cat1',
+            '_note_cat2',
+            '_note_cat3',
+            '_note_cat4',
+            '_note_cat5',
+            '_note_cat6',
+        );
+    }
+
+    $meta_keys = array_merge(
+        array_values( array_unique( $category_meta_keys ) ),
+        array(
+            '_jlg_average_score',
+            '_jlg_game_title',
+            '_jlg_tagline_fr',
+            '_jlg_tagline_en',
+            '_jlg_points_forts',
+            '_jlg_points_faibles',
+            '_jlg_developpeur',
+            '_jlg_editeur',
+            '_jlg_date_sortie',
+            '_jlg_plateformes',
+            '_jlg_cover_image_url',
+            '_jlg_version',
+            '_jlg_pegi',
+            '_jlg_temps_de_jeu',
+            '_jlg_user_ratings',
+            '_jlg_user_rating_avg',
+            '_jlg_user_rating_count',
+            '_jlg_user_rating_ips',
+        )
     );
 
     foreach ( $meta_keys as $meta_key ) {


### PR DESCRIPTION
## Summary
- trigger the legacy rating category migration during plugin bootstrap and activation
- render the all-in-one shortcode template from the dynamic category score collection and clean up uninstall logic
- update unit tests to seed rating metadata via the new helper-provided definitions

## Testing
- `composer test` *(fails: phpunit executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8ad9041c832eb703e7bd5c6133d0