### PR TITLE
Refactor admin templates to use shared styles

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/admin-page.php
+++ b/plugin-notation-jeux_V4/admin/templates/admin-page.php
@@ -5,13 +5,15 @@ $page_title = $variables['page_title'] ?? '';
 $tab_navigation = $variables['tab_navigation'] ?? '';
 $tab_content = $variables['tab_content'] ?? '';
 ?>
-<div class="wrap">
+<div class="wrap jlg-admin-page"<?php echo ! empty( $page_title ) ? ' role="region" aria-label="' . esc_attr( $page_title ) . '"' : ''; ?>>
     <?php if (!empty($page_title)) : ?>
         <h1><?php echo esc_html($page_title); ?></h1>
     <?php endif; ?>
     <?php echo $tab_navigation; ?>
-    <div style="background:#fff; padding:20px; margin-top:20px; border-radius:8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
-        <?php echo $tab_content; ?>
+    <div class="components-card jlg-admin-card" role="presentation">
+        <div class="components-card__body">
+            <?php echo $tab_content; ?>
+        </div>
     </div>
 </div>
 

--- a/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
@@ -13,55 +13,70 @@ $column_count = count($columns) + 2;
 <h2>📊 Vos Articles avec Notation</h2>
 
 <?php if (!$has_rated_posts) : ?>
-    <div style="text-align:center; padding:40px; background:#f9f9f9; border-radius:8px; margin-top:20px;">
-        <h3>🎮 Aucun test trouvé</h3>
-        <p>Créez votre premier article avec notation !</p>
-        <a href="<?php echo esc_url($empty_state['create_post_url'] ?? admin_url('post-new.php')); ?>" class="button button-primary">✏️ Créer un Test</a>
+    <div class="components-card jlg-empty-state" role="status" aria-live="polite">
+        <div class="components-card__body">
+            <h3 class="jlg-empty-state__title">🎮 Aucun test trouvé</h3>
+            <p class="jlg-empty-state__description">Créez votre premier article avec notation !</p>
+            <a href="<?php echo esc_url($empty_state['create_post_url'] ?? admin_url('post-new.php')); ?>" class="button button-primary jlg-empty-state__action">✏️ Créer un Test</a>
+        </div>
     </div>
 <?php else : ?>
     <?php if (!empty($stats)) : ?>
-        <div style="background:#f0f6fc; padding:15px; border-radius:4px; margin-bottom:20px;">
-            <?php
-            printf(
-                '<strong>%d</strong> articles avec notation trouvés • Page <strong>%d</strong> sur <strong>%d</strong> • Affichage de <strong>%d</strong> articles',
-                intval($stats['total_items'] ?? 0),
-                intval($stats['current_page'] ?? 1),
-                max(1, intval($stats['total_pages'] ?? 1)),
-                intval($stats['display_count'] ?? 0)
-            );
-            ?>
+        <div class="notice notice-info jlg-stats-notice" role="status" aria-live="polite">
+            <p>
+                <?php
+                printf(
+                    /* translators: 1: total posts, 2: current page, 3: total pages, 4: posts displayed */
+                    '<strong>%1$d</strong> articles avec notation trouvés • Page <strong>%2$d</strong> sur <strong>%3$d</strong> • Affichage de <strong>%4$d</strong> articles',
+                    intval($stats['total_items'] ?? 0),
+                    intval($stats['current_page'] ?? 1),
+                    max(1, intval($stats['total_pages'] ?? 1)),
+                    intval($stats['display_count'] ?? 0)
+                );
+                ?>
+            </p>
         </div>
     <?php endif; ?>
 
-    <table class="wp-list-table widefat striped">
+    <table class="wp-list-table widefat striped" role="table">
         <thead>
             <tr>
                 <?php foreach ($columns as $column) : ?>
                     <th scope="col" class="<?php echo esc_attr($column['class'] ?? ''); ?>" aria-sort="<?php echo esc_attr($column['aria_sort'] ?? 'none'); ?>">
-                        <a href="<?php echo esc_url($column['url'] ?? '#'); ?>">
+                        <a href="<?php echo esc_url($column['url'] ?? '#'); ?>" class="jlg-link--reset">
                             <span><?php echo esc_html($column['label'] ?? ''); ?></span>
                             <span class="sorting-indicator" aria-hidden="true"></span>
                         </a>
                     </th>
                 <?php endforeach; ?>
-                <th><?php echo esc_html('Catégories'); ?></th>
-                <th><?php echo esc_html('Actions'); ?></th>
+                <th scope="col"><?php echo esc_html('Catégories'); ?></th>
+                <th scope="col"><?php echo esc_html('Actions'); ?></th>
             </tr>
         </thead>
         <tbody>
             <?php if (!empty($posts)) : ?>
                 <?php foreach ($posts as $post) :
                     $categories = isset($post['categories']) && is_array($post['categories']) ? $post['categories'] : [];
+                    $score_color = $post['score_color'] ?? '#0073aa';
+                    $score_style = sprintf(' style="--jlg-score-color:%s;"', esc_attr($score_color));
                     ?>
                     <tr>
-                        <td><strong><a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>"><?php echo esc_html($post['title'] ?? ''); ?></a></strong></td>
-                        <td><?php echo esc_html($post['date'] ?? ''); ?></td>
-                        <td><strong style="color:<?php echo esc_attr($post['score_color'] ?? '#0073aa'); ?>;"><?php echo esc_html($post['score_display'] ?? ''); ?></strong>/10</td>
-                        <td><?php echo !empty($categories) ? esc_html(implode(', ', $categories)) : '-'; ?></td>
                         <td>
-                            <a href="<?php echo esc_url($post['view_link'] ?? '#'); ?>" target="_blank" rel="noopener noreferrer">👁 Voir</a>
-                            |
-                            <a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>">✏️ Modifier</a>
+                            <strong>
+                                <a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>" class="jlg-link--reset">
+                                    <?php echo esc_html($post['title'] ?? ''); ?>
+                                </a>
+                            </strong>
+                        </td>
+                        <td><?php echo esc_html($post['date'] ?? ''); ?></td>
+                        <td>
+                            <strong class="jlg-score"<?php echo $score_style; ?>><?php echo esc_html($post['score_display'] ?? ''); ?></strong>/10
+                        </td>
+                        <td><?php echo !empty($categories) ? esc_html(implode(', ', $categories)) : '-'; ?></td>
+                        <td class="jlg-admin-actions jlg-admin-actions--inline">
+                            <a href="<?php echo esc_url($post['view_link'] ?? '#'); ?>" target="_blank" rel="noopener noreferrer" class="jlg-link--action">👁 Voir</a>
+                            <span aria-hidden="true">|</span>
+                            <a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>" class="jlg-link--action">✏️ Modifier</a>
                         </td>
                     </tr>
                 <?php endforeach; ?>
@@ -74,7 +89,7 @@ $column_count = count($columns) + 2;
     </table>
 
     <?php if (!empty($pagination)) : ?>
-        <div class="tablenav bottom">
+        <div class="tablenav bottom" role="navigation" aria-label="Pagination des articles notés">
             <div class="tablenav-pages">
                 <?php echo wp_kses_post($pagination); ?>
             </div>
@@ -82,9 +97,10 @@ $column_count = count($columns) + 2;
     <?php endif; ?>
 
     <?php if (!empty($print_button_label)) : ?>
-        <div style="margin-top:20px;">
-            <p><a href="#" class="button" onclick="window.print(); return false;"><?php echo esc_html($print_button_label); ?></a></p>
+        <div class="jlg-admin-actions jlg-admin-actions--end">
+            <a href="#" class="button jlg-admin-actions__print" onclick="window.print(); return false;">
+                <?php echo esc_html($print_button_label); ?>
+            </a>
         </div>
     <?php endif; ?>
 <?php endif; ?>
-

--- a/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
@@ -4,179 +4,172 @@ if (!defined('ABSPATH')) exit;
 <h2>📝 Documentation des Shortcodes</h2>
 <p>Référence complète de tous les shortcodes disponibles avec leurs paramètres.</p>
 
-<!-- NOUVEAU : Bloc tout-en-un en premier -->
-<div style="background:#e8f5e9; padding:20px; margin:20px 0; border-left:4px solid #4caf50; border-radius:4px;">
-    <h3 style="color:#2e7d32; margin-top:0;">🆕 NOUVEAU : Bloc Complet Tout-en-Un</h3>
-    <p><strong>Le shortcode le plus complet qui combine notation, points forts/faibles et tagline en un seul bloc élégant !</strong></p>
-</div>
+<section class="components-card jlg-section-card jlg-section-card--success jlg-admin-section" role="region" aria-labelledby="jlg-shortcodes-hero">
+    <div class="components-card__body">
+        <h3 id="jlg-shortcodes-hero" class="jlg-section-card__title">🆕 NOUVEAU : Bloc Complet Tout-en-Un</h3>
+        <p><strong>Le shortcode le plus complet qui combine notation, points forts/faibles et tagline en un seul bloc élégant !</strong></p>
+    </div>
+</section>
 
-<div style="margin-top:30px;">
+<section class="jlg-admin-section" aria-labelledby="jlg-shortcodes-featured">
+    <div class="components-card jlg-section-card jlg-section-card--highlight" role="region" aria-labelledby="jlg-shortcodes-featured">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcodes-featured">⭐ 1. Bloc Complet Tout-en-Un (RECOMMANDÉ)</h3>
+            <div class="jlg-badge-group" role="group" aria-label="Alias du shortcode">
+                <code class="jlg-code jlg-code--inline">[jlg_bloc_complet]</code>
+                <span class="jlg-code-separator" aria-hidden="true">ou</span>
+                <code class="jlg-code jlg-code--inline">[bloc_notation_complet]</code>
+            </div>
+            <p class="jlg-highlight-text">✨ Combine en un seul bloc : Tagline + Notation complète + Points forts/faibles</p>
 
-    <!-- NOUVEAU SHORTCODE : Bloc Complet -->
-    <div style="background:#f0f8ff; padding:20px; margin-bottom:20px; border-left:4px solid #4caf50; border-radius:4px; border:2px solid #4caf50;">
-        <h3>⭐ 1. Bloc Complet Tout-en-Un (RECOMMANDÉ)</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[jlg_bloc_complet]</code>
-        <span style="margin-left:10px;">ou</span>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px; font-size:16px;">[bloc_notation_complet]</code>
+            <h4>Paramètres :</h4>
+            <ul class="jlg-bullet-list">
+                <li><strong>post_id</strong> : ID de l'article (défaut : article actuel)</li>
+                <li><strong>afficher_notation</strong> : "oui" ou "non" (défaut : "oui")</li>
+                <li><strong>afficher_points</strong> : "oui" ou "non" (défaut : "oui")</li>
+                <li><strong>afficher_tagline</strong> : "oui" ou "non" (défaut : "oui")</li>
+                <li><strong>style</strong> : "moderne", "classique" ou "compact" (défaut : "moderne")</li>
+                <li><strong>couleur_accent</strong> : Code couleur hex (ex: "#60a5fa")</li>
+                <li><strong>titre_points_forts</strong> : Titre personnalisé (défaut : "Points Forts")</li>
+                <li><strong>titre_points_faibles</strong> : Titre personnalisé (défaut : "Points Faibles")</li>
+            </ul>
 
-        <p style="color:#2e7d32; font-weight:bold;">✨ Combine en un seul bloc : Tagline + Notation complète + Points forts/faibles</p>
+            <h4>Exemples d'utilisation :</h4>
+            <pre class="jlg-code-block"><?php echo esc_html(implode("\n\n", array(
+                '// Bloc complet avec tous les éléments (recommandé)\n[jlg_bloc_complet]',
+                '// Sans la tagline du haut\n[jlg_bloc_complet afficher_tagline="non"]',
+                '// Style compact pour économiser l\'espace\n[jlg_bloc_complet style="compact"]',
+                '// Avec couleur personnalisée\n[jlg_bloc_complet couleur_accent="#ff6b6b"]',
+                '// Seulement notation et points (sans tagline)\n[jlg_bloc_complet afficher_tagline="non"]',
+                '// Configuration complète personnalisée\n[jlg_bloc_complet style="moderne" couleur_accent="#8b5cf6" titre_points_forts="Les +" titre_points_faibles="Les -"]'
+            ))); ?></pre>
 
-        <h4>Paramètres :</h4>
-        <ul>
-            <li><strong>post_id</strong> : ID de l'article (défaut : article actuel)</li>
-            <li><strong>afficher_notation</strong> : "oui" ou "non" (défaut : "oui")</li>
-            <li><strong>afficher_points</strong> : "oui" ou "non" (défaut : "oui")</li>
-            <li><strong>afficher_tagline</strong> : "oui" ou "non" (défaut : "oui")</li>
-            <li><strong>style</strong> : "moderne", "classique" ou "compact" (défaut : "moderne")</li>
-            <li><strong>couleur_accent</strong> : Code couleur hex (ex: "#60a5fa")</li>
-            <li><strong>titre_points_forts</strong> : Titre personnalisé (défaut : "Points Forts")</li>
-            <li><strong>titre_points_faibles</strong> : Titre personnalisé (défaut : "Points Faibles")</li>
-        </ul>
-
-        <h4>Exemples d'utilisation :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-<span style="color:#666;">// Bloc complet avec tous les éléments (recommandé)</span>
-[jlg_bloc_complet]
-
-<span style="color:#666;">// Sans la tagline du haut</span>
-[jlg_bloc_complet afficher_tagline="non"]
-
-<span style="color:#666;">// Style compact pour économiser l'espace</span>
-[jlg_bloc_complet style="compact"]
-
-<span style="color:#666;">// Avec couleur personnalisée</span>
-[jlg_bloc_complet couleur_accent="#ff6b6b"]
-
-<span style="color:#666;">// Seulement notation et points (sans tagline)</span>
-[jlg_bloc_complet afficher_tagline="non"]
-
-<span style="color:#666;">// Configuration complète personnalisée</span>
-[jlg_bloc_complet style="moderne" couleur_accent="#8b5cf6" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
-
-        <div style="background:#e8f5e9; padding:10px; margin-top:10px; border-radius:4px;">
-            <strong>💡 Conseil :</strong> Ce shortcode est idéal pour remplacer les 3 shortcodes séparés et avoir une présentation unifiée et professionnelle.
+            <div class="jlg-callout jlg-callout--success" role="note">
+                <strong>💡 Conseil :</strong> Ce shortcode est idéal pour remplacer les 3 shortcodes séparés et avoir une présentation unifiée et professionnelle.
+            </div>
         </div>
     </div>
+</section>
 
-    <hr style="margin: 30px 0; border:none; border-top:2px solid #e0e0e0;">
+<hr class="jlg-divider" aria-hidden="true">
 
-    <h3 style="color:#666; margin-bottom:20px;">Shortcodes individuels (si vous préférez les utiliser séparément)</h3>
+<section class="jlg-admin-section" aria-label="Shortcodes individuels">
+    <h3 class="jlg-section-heading">Shortcodes individuels (si vous préférez les utiliser séparément)</h3>
 
-    <!-- Bloc de notation principal -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>2. Bloc de Notation Principal (seul)</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[bloc_notation_jeu]</code>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-notation">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-notation">2. Bloc de Notation Principal (seul)</h3>
+            <code class="jlg-code jlg-code--inline">[bloc_notation_jeu]</code>
 
-        <h4>Paramètres :</h4>
-        <ul>
-            <li><strong>post_id</strong> (optionnel) : ID d'un article spécifique. Par défaut : article actuel</li>
-        </ul>
+            <h4>Paramètres :</h4>
+            <ul class="jlg-bullet-list">
+                <li><strong>post_id</strong> (optionnel) : ID d'un article spécifique. Par défaut : article actuel</li>
+            </ul>
 
-        <h4>Exemples :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[bloc_notation_jeu]
+            <h4>Exemples :</h4>
+            <pre class="jlg-code-block">[bloc_notation_jeu]
 [bloc_notation_jeu post_id="123"]</pre>
-    </div>
+        </div>
+    </article>
 
-    <!-- Fiche technique -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>3. Fiche Technique</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_fiche_technique]</code>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-fiche-technique">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-fiche-technique">3. Fiche Technique</h3>
+            <code class="jlg-code jlg-code--inline">[jlg_fiche_technique]</code>
 
-        <h4>Paramètres :</h4>
-        <ul>
-            <li><strong>titre</strong> : Titre du bloc (défaut : "Fiche Technique")</li>
-            <li><strong>champs</strong> : Champs à afficher, séparés par des virgules</li>
-        </ul>
+            <h4>Paramètres :</h4>
+            <ul class="jlg-bullet-list">
+                <li><strong>titre</strong> : Titre du bloc (défaut : "Fiche Technique")</li>
+                <li><strong>champs</strong> : Champs à afficher, séparés par des virgules</li>
+            </ul>
 
-        <h4>Champs disponibles :</h4>
-        <ul style="columns:2;">
-            <li>developpeur</li>
-            <li>editeur</li>
-            <li>date_sortie</li>
-            <li>version</li>
-            <li>pegi</li>
-            <li>temps_de_jeu</li>
-            <li>plateformes</li>
-        </ul>
+            <h4>Champs disponibles :</h4>
+            <ul class="jlg-bullet-list jlg-bullet-list--columns">
+                <li>developpeur</li>
+                <li>editeur</li>
+                <li>date_sortie</li>
+                <li>version</li>
+                <li>pegi</li>
+                <li>temps_de_jeu</li>
+                <li>plateformes</li>
+            </ul>
 
-        <h4>Exemples :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[jlg_fiche_technique]
+            <h4>Exemples :</h4>
+            <pre class="jlg-code-block">[jlg_fiche_technique]
 [jlg_fiche_technique titre="Informations"]
 [jlg_fiche_technique champs="developpeur,editeur,date_sortie"]
 [jlg_fiche_technique titre="Info Rapide" champs="plateformes,pegi"]</pre>
-    </div>
+        </div>
+    </article>
 
-    <!-- Tableau récapitulatif -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>4. Tableau Récapitulatif</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_tableau_recap]</code>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-tableau">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-tableau">4. Tableau Récapitulatif</h3>
+            <code class="jlg-code jlg-code--inline">[jlg_tableau_recap]</code>
 
-        <h4>Paramètres :</h4>
-        <ul>
-            <li><strong>posts_per_page</strong> : Nombre d'articles par page (défaut : 12)</li>
-            <li><strong>layout</strong> : "table" ou "grid" (défaut : "table")</li>
-            <li><strong>categorie</strong> : Slug de catégorie à filtrer</li>
-            <li><strong>colonnes</strong> : Colonnes à afficher (table uniquement)</li>
-        </ul>
+            <h4>Paramètres :</h4>
+            <ul class="jlg-bullet-list">
+                <li><strong>posts_per_page</strong> : Nombre d'articles par page (défaut : 12)</li>
+                <li><strong>layout</strong> : "table" ou "grid" (défaut : "table")</li>
+                <li><strong>categorie</strong> : Slug de catégorie à filtrer</li>
+                <li><strong>colonnes</strong> : Colonnes à afficher (table uniquement)</li>
+            </ul>
 
-        <h4>Colonnes disponibles :</h4>
-        <ul>
-            <li><strong>titre</strong> : Titre du jeu</li>
-            <li><strong>date</strong> : Date de publication</li>
-            <li><strong>note</strong> : Note moyenne</li>
-            <li><strong>developpeur</strong> : Développeur</li>
-            <li><strong>editeur</strong> : Éditeur</li>
-        </ul>
+            <h4>Colonnes disponibles :</h4>
+            <ul class="jlg-bullet-list">
+                <li><strong>titre</strong> : Titre du jeu</li>
+                <li><strong>date</strong> : Date de publication</li>
+                <li><strong>note</strong> : Note moyenne</li>
+                <li><strong>developpeur</strong> : Développeur</li>
+                <li><strong>editeur</strong> : Éditeur</li>
+            </ul>
 
-        <p><strong>Tri :</strong> les en-têtes sont cliquables pour ordonner les résultats par titre (`orderby=title`), date (`orderby=date`), note moyenne (`orderby=average_score`) ainsi que par métadonnées développeur ou éditeur (`orderby=meta__jlg_developpeur`, `orderby=meta__jlg_editeur`).</p>
+            <p><strong>Tri :</strong> les en-têtes sont cliquables pour ordonner les résultats par titre (<code class="jlg-code jlg-code--inline">orderby=title</code>), date (<code class="jlg-code jlg-code--inline">orderby=date</code>), note moyenne (<code class="jlg-code jlg-code--inline">orderby=average_score</code>) ainsi que par métadonnées développeur ou éditeur (<code class="jlg-code jlg-code--inline">orderby=meta__jlg_developpeur</code>, <code class="jlg-code jlg-code--inline">orderby=meta__jlg_editeur</code>).</p>
 
-        <h4>Exemples :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
-[jlg_tableau_recap]
+            <h4>Exemples :</h4>
+            <pre class="jlg-code-block">[jlg_tableau_recap]
 [jlg_tableau_recap layout="grid"]
 [jlg_tableau_recap posts_per_page="20"]
 [jlg_tableau_recap categorie="fps"]
 [jlg_tableau_recap colonnes="titre,note,developpeur"]
 [jlg_tableau_recap layout="grid" posts_per_page="16" categorie="rpg"]
 [jlg_tableau_recap colonnes="titre,date,note,editeur" posts_per_page="30"]</pre>
-    </div>
+        </div>
+    </article>
 
-    <!-- Points forts/faibles -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>5. Points Forts et Faibles (seuls)</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[jlg_points_forts_faibles]</code>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-points">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-points">5. Points Forts et Faibles (seuls)</h3>
+            <code class="jlg-code jlg-code--inline">[jlg_points_forts_faibles]</code>
+            <p>Affiche automatiquement les points forts et faibles définis dans les métadonnées de l'article.</p>
+            <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
 
-        <p>Affiche automatiquement les points forts et faibles définis dans les métadonnées de l'article.</p>
-        <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
+            <h4>Exemple :</h4>
+            <pre class="jlg-code-block">[jlg_points_forts_faibles]</pre>
+        </div>
+    </article>
 
-        <h4>Exemple :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[jlg_points_forts_faibles]</pre>
-    </div>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-tagline">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-tagline">6. Tagline Bilingue (seule)</h3>
+            <code class="jlg-code jlg-code--inline">[tagline_notation_jlg]</code>
+            <p>Affiche la phrase d'accroche avec switch de langue FR/EN.</p>
+            <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
 
-    <!-- Tagline -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>6. Tagline Bilingue (seule)</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[tagline_notation_jlg]</code>
+            <h4>Exemple :</h4>
+            <pre class="jlg-code-block">[tagline_notation_jlg]</pre>
+        </div>
+    </article>
 
-        <p>Affiche la phrase d'accroche avec switch de langue FR/EN.</p>
-        <p><em>Pas de paramètres - utilise les données de l'article actuel.</em></p>
+    <article class="components-card jlg-section-card" role="region" aria-labelledby="jlg-shortcode-users">
+        <div class="components-card__body">
+            <h3 id="jlg-shortcode-users">7. Notation Utilisateurs</h3>
+            <code class="jlg-code jlg-code--inline">[notation_utilisateurs_jlg]</code>
+            <p>Permet aux visiteurs de voter (système 5 étoiles).</p>
+            <p><em>Pas de paramètres - utilise l'article actuel.</em></p>
 
-        <h4>Exemple :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[tagline_notation_jlg]</pre>
-    </div>
-
-    <!-- Notation utilisateurs -->
-    <div style="background:#f9f9f9; padding:20px; margin-bottom:20px; border-left:4px solid #0073aa; border-radius:4px;">
-        <h3>7. Notation Utilisateurs</h3>
-        <code style="background:#fff; padding:5px 10px; display:inline-block; border-radius:3px;">[notation_utilisateurs_jlg]</code>
-
-        <p>Permet aux visiteurs de voter (système 5 étoiles).</p>
-        <p><em>Pas de paramètres - utilise l'article actuel.</em></p>
-
-        <h4>Exemple :</h4>
-        <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">[notation_utilisateurs_jlg]</pre>
-    </div>
-</div>
-
+            <h4>Exemple :</h4>
+            <pre class="jlg-code-block">[notation_utilisateurs_jlg]</pre>
+        </div>
+    </article>
+</section>

--- a/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
@@ -7,75 +7,94 @@ $platforms_url = $variables['platforms_url'] ?? '';
 <h2>📚 Guide d'Utilisation</h2>
 <p>Tutoriels et guides pour tirer le meilleur parti du plugin.</p>
 
-<div style="background:linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:white; padding:30px; border-radius:12px; margin:30px 0; box-shadow: 0 10px 25px rgba(102,126,234,0.3);">
-    <h2 style="color:white; margin-top:0;">🚀 Nouveauté : Bloc Complet Tout-en-Un</h2>
-    <p style="font-size:18px; margin-bottom:20px;">Simplifiez votre workflow avec le nouveau shortcode <code style="background:rgba(255,255,255,0.2); padding:3px 8px; border-radius:4px;">[jlg_bloc_complet]</code> qui combine automatiquement :</p>
-    <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(200px, 1fr)); gap:15px;">
-        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Tagline bilingue</div>
-        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Notation détaillée</div>
-        <div style="background:rgba(255,255,255,0.1); padding:15px; border-radius:8px;">✅ Points forts/faibles</div>
-    </div>
-    <p style="margin-top:20px;"><strong>Un seul shortcode pour tout afficher de manière élégante et cohérente !</strong></p>
-</div>
-
-<div class="jlg-tutorial-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap:20px; margin-top:30px;">
-    <?php foreach ($tutorials as $tutorial) :
-        $steps = isset($tutorial['steps']) && is_array($tutorial['steps']) ? $tutorial['steps'] : [];
-        ?>
-        <div style="background:#f9f9f9; padding:20px; border-radius:8px; border-left:4px solid #0073aa;">
-            <h3><?php echo esc_html($tutorial['title'] ?? ''); ?></h3>
-            <p><?php echo esc_html($tutorial['content'] ?? ''); ?></p>
-            <?php if (!empty($steps)) : ?>
-                <ol style="margin-left:20px;">
-                    <?php foreach ($steps as $step) : ?>
-                        <li><?php echo esc_html($step); ?></li>
-                    <?php endforeach; ?>
-                </ol>
-            <?php endif; ?>
+<section class="components-card jlg-hero-card jlg-admin-section" role="region" aria-labelledby="jlg-hero-card-title">
+    <div class="components-card__body">
+        <h2 id="jlg-hero-card-title" class="jlg-hero-card__title">🚀 Nouveauté : Bloc Complet Tout-en-Un</h2>
+        <p class="jlg-hero-card__lead">Simplifiez votre workflow avec le nouveau shortcode <code class="jlg-code">[jlg_bloc_complet]</code> qui combine automatiquement :</p>
+        <div class="jlg-feature-grid" role="list">
+            <div class="jlg-feature-pill" role="listitem">✅ Tagline bilingue</div>
+            <div class="jlg-feature-pill" role="listitem">✅ Notation détaillée</div>
+            <div class="jlg-feature-pill" role="listitem">✅ Points forts/faibles</div>
         </div>
-    <?php endforeach; ?>
-</div>
+        <p class="jlg-hero-card__foot"><strong>Un seul shortcode pour tout afficher de manière élégante et cohérente !</strong></p>
+    </div>
+</section>
 
-<div style="background:#e3f2fd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #2196f3;">
-    <h3>📝 Exemples d'utilisation du Bloc Complet</h3>
-    <p>Voici différentes configurations possibles pour le shortcode <code>[jlg_bloc_complet]</code> :</p>
-    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
-        <h4>Configuration minimale (recommandée pour débuter) :</h4>
-        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #4caf50;">[jlg_bloc_complet]</pre>
+<section class="jlg-admin-section" aria-label="Tutoriels guidés">
+    <div class="jlg-card-grid" role="list">
+        <?php foreach ($tutorials as $tutorial) :
+            $steps = isset($tutorial['steps']) && is_array($tutorial['steps']) ? $tutorial['steps'] : [];
+            ?>
+            <article class="components-card jlg-tutorial-card" role="listitem">
+                <div class="components-card__body">
+                    <h3 class="jlg-tutorial-card__title"><?php echo esc_html($tutorial['title'] ?? ''); ?></h3>
+                    <p class="jlg-tutorial-card__description"><?php echo esc_html($tutorial['content'] ?? ''); ?></p>
+                    <?php if (!empty($steps)) : ?>
+                        <ol class="jlg-tutorial-card__steps">
+                            <?php foreach ($steps as $step) : ?>
+                                <li><?php echo esc_html($step); ?></li>
+                            <?php endforeach; ?>
+                        </ol>
+                    <?php endif; ?>
+                </div>
+            </article>
+        <?php endforeach; ?>
     </div>
-    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
-        <h4>Style compact sans tagline :</h4>
-        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #ff9800;">[jlg_bloc_complet style="compact" afficher_tagline="non"]</pre>
-    </div>
-    <div style="background:white; padding:15px; border-radius:4px; margin-top:15px;">
-        <h4>Personnalisation complète :</h4>
-        <pre style="background:#f5f5f5; padding:10px; border-left:3px solid #9c27b0;">[jlg_bloc_complet style="moderne" couleur_accent="#e91e63" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
-    </div>
-</div>
+</section>
 
-<div style="background:#fce4ec; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #e91e63;">
-    <h3>🔄 Migration vers le Bloc Complet</h3>
-    <p><strong>Vous utilisez déjà les shortcodes séparés ?</strong> Voici comment migrer :</p>
-    <table style="width:100%; background:white; border-radius:4px; overflow:hidden; margin-top:15px;">
-        <tr style="background:#f5f5f5;">
-            <th style="padding:10px; text-align:left;">Avant (3 shortcodes)</th>
-            <th style="padding:10px; text-align:left;">Après (1 shortcode)</th>
-        </tr>
-        <tr>
-            <td style="padding:10px; border-top:1px solid #ddd;"><pre>[tagline_notation_jlg]
+<section class="components-card jlg-section-card jlg-section-card--info jlg-admin-section" role="region" aria-labelledby="jlg-examples-title">
+    <div class="components-card__body">
+        <h3 id="jlg-examples-title">📝 Exemples d'utilisation du Bloc Complet</h3>
+        <p>Voici différentes configurations possibles pour le shortcode <code class="jlg-code">[jlg_bloc_complet]</code> :</p>
+        <div class="jlg-example-list">
+            <div class="jlg-example-card">
+                <h4>Configuration minimale (recommandée pour débuter) :</h4>
+                <pre class="jlg-code-block">[jlg_bloc_complet]</pre>
+            </div>
+            <div class="jlg-example-card">
+                <h4>Style compact sans tagline :</h4>
+                <pre class="jlg-code-block">[jlg_bloc_complet style="compact" afficher_tagline="non"]</pre>
+            </div>
+            <div class="jlg-example-card">
+                <h4>Personnalisation complète :</h4>
+                <pre class="jlg-code-block">[jlg_bloc_complet style="moderne" couleur_accent="#e91e63" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="components-card jlg-section-card jlg-section-card--migration jlg-admin-section" role="region" aria-labelledby="jlg-migration-title">
+    <div class="components-card__body">
+        <h3 id="jlg-migration-title">🔄 Migration vers le Bloc Complet</h3>
+        <p><strong>Vous utilisez déjà les shortcodes séparés ?</strong> Voici comment migrer :</p>
+        <div class="jlg-table-wrapper" role="group" aria-label="Comparaison avant après">
+            <table class="jlg-compare-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Avant (3 shortcodes)</th>
+                        <th scope="col">Après (1 shortcode)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><pre class="jlg-code-block">[tagline_notation_jlg]
 [bloc_notation_jeu]
 [jlg_points_forts_faibles]</pre></td>
-            <td style="padding:10px; border-top:1px solid #ddd;"><pre>[jlg_bloc_complet]</pre></td>
-        </tr>
-    </table>
-    <p style="margin-top:15px;"><em>✅ Plus simple, plus cohérent, même résultat en mieux !</em></p>
-</div>
+                        <td><pre class="jlg-code-block">[jlg_bloc_complet]</pre></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class="jlg-migration-note"><em>✅ Plus simple, plus cohérent, même résultat en mieux !</em></p>
+    </div>
+</section>
 
-<div style="background:#fff3cd; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #ffc107;">
-    <h3>💡 Astuce Pro</h3>
-    <p><strong>Pour une intégration optimale :</strong> Créez un template d'article dédié aux tests dans votre thème avec le shortcode <code>[jlg_bloc_complet]</code> pré-intégré. Ainsi, vous n'aurez plus qu'à remplir les métadonnées !</p>
-    <p style="margin-top:10px;">Exemple de template personnalisé :</p>
-    <pre style="background:#f5f5f5; padding:10px; border-radius:4px;">&lt;?php
+<section class="components-card jlg-section-card jlg-section-card--tip jlg-admin-section" role="region" aria-labelledby="jlg-pro-tip-title">
+    <div class="components-card__body">
+        <h3 id="jlg-pro-tip-title">💡 Astuce Pro</h3>
+        <p><strong>Pour une intégration optimale :</strong> Créez un template d'article dédié aux tests dans votre thème avec le shortcode <code class="jlg-code">[jlg_bloc_complet]</code> pré-intégré. Ainsi, vous n'aurez plus qu'à remplir les métadonnées !</p>
+        <p>Exemple de template personnalisé :</p>
+        <pre class="jlg-code-block">&lt;?php
 // Dans votre template single-test.php
 if (have_posts()) : while (have_posts()) : the_post(); ?&gt;
     &lt;article&gt;
@@ -91,42 +110,47 @@ if (have_posts()) : while (have_posts()) : the_post(); ?&gt;
         &lt;?php echo do_shortcode('[notation_utilisateurs_jlg]'); ?&gt;
     &lt;/article&gt;
 &lt;?php endwhile; endif; ?&gt;</pre>
-</div>
+    </div>
+</section>
 
-<div style="background:#f3e5f5; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #9c27b0;">
-    <h3>❓ Questions Fréquentes sur le Bloc Complet</h3>
-    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
-        <summary style="cursor:pointer; font-weight:bold;">Puis-je utiliser le bloc complet ET les shortcodes séparés ?</summary>
-        <p style="margin-top:10px;">Oui, mais évitez la duplication. Utilisez soit le bloc complet, soit les shortcodes individuels, pas les deux ensemble.</p>
-    </details>
-    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
-        <summary style="cursor:pointer; font-weight:bold;">Comment changer l'ordre des sections ?</summary>
-        <p style="margin-top:10px;">L'ordre est fixe (Tagline → Notation → Points), mais vous pouvez masquer des sections avec les paramètres afficher_*="non".</p>
-    </details>
-    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
-        <summary style="cursor:pointer; font-weight:bold;">Le bloc complet est-il plus lourd en performance ?</summary>
-        <p style="margin-top:10px;">Non, au contraire ! Un seul shortcode est plus performant que trois shortcodes séparés.</p>
-    </details>
-    <details style="margin:10px 0; background:white; padding:10px; border-radius:4px;">
-        <summary style="cursor:pointer; font-weight:bold;">Puis-je avoir plusieurs blocs complets sur la même page ?</summary>
-        <p style="margin-top:10px;">Oui, en utilisant le paramètre post_id pour cibler différents articles : [jlg_bloc_complet post_id="123"]</p>
-    </details>
-</div>
+<section class="components-card jlg-section-card jlg-section-card--faq jlg-admin-section" role="region" aria-labelledby="jlg-faq-title">
+    <div class="components-card__body">
+        <h3 id="jlg-faq-title">❓ Questions Fréquentes sur le Bloc Complet</h3>
+        <div class="jlg-faq-list">
+            <details class="jlg-faq" data-level="0">
+                <summary>Puis-je utiliser le bloc complet ET les shortcodes séparés ?</summary>
+                <p>Oui, mais évitez la duplication. Utilisez soit le bloc complet, soit les shortcodes individuels, pas les deux ensemble.</p>
+            </details>
+            <details class="jlg-faq" data-level="0">
+                <summary>Comment changer l'ordre des sections ?</summary>
+                <p>L'ordre est fixe (Tagline → Notation → Points), mais vous pouvez masquer des sections avec les paramètres afficher_*="non".</p>
+            </details>
+            <details class="jlg-faq" data-level="0">
+                <summary>Le bloc complet est-il plus lourd en performance ?</summary>
+                <p>Non, au contraire ! Un seul shortcode est plus performant que trois shortcodes séparés.</p>
+            </details>
+            <details class="jlg-faq" data-level="0">
+                <summary>Puis-je avoir plusieurs blocs complets sur la même page ?</summary>
+                <p>Oui, en utilisant le paramètre post_id pour cibler différents articles : [jlg_bloc_complet post_id="123"]</p>
+            </details>
+        </div>
+    </div>
+</section>
 
-<div style="background:#e8f5e9; padding:20px; border-radius:8px; margin-top:30px; border-left:4px solid #4caf50;">
-    <h3>🎮 Gestion des Plateformes</h3>
-    <p><strong>Nouveau système de plateformes dynamiques !</strong></p>
-    <ul style="margin-left:20px;">
-        <li>Ajoutez vos propres plateformes depuis l'onglet "Plateformes"</li>
-        <li>Réorganisez l'ordre d'affichage par glisser-déposer</li>
-        <li>Associez des tags WordPress à chaque plateforme pour créer des passerelles éditoriales</li>
-        <li>Les plateformes personnalisées apparaissent automatiquement dans les metaboxes</li>
-        <li>Supprimez les plateformes obsolètes en un clic</li>
-        <li>Compatibilité totale avec le shortcode [jlg_fiche_technique]</li>
-    </ul>
-    <p style="margin-top:10px;">Une nouvelle section "Tags liés" est disponible sur la page d'administration pour connecter vos plateformes aux bons contenus.</p>
-    <p style="margin-top:15px;">
-        <a href="<?php echo esc_url($platforms_url); ?>" class="button button-primary">Gérer les plateformes →</a>
-    </p>
-</div>
-
+<section class="components-card jlg-section-card jlg-section-card--success jlg-admin-section" role="region" aria-labelledby="jlg-platforms-title">
+    <div class="components-card__body">
+        <h3 id="jlg-platforms-title">🎮 Gestion des Plateformes</h3>
+        <p><strong>Nouveau système de plateformes dynamiques !</strong></p>
+        <ul class="jlg-bullet-list">
+            <li>Ajoutez vos propres plateformes depuis l'onglet « Plateformes »</li>
+            <li>Réorganisez l'ordre d'affichage par glisser-déposer</li>
+            <li>Associez des tags WordPress à chaque plateforme pour créer des passerelles éditoriales</li>
+            <li>Les plateformes personnalisées apparaissent automatiquement dans les metaboxes</li>
+            <li>Supprimez les plateformes obsolètes en un clic</li>
+            <li>Compatibilité totale avec le shortcode [jlg_fiche_technique]</li>
+        </ul>
+        <p class="jlg-admin-actions jlg-admin-actions--start">
+            <a href="<?php echo esc_url($platforms_url); ?>" class="button button-primary">Gérer les plateformes →</a>
+        </p>
+    </div>
+</section>

--- a/plugin-notation-jeux_V4/assets/css/jlg-admin.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-admin.css
@@ -1,0 +1,390 @@
+.jlg-admin-page {
+    --jlg-spacing-xs: 0.25rem;
+    --jlg-spacing-sm: 0.5rem;
+    --jlg-spacing-md: 1rem;
+    --jlg-spacing-lg: 1.5rem;
+    --jlg-spacing-xl: 2rem;
+    --jlg-radius-sm: 4px;
+    --jlg-radius-md: 8px;
+    --jlg-radius-lg: 12px;
+    --jlg-surface-color: #ffffff;
+    --jlg-muted-color: #50575e;
+    --jlg-border-color: #dcdcde;
+    --jlg-accent-color: #0073aa;
+    --jlg-success-color: #2e7d32;
+    --jlg-info-color: #1e88e5;
+    --jlg-warning-color: #ad6800;
+    --jlg-focus-ring: 0 0 0 2px rgba(0, 115, 170, 0.4);
+}
+
+.jlg-admin-page .nav-tab-wrapper {
+    margin-top: var(--jlg-spacing-md);
+    margin-bottom: 0;
+}
+
+.jlg-admin-page .components-card {
+    border-radius: var(--jlg-radius-md);
+}
+
+.jlg-admin-card {
+    margin-top: var(--jlg-spacing-lg);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.05);
+}
+
+.jlg-admin-card .components-card__body {
+    padding: var(--jlg-spacing-lg);
+    color: #1d2327;
+    font-size: 15px;
+    line-height: 1.6;
+}
+
+.jlg-admin-section {
+    margin-top: var(--jlg-spacing-lg);
+}
+
+.jlg-empty-state {
+    text-align: center;
+    background: linear-gradient(135deg, #f0f6ff 0%, #ffffff 100%);
+    border: 1px solid rgba(30, 136, 229, 0.2);
+}
+
+.jlg-empty-state .components-card__body {
+    padding: var(--jlg-spacing-xl) var(--jlg-spacing-lg);
+}
+
+.jlg-empty-state__title {
+    margin-bottom: var(--jlg-spacing-sm);
+}
+
+.jlg-empty-state__description {
+    margin-bottom: var(--jlg-spacing-md);
+    color: var(--jlg-muted-color);
+}
+
+.jlg-empty-state__action {
+    padding-left: var(--jlg-spacing-lg);
+    padding-right: var(--jlg-spacing-lg);
+}
+
+.jlg-stats-notice {
+    margin: var(--jlg-spacing-lg) 0 var(--jlg-spacing-md);
+}
+
+.jlg-stats-notice p {
+    margin: 0;
+}
+
+.jlg-link--reset {
+    color: inherit;
+    text-decoration: none;
+}
+
+.jlg-link--reset:hover,
+.jlg-link--reset:focus-visible {
+    color: var(--jlg-accent-color);
+    text-decoration: underline;
+}
+
+.jlg-link--action {
+    color: var(--jlg-accent-color);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.jlg-link--action:hover,
+.jlg-link--action:focus-visible {
+    text-decoration: underline;
+}
+
+.jlg-score {
+    color: var(--jlg-score-color, var(--jlg-accent-color));
+}
+
+.jlg-admin-actions {
+    display: flex;
+    gap: var(--jlg-spacing-sm);
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: var(--jlg-spacing-md);
+}
+
+.jlg-admin-actions--inline {
+    justify-content: flex-start;
+}
+
+.jlg-admin-actions--end {
+    justify-content: flex-end;
+}
+
+.jlg-admin-actions--start {
+    justify-content: flex-start;
+}
+
+.jlg-admin-actions__print {
+    min-width: 180px;
+}
+
+.jlg-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--jlg-spacing-md);
+}
+
+.jlg-tutorial-card {
+    border-left: 4px solid var(--jlg-accent-color);
+}
+
+.jlg-tutorial-card__title {
+    margin-top: 0;
+}
+
+.jlg-tutorial-card__description {
+    color: var(--jlg-muted-color);
+}
+
+.jlg-tutorial-card__steps {
+    margin-top: var(--jlg-spacing-sm);
+    margin-left: 1.25rem;
+    padding-left: 0.5rem;
+}
+
+.jlg-tutorial-card__steps li {
+    margin-bottom: var(--jlg-spacing-xs);
+}
+
+.jlg-hero-card {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+}
+
+.jlg-hero-card .components-card__body {
+    padding: var(--jlg-spacing-xl);
+}
+
+.jlg-hero-card__title {
+    margin-top: 0;
+    margin-bottom: var(--jlg-spacing-sm);
+}
+
+.jlg-hero-card__lead {
+    font-size: 1.05rem;
+    margin-bottom: var(--jlg-spacing-md);
+}
+
+.jlg-hero-card__foot {
+    margin-top: var(--jlg-spacing-md);
+}
+
+.jlg-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--jlg-spacing-sm);
+    margin-top: var(--jlg-spacing-sm);
+}
+
+.jlg-feature-pill {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: var(--jlg-radius-sm);
+    padding: var(--jlg-spacing-sm) var(--jlg-spacing-md);
+    font-weight: 600;
+}
+
+.jlg-section-card {
+    background: var(--jlg-surface-color);
+    border: 1px solid rgba(0, 0, 0, 0.03);
+    box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
+}
+
+.jlg-section-card .components-card__body {
+    padding: var(--jlg-spacing-lg);
+}
+
+.jlg-section-card__title,
+.jlg-section-heading {
+    margin-top: 0;
+}
+
+.jlg-section-card--highlight {
+    border-left: 4px solid var(--jlg-success-color);
+}
+
+.jlg-section-card--info {
+    border-left: 4px solid var(--jlg-info-color);
+}
+
+.jlg-section-card--migration {
+    border-left: 4px solid #9c27b0;
+}
+
+.jlg-section-card--tip {
+    border-left: 4px solid #ffc107;
+}
+
+.jlg-section-card--faq {
+    border-left: 4px solid #9c27b0;
+}
+
+.jlg-section-card--success {
+    border-left: 4px solid var(--jlg-success-color);
+}
+
+.jlg-highlight-text {
+    color: var(--jlg-success-color);
+    font-weight: 600;
+}
+
+.jlg-badge-group {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--jlg-spacing-sm);
+    margin-bottom: var(--jlg-spacing-sm);
+}
+
+.jlg-code {
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    border-radius: var(--jlg-radius-sm);
+    background: rgba(0, 0, 0, 0.05);
+    color: #1d2327;
+    padding: 0 var(--jlg-spacing-sm);
+}
+
+.jlg-code--inline {
+    display: inline-flex;
+    align-items: center;
+    height: 2rem;
+}
+
+.jlg-code-block {
+    display: block;
+    padding: var(--jlg-spacing-sm) var(--jlg-spacing-md);
+    background: #f6f7f7;
+    border: 1px solid var(--jlg-border-color);
+    border-radius: var(--jlg-radius-sm);
+    overflow-x: auto;
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+.jlg-code-separator {
+    color: var(--jlg-muted-color);
+}
+
+.jlg-callout {
+    border-radius: var(--jlg-radius-sm);
+    padding: var(--jlg-spacing-sm) var(--jlg-spacing-md);
+    margin-top: var(--jlg-spacing-md);
+}
+
+.jlg-callout--success {
+    background: rgba(76, 175, 80, 0.12);
+    border: 1px solid rgba(76, 175, 80, 0.4);
+}
+
+.jlg-example-list {
+    display: grid;
+    gap: var(--jlg-spacing-md);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.jlg-example-card {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid var(--jlg-border-color);
+    border-radius: var(--jlg-radius-sm);
+    padding: var(--jlg-spacing-md);
+}
+
+.jlg-table-wrapper {
+    overflow-x: auto;
+    margin-top: var(--jlg-spacing-md);
+    border-radius: var(--jlg-radius-sm);
+    border: 1px solid var(--jlg-border-color);
+}
+
+.jlg-compare-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--jlg-surface-color);
+}
+
+.jlg-compare-table th,
+.jlg-compare-table td {
+    padding: var(--jlg-spacing-sm) var(--jlg-spacing-md);
+    border-bottom: 1px solid var(--jlg-border-color);
+    text-align: left;
+    vertical-align: top;
+}
+
+.jlg-migration-note {
+    margin-top: var(--jlg-spacing-md);
+}
+
+.jlg-faq-list {
+    display: grid;
+    gap: var(--jlg-spacing-sm);
+}
+
+.jlg-faq {
+    border: 1px solid var(--jlg-border-color);
+    border-radius: var(--jlg-radius-sm);
+    padding: var(--jlg-spacing-sm) var(--jlg-spacing-md);
+    background: #fff;
+}
+
+.jlg-faq summary {
+    cursor: pointer;
+    font-weight: 600;
+    outline: none;
+}
+
+.jlg-faq summary:focus-visible {
+    box-shadow: var(--jlg-focus-ring);
+}
+
+.jlg-bullet-list {
+    padding-left: 1.2rem;
+}
+
+.jlg-bullet-list li {
+    margin-bottom: var(--jlg-spacing-xs);
+}
+
+.jlg-bullet-list--columns {
+    columns: 2;
+    column-gap: var(--jlg-spacing-lg);
+}
+
+.jlg-divider {
+    border: none;
+    border-top: 1px solid var(--jlg-border-color);
+    margin: var(--jlg-spacing-xl) 0;
+}
+
+.jlg-admin-page a.button:focus-visible,
+.jlg-admin-page .jlg-link--action:focus-visible,
+.jlg-admin-page .jlg-link--reset:focus-visible {
+    outline: none;
+    box-shadow: var(--jlg-focus-ring);
+    border-radius: var(--jlg-radius-sm);
+}
+
+@media (max-width: 782px) {
+    .jlg-admin-card .components-card__body,
+    .jlg-section-card .components-card__body {
+        padding: var(--jlg-spacing-md);
+    }
+
+    .jlg-hero-card .components-card__body {
+        padding: var(--jlg-spacing-lg);
+    }
+
+    .jlg-bullet-list--columns {
+        columns: 1;
+    }
+
+    .jlg-admin-actions--end {
+        justify-content: stretch;
+    }
+
+    .jlg-admin-actions__print {
+        width: 100%;
+    }
+}

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -41,6 +41,14 @@ class Assets {
 
         $version = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
 
+        wp_enqueue_style( 'wp-components' );
+        wp_enqueue_style(
+            'jlg-admin-styles',
+            JLG_NOTATION_PLUGIN_URL . 'assets/css/jlg-admin.css',
+            array( 'wp-components' ),
+            $version
+        );
+
         wp_enqueue_style( 'wp-color-picker' );
         wp_enqueue_script( 'wp-color-picker' );
 


### PR DESCRIPTION
## Summary
- replace inline styling in admin templates with WordPress component cards, notices, and semantic regions
- add a dedicated admin stylesheet that unifies spacing, typography, and focus interactions while staying responsive
- ensure admin assets enqueue the new stylesheet alongside wp-components so tables, actions, and buttons adopt core classes

## Testing
- php -l plugin-notation-jeux_V4/admin/templates/admin-page.php
- php -l plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
- php -l plugin-notation-jeux_V4/admin/templates/tabs/tutorials.php
- php -l plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
- php -l plugin-notation-jeux_V4/includes/Assets.php


------
https://chatgpt.com/codex/tasks/task_e_68de9f3eb6e4832e8593e9cedda05388