### PR TITLE
Add CTA controls to all-in-one block

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
@@ -31,6 +31,10 @@ if (!defined('ABSPATH')) exit;
             <li><strong>couleur_accent</strong> : Code couleur hex (ex: "#60a5fa")</li>
             <li><strong>titre_points_forts</strong> : Titre personnalisé (défaut : "Points Forts")</li>
             <li><strong>titre_points_faibles</strong> : Titre personnalisé (défaut : "Points Faibles")</li>
+            <li><strong>cta_label</strong> : Texte du bouton d'appel à l'action (défaut : valeur de la métadonnée)</li>
+            <li><strong>cta_url</strong> : URL absolue du bouton (défaut : valeur de la métadonnée)</li>
+            <li><strong>cta_role</strong> : Attribut <code>role</code> du lien (défaut : <code>button</code>)</li>
+            <li><strong>cta_rel</strong> : Attribut <code>rel</code> (défaut : <code>nofollow sponsored</code>)</li>
         </ul>
 
         <h4>Exemples d'utilisation :</h4>
@@ -49,6 +53,9 @@ if (!defined('ABSPATH')) exit;
 
 <span style="color:#666;">// Seulement notation et points (sans tagline)</span>
 [jlg_bloc_complet afficher_tagline="non"]
+
+<span style="color:#666;">// Bouton personnalisé avec texte et URL dédiés</span>
+[jlg_bloc_complet cta_label="Acheter le jeu" cta_url="https://exemple.com/boutique" cta_rel="nofollow noopener"]
 
 <span style="color:#666;">// Configuration complète personnalisée</span>
 [jlg_bloc_complet style="moderne" couleur_accent="#8b5cf6" titre_points_forts="Les +" titre_points_faibles="Les -"]</pre>

--- a/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
@@ -42,6 +42,22 @@
     "consTitle": {
       "type": "string",
       "default": "Points Faibles"
+    },
+    "ctaLabel": {
+      "type": "string",
+      "default": ""
+    },
+    "ctaUrl": {
+      "type": "string",
+      "default": ""
+    },
+    "ctaRole": {
+      "type": "string",
+      "default": "button"
+    },
+    "ctaRel": {
+      "type": "string",
+      "default": "nofollow sponsored"
     }
   },
   "editorScript": "notation-jlg-all-in-one-editor",

--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -199,6 +199,44 @@
     color: var(--jlg-aio-text-color, #111827);
 }
 
+.jlg-aio-cta {
+    padding: 0 30px 30px;
+    text-align: center;
+    background: var(--jlg-aio-bg, #ffffff);
+}
+
+.jlg-aio-cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 32px;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 1.2;
+    color: var(--jlg-aio-cta-text, #ffffff);
+    background: var(--jlg-aio-cta-bg, #2563eb);
+    border-radius: 9999px;
+    text-decoration: none;
+    box-shadow: 0 10px 20px -10px rgba(0, 0, 0, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.jlg-aio-cta-button:hover,
+.jlg-aio-cta-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 25px -15px rgba(0, 0, 0, 0.4);
+    filter: brightness(1.05);
+}
+
+.jlg-aio-cta-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 3px;
+}
+
+.jlg-aio-cta-label {
+    pointer-events: none;
+}
+
 .jlg-aio-score-number {
     color: var(--jlg-aio-score-number-color, #6b7280);
     font-weight: 500;

--- a/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
@@ -134,6 +134,42 @@
                                 setAttributes({ consTitle: value || '' });
                             },
                         })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Bouton d\'action', 'notation-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('Texte du bouton', 'notation-jlg'),
+                            value: attributes.ctaLabel || '',
+                            onChange: function (value) {
+                                setAttributes({ ctaLabel: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('URL du bouton', 'notation-jlg'),
+                            type: 'url',
+                            value: attributes.ctaUrl || '',
+                            onChange: function (value) {
+                                setAttributes({ ctaUrl: value || '' });
+                            },
+                            help: __('Utilisez une URL absolue (https://...)', 'notation-jlg'),
+                        }),
+                        createElement(TextControl, {
+                            label: __('Attribut role', 'notation-jlg'),
+                            value: attributes.ctaRole || '',
+                            onChange: function (value) {
+                                setAttributes({ ctaRole: value || '' });
+                            },
+                            help: __('Par défaut : button', 'notation-jlg'),
+                        }),
+                        createElement(TextControl, {
+                            label: __('Attribut rel', 'notation-jlg'),
+                            value: attributes.ctaRel || '',
+                            onChange: function (value) {
+                                setAttributes({ ctaRel: value || '' });
+                            },
+                            help: __('Par défaut : nofollow sponsored', 'notation-jlg'),
+                        })
                     )
                 ),
                 createElement(
@@ -150,6 +186,10 @@
                             accentColor: attributes.accentColor || '',
                             prosTitle: attributes.prosTitle || '',
                             consTitle: attributes.consTitle || '',
+                            ctaLabel: attributes.ctaLabel || '',
+                            ctaUrl: attributes.ctaUrl || '',
+                            ctaRole: attributes.ctaRole || '',
+                            ctaRel: attributes.ctaRel || '',
                         },
                         label: __('Bloc tout-en-un', 'notation-jlg'),
                     })

--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -476,6 +476,31 @@ class Blocks {
             $atts['titre_points_faibles'] = sanitize_text_field( $attributes['consTitle'] );
         }
 
+        if ( ! empty( $attributes['ctaLabel'] ) && is_string( $attributes['ctaLabel'] ) ) {
+            $atts['cta_label'] = sanitize_text_field( $attributes['ctaLabel'] );
+        }
+
+        if ( ! empty( $attributes['ctaUrl'] ) && is_string( $attributes['ctaUrl'] ) ) {
+            $url = esc_url_raw( $attributes['ctaUrl'] );
+            if ( $url !== '' && wp_http_validate_url( $url ) ) {
+                $atts['cta_url'] = $url;
+            }
+        }
+
+        if ( ! empty( $attributes['ctaRole'] ) && is_string( $attributes['ctaRole'] ) ) {
+            $role = sanitize_key( $attributes['ctaRole'] );
+            if ( $role !== '' ) {
+                $atts['cta_role'] = $role;
+            }
+        }
+
+        if ( isset( $attributes['ctaRel'] ) && is_string( $attributes['ctaRel'] ) ) {
+            $rel = sanitize_text_field( $attributes['ctaRel'] );
+            if ( $rel !== '' ) {
+                $atts['cta_rel'] = $rel;
+            }
+        }
+
         return $this->render_shortcode( 'jlg_bloc_complet', $atts );
     }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -15,6 +15,9 @@ $has_dual_tagline = ( ! empty( $tagline_fr ) && ! empty( $tagline_en ) );
 $show_rating      = ( $atts['afficher_notation'] === 'oui' && $average_score !== null );
 $show_points      = ( $atts['afficher_points'] === 'oui' && ( ! empty( $pros_list ) || ! empty( $cons_list ) ) );
 $category_scores  = isset( $category_scores ) && is_array( $category_scores ) ? $category_scores : array();
+$has_cta          = ( ! empty( $cta_label ) && ! empty( $cta_url ) );
+$cta_role_attr    = ! empty( $cta_role ) ? $cta_role : 'button';
+$cta_rel_attr     = isset( $cta_rel ) ? trim( (string) $cta_rel ) : '';
 $data_attributes  = sprintf(
     ' data-animations-enabled="%s" data-has-multiple-taglines="%s"',
     esc_attr( $animations_enabled ? 'true' : 'false' ),
@@ -147,6 +150,14 @@ $data_attributes  = sprintf(
             </ul>
         </div>
         <?php endif; ?>
+    </div>
+    <?php endif; ?>
+
+    <?php if ( $has_cta ) : ?>
+    <div class="jlg-aio-cta">
+        <a class="jlg-aio-cta-button" href="<?php echo esc_url( $cta_url ); ?>" role="<?php echo esc_attr( $cta_role_attr ); ?>"<?php echo $cta_rel_attr !== '' ? ' rel="' . esc_attr( $cta_rel_attr ) . '"' : ''; ?>>
+            <span class="jlg-aio-cta-label"><?php echo esc_html( $cta_label ); ?></span>
+        </a>
     </div>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- add CTA label and URL controls to the review metabox with validation
- load and expose CTA data in the all-in-one shortcode, template, and styles
- document and surface CTA overrides in the shortcode docs and Gutenberg block

## Testing
- php -l plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
- php -l plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
- php -l plugin-notation-jeux_V4/includes/Blocks.php
- php -l plugin-notation-jeux_V4/templates/shortcode-all-in-one.php

------
https://chatgpt.com/codex/tasks/task_e_68dee54e3c28832e88b7e7e9436fedca