### PR TITLE
Adjust user rating star sizing for accessibility

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -171,10 +171,10 @@
 .jlg-user-rating-block{max-width:650px;margin:32px auto;text-align:center;color:var(--jlg-user-rating-text-color);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-user-rating-block.is-loading{opacity:.6;cursor:wait;pointer-events:none;}
 .jlg-user-rating-title{font-size:1.2rem;font-weight:600;color:var(--jlg-main-text-color);margin-bottom:12px;}
-.jlg-user-rating-stars{display:inline-flex;gap:5px;margin-bottom:12px;}
-.jlg-user-star{font-size:28px;color:#52525b;transition:color .2s,transform .2s;background:0 0;border:0;padding:4px;line-height:1;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;border-radius:50%;appearance:none;-webkit-appearance:none;background-color:transparent;}
+.jlg-user-rating-stars{display:inline-flex;gap:8px;margin-bottom:12px;}
+.jlg-user-star{font-size:26px;color:#52525b;transition:color .2s,transform .2s;background:0 0;border:0;padding:8px;line-height:1;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;border-radius:50%;appearance:none;-webkit-appearance:none;background-color:transparent;min-width:44px;min-height:44px;}
 .jlg-user-star:focus{outline:none;}
-.jlg-user-star:focus-visible{outline:2px solid var(--jlg-user-rating-star-color);outline-offset:3px;}
+.jlg-user-star:focus-visible{outline:2px solid var(--jlg-user-rating-star-color);outline-offset:4px;}
 .jlg-user-rating-block.has-voted .jlg-user-star{cursor:default;}
 .jlg-user-rating-block.has-voted .jlg-user-star:hover,
 .jlg-user-rating-block.has-voted .jlg-user-star.hover{color:#52525b;transform:none;}


### PR DESCRIPTION
## Summary
- ensure each user rating star meets the 44px minimum hit target with revised padding and font sizing
- widen the spacing between rating stars to keep desktop alignment balanced
- maintain a visible focus outline that works with the updated dimensions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dedee28a2c832ebe23129bdd86b9ae