### PR TITLE
Improve admin color picker integration

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -125,6 +125,12 @@ Pour vérifier que les options ne peuvent pas injecter de CSS invalide :
    - La variable `--jlg-score-gradient-1` ne doit contenir aucun morceau comme `background:red;` et revient à la couleur par défaut du plugin (la valeur malicieuse est neutralisée).
 5. Réinitialisez ensuite les couleurs avec des valeurs hexadécimales légitimes pour confirmer que l'affichage redevient normal.
 
+### Vérification du sélecteur de couleurs WordPress
+
+1. Dans **Notation – JLG > Réglages**, ouvrez un champ couleur (par exemple *Fond des lignes*) et choisissez une nouvelle teinte via le color picker WordPress, puis enregistrez. La valeur hex personnalisée doit être conservée après rechargement.
+2. Pour un champ autorisant la transparence, saisissez `transparent` directement dans le champ texte, enregistrez puis vérifiez que l'interface conserve bien la valeur `transparent`.
+3. Utilisez ensuite le bouton de réinitialisation du color picker pour revenir à la couleur par défaut et confirmez que le champ reprend la valeur initiale.
+
 ## Frequently Asked Questions
 
 ### Comment personnaliser les catégories de notation ?

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -121,6 +121,12 @@ Pour valider que des options malicieuses ne génèrent pas de CSS invalide :
    * Vérifiez que `--jlg-score-gradient-1` ne contient pas de fragment `background:red;` et qu'elle revient à la couleur par défaut du plugin (la portion malveillante est supprimée).
 5. Restaurez ensuite des couleurs hexadécimales valides pour confirmer que l'affichage retrouve ses couleurs.
 
+== Vérification du sélecteur de couleurs WordPress ==
+
+1. Depuis **Notation – JLG > Réglages**, ouvrez un champ couleur (par exemple *Fond des lignes*) et sélectionnez une nouvelle teinte avec le color picker WordPress, puis sauvegardez. La valeur hex personnalisée doit être conservée après rechargement.
+2. Pour un champ autorisant la transparence, saisissez `transparent` directement dans le champ texte, enregistrez puis confirmez que l'interface conserve bien la valeur `transparent`.
+3. Utilisez enfin le bouton de réinitialisation du color picker pour revenir à la couleur par défaut et vérifiez que la valeur d'origine est restaurée.
+
 == Frequently Asked Questions ==
 
 = Comment personnaliser les catégories de notation ? =

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -763,7 +763,7 @@ class Settings {
                 'id'                => 'table_row_bg_color',
                 'type'              => 'color',
                 'allow_transparent' => true,
-                'desc'              => 'Le sélecteur accepte aussi "transparent" pour conserver la valeur par défaut.',
+                'desc'              => 'Le sélecteur WordPress accepte le clic ou la saisie libre. Tapez "transparent" pour conserver la valeur par défaut.',
             )
         );
         add_settings_field(
@@ -798,7 +798,7 @@ class Settings {
                 'id'                => 'table_zebra_bg_color',
                 'type'              => 'color',
                 'allow_transparent' => true,
-                'desc'              => 'Utilisez le sélecteur ou saisissez "transparent" pour désactiver la couleur alternée.',
+                'desc'              => 'Utilisez le sélecteur WordPress ou saisissez "transparent" pour désactiver la couleur alternée.',
             )
         );
         add_settings_field(

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -33,6 +33,7 @@ class Assets {
         $plugin_pages = array(
             'toplevel_page_notation_jlg_settings',
             'notation-jlg_page_notation_jlg_settings',
+            'notation_jlg_page_notation_jlg_settings',
         );
 
         if ( ! in_array( $hook_suffix, $plugin_pages, true ) ) {

--- a/plugin-notation-jeux_V4/tests/AdminSettingsSanitizationTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminSettingsSanitizationTest.php
@@ -36,4 +36,34 @@ class AdminSettingsSanitizationTest extends TestCase
         $this->assertSame(50, $sanitized['circle_glow_intensity']);
         $this->assertSame(15, $sanitized['text_glow_intensity']);
     }
+
+    public function test_color_fields_accept_custom_hex_and_transparent(): void
+    {
+        $input = [
+            'table_header_bg_color' => '#ABCDEF',
+            'table_row_bg_color'    => 'Transparent',
+            'table_zebra_bg_color'  => '#123456',
+            'thumb_text_color'      => '#zzzzzz',
+        ];
+
+        $sanitized = $this->settings->sanitize_options($input);
+
+        $this->assertSame('#abcdef', $sanitized['table_header_bg_color']);
+        $this->assertSame('transparent', $sanitized['table_row_bg_color']);
+        $this->assertSame('#123456', $sanitized['table_zebra_bg_color']);
+        $this->assertSame('#ffffff', $sanitized['thumb_text_color']);
+    }
+
+    public function test_transparent_is_preserved_for_zebra_background(): void
+    {
+        $input = [
+            'table_row_bg_color'   => 'transparent',
+            'table_zebra_bg_color' => 'transparent',
+        ];
+
+        $sanitized = $this->settings->sanitize_options($input);
+
+        $this->assertSame('transparent', $sanitized['table_row_bg_color']);
+        $this->assertSame('transparent', $sanitized['table_zebra_bg_color']);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the plugin admin pages always load the WordPress color picker assets
- refresh the in-app help text and documentation to highlight the enhanced picker behaviour
- cover custom hex and transparent values in the settings sanitization tests

## Testing
- composer install
- composer test *(fails: bootstrap expects WordPress helpers not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f7cf330832e829165f6fac4d72d