### PR TITLE
feat: allow configurable score scale

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -21,7 +21,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 
 ### Fonctionnalités principales
 
-- **Système de notation flexible** : 6 catégories personnalisables notées sur 10
+- **Système de notation flexible** : 6 catégories personnalisables avec un barème ajustable (par défaut sur 10)
 - **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
 - **Notation utilisateurs** : Permettez à vos lecteurs de voter
 - **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -18,7 +18,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 
 = Fonctionnalités principales =
 
-* **Système de notation flexible** : 6 catégories personnalisables notées sur 10
+* **Système de notation flexible** : 6 catégories personnalisables avec un barème ajustable (par défaut sur 10)
 * **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
 * **Notation utilisateurs** : Permettez à vos lecteurs de voter
 * **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage

--- a/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/posts-list.php
@@ -1,6 +1,9 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+$score_max       = \JLG\Notation\Helpers::get_score_max();
+$score_max_label = number_format_i18n($score_max);
+
 $has_rated_posts = $variables['has_rated_posts'] ?? false;
 $empty_state = isset($variables['empty_state']) && is_array($variables['empty_state']) ? $variables['empty_state'] : [];
 $stats = isset($variables['stats']) && is_array($variables['stats']) ? $variables['stats'] : [];
@@ -56,7 +59,7 @@ $column_count = count($columns) + 2;
                     <tr>
                         <td><strong><a href="<?php echo esc_url($post['edit_link'] ?? '#'); ?>"><?php echo esc_html($post['title'] ?? ''); ?></a></strong></td>
                         <td><?php echo esc_html($post['date'] ?? ''); ?></td>
-                        <td><strong style="color:<?php echo esc_attr($post['score_color'] ?? '#0073aa'); ?>;"><?php echo esc_html($post['score_display'] ?? ''); ?></strong>/10</td>
+                        <td><strong style="color:<?php echo esc_attr($post['score_color'] ?? '#0073aa'); ?>;"><?php echo esc_html($post['score_display'] ?? ''); ?></strong><?php printf( esc_html__( '/%s', 'notation-jlg' ), esc_html( $score_max_label ) ); ?></td>
                         <td><?php echo !empty($categories) ? esc_html(implode(', ', $categories)) : '-'; ?></td>
                         <td>
                             <a href="<?php echo esc_url($post['view_link'] ?? '#'); ?>" target="_blank" rel="noopener noreferrer">👁 Voir</a>

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -102,6 +102,17 @@ class Settings {
             }
         }
 
+        $old_score_max = isset( $current_options['score_max'] )
+            ? Helpers::get_score_max( array( 'score_max' => $current_options['score_max'] ) )
+            : Helpers::get_default_settings()['score_max'];
+        $new_score_max = isset( $sanitized['score_max'] )
+            ? Helpers::get_score_max( array( 'score_max' => $sanitized['score_max'] ) )
+            : Helpers::get_default_settings()['score_max'];
+
+        if ( $old_score_max !== $new_score_max ) {
+            Helpers::schedule_score_scale_migration( $old_score_max, $new_score_max );
+        }
+
         Helpers::flush_plugin_options_cache();
 
         return $sanitized;
@@ -307,6 +318,24 @@ class Settings {
 
         // Section 2: Présentation de la Note Globale
         add_settings_section( 'jlg_layout', '2. 🎨 Présentation de la Note Globale', null, 'notation_jlg_page' );
+        $score_max_field_args = array(
+            'id'    => 'score_max',
+            'type'  => 'number',
+            'min'   => 5,
+            'max'   => 100,
+            'step'  => 1,
+            'desc'  => __( 'Définissez la note maximale utilisée pour vos tests (par exemple 10, 20 ou 100).', 'notation-jlg' ),
+        );
+        add_settings_field(
+            'score_max',
+            __( 'Barème maximum', 'notation-jlg' ),
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_layout',
+            $score_max_field_args
+        );
+        $this->store_field_constraints( $score_max_field_args );
+
         add_settings_field(
             'score_layout',
             'Style d\'affichage',
@@ -444,7 +473,7 @@ class Settings {
             'score_gradient_2' => 'Dégradé Note 2',
             'color_low'        => 'Notes Faibles (0-3)',
             'color_mid'        => 'Notes Moyennes (4-7)',
-            'color_high'       => 'Notes Élevées (8-10)',
+            'color_high'       => 'Notes Élevées (haut du barème)',
         );
         foreach ( $semantic_colors as $id => $label ) {
             add_settings_field(

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -1459,16 +1459,17 @@ class Frontend {
             return;
         }
 
+        $score_max            = Helpers::get_score_max();
         $review_rating_bounds = apply_filters(
             'jlg_review_rating_bounds',
             array(
                 'min' => 0,
-                'max' => 10,
+                'max' => $score_max,
             ),
             $post_id
         );
 
-        $review_best_rating  = isset( $review_rating_bounds['max'] ) ? floatval( $review_rating_bounds['max'] ) : 10;
+        $review_best_rating  = isset( $review_rating_bounds['max'] ) ? floatval( $review_rating_bounds['max'] ) : $score_max;
         $review_worst_rating = isset( $review_rating_bounds['min'] ) ? floatval( $review_rating_bounds['min'] ) : 0;
 
         $schema = array(
@@ -1610,6 +1611,7 @@ class Frontend {
                 'paged'                => 1,
                 'orderby'              => '',
                 'order'                => '',
+                'score_max'            => Helpers::get_score_max(),
                 'colonnes'             => array(),
                 'colonnes_disponibles' => array(),
                 'error_message'        => '',

--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -12,6 +12,10 @@ exit;
 
 class Helpers {
 
+    public const SCORE_SCALE_MIGRATION_OPTION = 'jlg_score_scale_migration';
+    public const SCORE_SCALE_QUEUE_OPTION     = 'jlg_score_scale_queue';
+    public const SCORE_SCALE_EVENT_HOOK       = 'jlg_process_score_scale_migration';
+
     private const GAME_EXPLORER_DEFAULT_SCORE_POSITION = 'bottom-right';
     private const PLATFORM_TAG_OPTION                  = 'jlg_platform_tag_map';
     private const LEGACY_CATEGORY_SUFFIXES             = array( 'cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6' );
@@ -376,6 +380,7 @@ class Helpers {
             // Options générales
             'visual_theme'                 => 'dark',
             'score_layout'                 => 'text',
+            'score_max'                    => 10,
             'enable_animations'            => 1,
             'tagline_font_size'            => 16,
 
@@ -477,7 +482,136 @@ class Helpers {
 
         self::$options_cache['game_explorer_score_position'] = self::normalize_game_explorer_score_position( $score_position );
 
+        $score_max = isset( self::$options_cache['score_max'] ) ? self::$options_cache['score_max'] : null;
+        self::$options_cache['score_max'] = self::normalize_score_max( $score_max, self::$default_settings_cache['score_max'] ?? 10 );
+
         return self::$options_cache;
+    }
+
+    public static function schedule_score_scale_migration( $old_max, $new_max ) {
+        $old_max = self::normalize_score_max( $old_max, $old_max );
+        $new_max = self::normalize_score_max( $new_max, $new_max );
+
+        if ( $old_max <= 0 || $new_max <= 0 || abs( $old_max - $new_max ) < 0.0001 ) {
+            return;
+        }
+
+        $post_ids = self::get_rated_post_ids();
+
+        $migration_payload = array(
+            'old_max' => $old_max,
+            'new_max' => $new_max,
+            'ratio'   => $new_max / $old_max,
+        );
+
+        update_option( self::SCORE_SCALE_MIGRATION_OPTION, $migration_payload, false );
+        update_option( self::SCORE_SCALE_QUEUE_OPTION, $post_ids, false );
+
+        self::clear_rated_post_ids_cache();
+
+        if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+            return;
+        }
+
+        $hook = self::SCORE_SCALE_EVENT_HOOK;
+
+        if ( function_exists( 'wp_next_scheduled' ) && wp_next_scheduled( $hook ) ) {
+            return;
+        }
+
+        wp_schedule_single_event( time() + 1, $hook );
+    }
+
+    public static function rescale_post_scores_for_scale_change( $post_id, $old_max, $new_max ) {
+        $post_id = (int) $post_id;
+
+        if ( $post_id <= 0 ) {
+            return;
+        }
+
+        $old_max = self::normalize_score_max( $old_max, $old_max );
+        $new_max = self::normalize_score_max( $new_max, $new_max );
+
+        if ( $old_max <= 0 || $new_max <= 0 || abs( $old_max - $new_max ) < 0.0001 ) {
+            return;
+        }
+
+        $ratio          = $new_max / $old_max;
+        $definitions    = self::get_rating_category_definitions();
+        $updated_scores = false;
+
+        foreach ( $definitions as $definition ) {
+            $meta_key = isset( $definition['meta_key'] ) ? (string) $definition['meta_key'] : '';
+
+            if ( $meta_key === '' ) {
+                continue;
+            }
+
+            $raw_value = get_post_meta( $post_id, $meta_key, true );
+
+            if ( $raw_value === '' || $raw_value === null ) {
+                continue;
+            }
+
+            $numeric_value = self::normalize_score_candidate( $raw_value );
+
+            if ( $numeric_value === null ) {
+                continue;
+            }
+
+            $scaled = round( max( 0, min( $new_max, $numeric_value * $ratio ) ), 1 );
+
+            if ( abs( $scaled - (float) $numeric_value ) < 0.05 ) {
+                continue;
+            }
+
+            update_post_meta( $post_id, $meta_key, $scaled );
+            $updated_scores = true;
+        }
+
+        if ( $updated_scores ) {
+            return;
+        }
+
+        $stored_average = get_post_meta( $post_id, '_jlg_average_score', true );
+
+        if ( $stored_average === '' || $stored_average === null || ! is_numeric( $stored_average ) ) {
+            return;
+        }
+
+        $average = (float) $stored_average;
+        $scaled  = round( max( 0, min( $new_max, $average * $ratio ) ), 1 );
+
+        if ( abs( $scaled - $average ) < 0.05 ) {
+            return;
+        }
+
+        update_post_meta( $post_id, '_jlg_average_score', $scaled );
+    }
+
+    public static function get_score_max( $options = null ) {
+        if ( $options === null ) {
+            $options = self::get_plugin_options();
+        }
+
+        $raw_value = is_array( $options ) ? ( $options['score_max'] ?? null ) : null;
+
+        return self::normalize_score_max( $raw_value, self::get_default_settings()['score_max'] ?? 10 );
+    }
+
+    private static function normalize_score_max( $value, $fallback = 10 ) {
+        $min = 5;
+        $max = 100;
+
+        if ( ! is_numeric( $value ) ) {
+            $normalized = is_numeric( $fallback ) ? (float) $fallback : 10.0;
+        } else {
+            $normalized = (float) $value;
+        }
+
+        $normalized = max( $min, min( $max, $normalized ) );
+
+        return (int) round( $normalized );
     }
 
     public static function migrate_legacy_rating_configuration() {
@@ -852,6 +986,9 @@ class Helpers {
             }
         }
 
+        $meta_keys[] = '_jlg_average_score';
+        $meta_keys   = array_values( array_unique( array_filter( $meta_keys ) ) );
+
         if ( empty( $meta_keys ) ) {
             return array();
         }
@@ -942,6 +1079,12 @@ class Helpers {
             if ( $value !== '' && $value !== null && $value !== false ) {
                 return true;
             }
+        }
+
+        $average = get_post_meta( $post_id, '_jlg_average_score', true );
+
+        if ( $average !== '' && $average !== null && $average !== false ) {
+            return true;
         }
 
         return false;
@@ -1050,7 +1193,10 @@ class Helpers {
         }
 
         // S'assurer que la note est un nombre
-        $note = floatval( $note );
+        $note      = floatval( $note );
+        $score_max = max( 1, self::get_score_max( $options ) );
+
+        $note = max( 0, min( $score_max, $note ) );
 
         // Récupérer les couleurs définies dans les options
         $color_low  = $options['color_low'] ?? '#ef4444';
@@ -1073,19 +1219,21 @@ class Helpers {
 			$parsed_high = array( 34, 197, 94 );
         }
 
+        $midpoint = $score_max / 2;
+
         // Calculer l'interpolation selon la note
-        if ( $note <= 5 ) {
-            // Entre 0 et 5 : interpolation entre low et mid
-            $ratio = $note / 5.0;
-            $r     = round( $parsed_low[0] + ( $parsed_mid[0] - $parsed_low[0] ) * $ratio );
-            $g     = round( $parsed_low[1] + ( $parsed_mid[1] - $parsed_low[1] ) * $ratio );
-            $b     = round( $parsed_low[2] + ( $parsed_mid[2] - $parsed_low[2] ) * $ratio );
+        if ( $note <= $midpoint ) {
+            $divider = $midpoint > 0 ? $midpoint : 1;
+            $ratio   = $note / $divider;
+            $r       = round( $parsed_low[0] + ( $parsed_mid[0] - $parsed_low[0] ) * $ratio );
+            $g       = round( $parsed_low[1] + ( $parsed_mid[1] - $parsed_low[1] ) * $ratio );
+            $b       = round( $parsed_low[2] + ( $parsed_mid[2] - $parsed_low[2] ) * $ratio );
         } else {
-            // Entre 5 et 10 : interpolation entre mid et high
-            $ratio = ( $note - 5.0 ) / 5.0;
-            $r     = round( $parsed_mid[0] + ( $parsed_high[0] - $parsed_mid[0] ) * $ratio );
-            $g     = round( $parsed_mid[1] + ( $parsed_high[1] - $parsed_mid[1] ) * $ratio );
-            $b     = round( $parsed_mid[2] + ( $parsed_high[2] - $parsed_mid[2] ) * $ratio );
+            $divider = $midpoint > 0 ? $midpoint : 1;
+            $ratio   = ( $note - $midpoint ) / $divider;
+            $r       = round( $parsed_mid[0] + ( $parsed_high[0] - $parsed_mid[0] ) * $ratio );
+            $g       = round( $parsed_mid[1] + ( $parsed_high[1] - $parsed_mid[1] ) * $ratio );
+            $b       = round( $parsed_mid[2] + ( $parsed_high[2] - $parsed_mid[2] ) * $ratio );
         }
 
         // S'assurer que les valeurs sont dans les limites

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -355,12 +355,13 @@ class AllInOne {
                                 'cons_list'          => $cons_list,
                                 'tagline_fr'         => $tagline_fr,
                                 'tagline_en'         => $tagline_en,
-				'atts'               => $atts,
-				'block_classes'      => $block_classes,
-				'css_variables'      => $css_variables_string,
-				'score_layout'       => $score_layout,
-				'animations_enabled' => ! empty( $options['enable_animations'] ),
-			)
+                                'atts'               => $atts,
+                                'block_classes'      => $block_classes,
+                                'css_variables'      => $css_variables_string,
+                                'score_layout'       => $score_layout,
+                                'animations_enabled' => ! empty( $options['enable_animations'] ),
+                                'score_max'          => Helpers::get_score_max( $options ),
+                        )
         );
     }
 

--- a/plugin-notation-jeux_V4/includes/Utils/Validator.php
+++ b/plugin-notation-jeux_V4/includes/Utils/Validator.php
@@ -2,6 +2,8 @@
 
 namespace JLG\Notation\Utils;
 
+use JLG\Notation\Helpers;
+
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
 }
@@ -19,7 +21,9 @@ class Validator {
         }
 
         $numeric_score = floatval( $score );
-        return $numeric_score >= 0 && $numeric_score <= 10;
+        $score_max     = Helpers::get_score_max();
+
+        return $numeric_score >= 0 && $numeric_score <= $score_max;
     }
 
     public static function sanitize_score( $score ) {
@@ -31,7 +35,10 @@ class Validator {
             return '';
         }
 
-        return round( floatval( $score ), 1 );
+        $score_max = Helpers::get_score_max();
+        $value     = max( 0, min( $score_max, floatval( $score ) ) );
+
+        return round( $value, 1 );
     }
 
     public static function validate_notation_data( $post_data ) {

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -13,6 +13,8 @@ $total_items = isset( $total_items ) ? (int) $total_items : 0;
 $score_position = isset( $score_position )
     ? \JLG\Notation\Helpers::normalize_game_explorer_score_position( $score_position )
     : \JLG\Notation\Helpers::normalize_game_explorer_score_position( '' );
+$score_max_value  = isset( $score_max ) ? max( 1, (float) $score_max ) : \JLG\Notation\Helpers::get_score_max();
+$score_max_label  = number_format_i18n( $score_max_value );
 $score_classes = array(
     'jlg-ge-card__score',
     'jlg-ge-card__score--' . sanitize_html_class( $score_position ),
@@ -151,7 +153,15 @@ if ( empty( $games ) ) {
                     <span class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $score_classes ) ) ); ?>" style="--jlg-ge-score-color: <?php echo esc_attr( $score_color ); ?>;">
                         <?php echo esc_html( $score_display ); ?>
                         <?php if ( $has_score ) : ?>
-                            <span class="jlg-ge-card__score-outof">/10</span>
+                            <span class="jlg-ge-card__score-outof">
+                                <?php
+                                printf(
+                                    /* translators: %s: Maximum possible rating value. */
+                                    esc_html__( '/%s', 'notation-jlg' ),
+                                    esc_html( $score_max_label )
+                                );
+                                ?>
+                            </span>
                         <?php endif; ?>
                     </span>
                 <?php endif; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$score_max       = isset( $score_max ) ? max( 1, (float) $score_max ) : \JLG\Notation\Helpers::get_score_max();
+$score_max_label = number_format_i18n( $score_max );
 $style_attribute = '';
 if ( ! empty( $css_variables ) ) {
     $style_attribute = ' style="' . esc_attr( $css_variables ) . '"';
@@ -89,11 +91,26 @@ $data_attributes  = sprintf(
             <div class="jlg-aio-score-item">
                 <div class="jlg-aio-score-header">
                     <span class="jlg-aio-score-label"><?php echo esc_html( $label ); ?></span>
-                    <span class="jlg-aio-score-number"><?php echo esc_html( number_format_i18n( $score_value, 1 ) ); ?> / 10</span>
+                    <span class="jlg-aio-score-number">
+                        <?php echo esc_html( number_format_i18n( $score_value, 1 ) ); ?>
+                        <?php
+                        printf(
+                            /* translators: %s: Maximum possible rating value. */
+                            esc_html_x( '/ %s', 'score input suffix', 'notation-jlg' ),
+                            esc_html( $score_max_label )
+                        );
+                        ?>
+                    </span>
                 </div>
                 <div class="jlg-aio-score-bar-bg">
+                    <?php
+                    $percentage = $score_max > 0
+                        ? max( 0, min( 100, ( $score_value / $score_max ) * 100 ) )
+                        : 0;
+                    $percentage_attr = esc_attr( round( $percentage, 2 ) );
+                    ?>
                     <div class="jlg-aio-score-bar"
-                        style="--bar-color: <?php echo esc_attr( $bar_color ); ?>; --bar-width: <?php echo esc_attr( $score_value * 10 ); ?>%; width: <?php echo esc_attr( $score_value * 10 ); ?>%;"></div>
+                        style="--bar-color: <?php echo esc_attr( $bar_color ); ?>; --bar-width: <?php echo $percentage_attr; ?>%; width: <?php echo $percentage_attr; ?>%;"></div>
                 </div>
             </div>
             <?php endforeach; ?>

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -13,7 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$options = \JLG\Notation\Helpers::get_plugin_options();
+$options          = \JLG\Notation\Helpers::get_plugin_options();
+$score_max        = \JLG\Notation\Helpers::get_score_max( $options );
+$score_max_label  = number_format_i18n( $score_max );
 ?>
 
 <div class="review-box-jlg<?php echo $options['enable_animations'] ? ' jlg-animate' : ''; ?>">
@@ -55,13 +57,18 @@ $options = \JLG\Notation\Helpers::get_plugin_options();
                             /* translators: 1: Rating value for a specific category. 2: Maximum possible rating. */
                             esc_html__( '%1$s / %2$s', 'notation-jlg' ),
                             $formatted_score_value,
-                            10
+                            esc_html( $score_max_label )
                         );
                         ?>
                     </span>
                 </div>
                 <div class="rating-bar-container">
-                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( $score_value * 10 ); ?>%; --bar-color:<?php echo esc_attr( $bar_color ); ?>;"></div>
+                    <?php
+                    $percentage = $score_max > 0
+                        ? max( 0, min( 100, ( $score_value / $score_max ) * 100 ) )
+                        : 0;
+                    ?>
+                    <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( round( $percentage, 2 ) ); ?>%; --bar-color:<?php echo esc_attr( $bar_color ); ?>;"></div>
                 </div>
             </div>
         <?php endforeach; ?>

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -7,6 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+$score_max         = isset( $score_max ) ? max( 1, (float) $score_max ) : \JLG\Notation\Helpers::get_score_max();
+$score_max_label   = number_format_i18n( $score_max );
 $columns           = is_array( $colonnes ) ? $colonnes : array();
 $available_columns = is_array( $colonnes_disponibles ) ? $colonnes_disponibles : array();
 $table_id          = ! empty( $table_id ) ? sanitize_html_class( $table_id ) : '';
@@ -336,7 +338,7 @@ else :
                                         printf(
                                             /* translators: %s: Maximum possible rating value. */
                                             esc_html__( '/ %s', 'notation-jlg' ),
-                                            10
+                                            esc_html( $score_max_label )
                                         );
                                         break;
                                     case 'developpeur':

--- a/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
+++ b/plugin-notation-jeux_V4/templates/widget-thumbnail-score.php
@@ -14,8 +14,10 @@ if ( $average_score === null ) {
 	return;
 }
 
-$options     = \JLG\Notation\Helpers::get_plugin_options();
-$score_color = \JLG\Notation\Helpers::calculate_color_from_note( $average_score, $options );
+$options         = \JLG\Notation\Helpers::get_plugin_options();
+$score_color     = \JLG\Notation\Helpers::calculate_color_from_note( $average_score, $options );
+$score_max       = \JLG\Notation\Helpers::get_score_max( $options );
+$score_max_label = number_format_i18n( $score_max );
 ?>
 
 <div class="jlg-thumbnail-score" style="
@@ -39,7 +41,7 @@ $score_color = \JLG\Notation\Helpers::calculate_color_from_note( $average_score,
         printf(
             /* translators: %s: Maximum rating value displayed with the thumbnail score. */
             esc_html__( '/%s', 'notation-jlg' ),
-            10
+            esc_html( $score_max_label )
         );
         ?>
     </span>

--- a/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersRatingCacheTest.php
@@ -79,6 +79,25 @@ class HelpersRatingCacheTest extends TestCase
 
         $this->assertFalse(get_transient('jlg_rated_post_ids_v1'));
     }
+
+    public function test_status_transition_with_average_only_clears_rated_cache(): void
+    {
+        $post_id = 654;
+
+        $post = new WP_Post([
+            'ID' => $post_id,
+            'post_type' => 'post',
+        ]);
+
+        $GLOBALS['jlg_test_posts'][$post_id] = $post;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_average_score'] = '8.4';
+
+        set_transient('jlg_rated_post_ids_v1', [10, 20]);
+
+        \JLG\Notation\Helpers::maybe_clear_rated_post_ids_cache_for_status_change('draft', 'publish', $post);
+
+        $this->assertFalse(get_transient('jlg_rated_post_ids_v1'));
+    }
     private function get_primary_rating_meta_key(): string
     {
         $definitions = \JLG\Notation\Helpers::get_rating_category_definitions();

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
@@ -29,7 +29,7 @@ class ShortcodeGameExplorerScoreDisplayTest extends TestCase
         $this->assertStringNotContainsString(
             'jlg-ge-card__score-outof',
             $output,
-            'The "/10" suffix should not be displayed when no numeric score is available.'
+            'The score suffix should not be displayed when no numeric score is available.'
         );
     }
 
@@ -41,10 +41,13 @@ class ShortcodeGameExplorerScoreDisplayTest extends TestCase
             'has_score' => true,
         ]);
 
-        $this->assertStringContainsString(
-            '<span class="jlg-ge-card__score-outof">/10</span>',
+        $score_max_label = number_format_i18n( \JLG\Notation\Helpers::get_score_max() );
+        $pattern         = '/<span class="jlg-ge-card__score-outof">\s*\/' . preg_quote( $score_max_label, '/' ) . '<\/span>/';
+
+        $this->assertMatchesRegularExpression(
+            $pattern,
             $output,
-            'The "/10" suffix should be rendered when a numeric score is available.'
+            'The score suffix should be rendered when a numeric score is available.'
         );
     }
 


### PR DESCRIPTION
## Summary
- add a configurable `score_max` setting with validation and expose it through the helper API
- refresh admin, frontend templates, and shortcodes to honour the dynamic score scale and compute percentages accordingly
- schedule an asynchronous migration to rescale stored ratings and refresh caches when the score range changes

## Testing
- composer test *(fails: phpunit not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f3d56f4832e98cd1048160eb25a