### PR TITLE
Add rating block customization overrides

### DIFF
--- a/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
@@ -14,6 +14,18 @@
     "postId": {
       "type": "integer",
       "default": 0
+    },
+    "scoreLayout": {
+      "type": "string",
+      "default": "text"
+    },
+    "accentColor": {
+      "type": "string",
+      "default": ""
+    },
+    "showAnimations": {
+      "type": "boolean",
+      "default": true
     }
   },
   "editorScript": "notation-jlg-rating-block-editor",

--- a/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
@@ -14,6 +14,10 @@
         return wp.element.createElement(wp.element.Fragment, null, props.children);
     };
     var PanelBody = wp.components.PanelBody;
+    var ToggleControl = wp.components.ToggleControl;
+    var SelectControl = wp.components.SelectControl;
+    var ColorPalette = (blockEditor && blockEditor.ColorPalette) || wp.components.ColorPalette;
+    var PanelColorSettings = blockEditor.PanelColorSettings || blockEditor.__experimentalPanelColorSettings;
     var useBlockPropsHook = blockEditor.useBlockProps;
     var createElement = wp.element.createElement;
     var Fragment = wp.element.Fragment;
@@ -36,6 +40,32 @@
             var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
             var blockProps = useBlockProps({ className: 'notation-jlg-rating-block-editor' });
 
+            var colorControl = PanelColorSettings
+                ? createElement(PanelColorSettings, {
+                      title: __('Couleurs', 'notation-jlg'),
+                      colorSettings: [
+                          {
+                              value: attributes.accentColor || '',
+                              onChange: function (value) {
+                                  setAttributes({ accentColor: value || '' });
+                              },
+                              label: __('Couleur d\'accent', 'notation-jlg'),
+                          },
+                      ],
+                  })
+                : createElement(
+                      PanelBody,
+                      { title: __('Couleur d\'accent', 'notation-jlg'), initialOpen: false },
+                      ColorPalette
+                          ? createElement(ColorPalette, {
+                                value: attributes.accentColor || '',
+                                onChange: function (value) {
+                                    setAttributes({ accentColor: value || '' });
+                                },
+                            })
+                          : null
+                  );
+
             return createElement(
                 Fragment,
                 null,
@@ -44,21 +74,45 @@
                     null,
                     createElement(
                         PanelBody,
-                        { title: __('Source des données', 'notation-jlg'), initialOpen: true },
+                        { title: __('Source et affichage', 'notation-jlg'), initialOpen: true },
                         createElement(PostPicker, {
                             value: attributes.postId || 0,
                             onChange: function (value) {
                                 setAttributes({ postId: value || 0 });
                             },
+                        }),
+                        createElement(SelectControl, {
+                            label: __('Disposition du score', 'notation-jlg'),
+                            value: attributes.scoreLayout || 'text',
+                            options: [
+                                { value: 'text', label: __('Texte', 'notation-jlg') },
+                                { value: 'circle', label: __('Cercle', 'notation-jlg') },
+                            ],
+                            onChange: function (value) {
+                                setAttributes({ scoreLayout: value || 'text' });
+                            },
+                        }),
+                        createElement(ToggleControl, {
+                            label: __('Afficher les animations', 'notation-jlg'),
+                            checked: typeof attributes.showAnimations === 'boolean' ? attributes.showAnimations : true,
+                            onChange: function (value) {
+                                setAttributes({ showAnimations: !!value });
+                            },
                         })
-                    )
+                    ),
+                    colorControl
                 ),
                 createElement(
                     'div',
                     blockProps,
                     createElement(BlockPreview, {
                         block: 'notation-jlg/rating-block',
-                        attributes: attributes,
+                        attributes: {
+                            postId: attributes.postId || 0,
+                            scoreLayout: attributes.scoreLayout || 'text',
+                            showAnimations: typeof attributes.showAnimations === 'boolean' ? attributes.showAnimations : true,
+                            accentColor: attributes.accentColor || '',
+                        },
                         label: __('Bloc de notation', 'notation-jlg'),
                     })
                 )

--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -350,6 +350,24 @@ class Blocks {
             $atts['post_id'] = $post_id;
         }
 
+        if ( ! empty( $attributes['scoreLayout'] ) && is_string( $attributes['scoreLayout'] ) ) {
+            $layout = sanitize_key( $attributes['scoreLayout'] );
+            if ( in_array( $layout, array( 'text', 'circle' ), true ) ) {
+                $atts['score_layout'] = $layout;
+            }
+        }
+
+        if ( isset( $attributes['showAnimations'] ) ) {
+            $atts['animations'] = (bool) $attributes['showAnimations'];
+        }
+
+        if ( ! empty( $attributes['accentColor'] ) && is_string( $attributes['accentColor'] ) ) {
+            $color = sanitize_hex_color( $attributes['accentColor'] );
+            if ( ! empty( $color ) ) {
+                $atts['accent_color'] = $color;
+            }
+        }
+
         return $this->render_shortcode( 'bloc_notation_jeu', $atts );
     }
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
@@ -19,7 +19,10 @@ class RatingBlock {
     public function render( $atts, $content = '', $shortcode_tag = '' ) {
         $atts = shortcode_atts(
             array(
-				'post_id' => get_the_ID(),
+                'post_id'      => get_the_ID(),
+                'score_layout' => '',
+                'animations'   => '',
+                'accent_color' => '',
             ),
             $atts,
             'bloc_notation_jeu'
@@ -57,17 +60,72 @@ class RatingBlock {
             }
         }
 
+        $options  = Helpers::get_plugin_options();
+        $defaults = Helpers::get_default_settings();
+
+        $score_layout = is_string( $atts['score_layout'] ) ? sanitize_key( $atts['score_layout'] ) : '';
+        if ( in_array( $score_layout, array( 'text', 'circle' ), true ) ) {
+            $options['score_layout'] = $score_layout;
+        } elseif ( ! isset( $options['score_layout'] ) ) {
+            $options['score_layout'] = $defaults['score_layout'] ?? 'text';
+        }
+
+        $animations_override = $this->normalize_bool_attribute( $atts['animations'] );
+        if ( $animations_override !== null ) {
+            $options['enable_animations'] = $animations_override ? 1 : 0;
+        } elseif ( ! isset( $options['enable_animations'] ) ) {
+            $options['enable_animations'] = ! empty( $defaults['enable_animations'] );
+        }
+
+        $accent_color = '';
+        if ( is_string( $atts['accent_color'] ) && $atts['accent_color'] !== '' ) {
+            $accent_color = sanitize_hex_color( $atts['accent_color'] );
+        }
+
+        if ( ! empty( $accent_color ) ) {
+            $options['score_gradient_1'] = $accent_color;
+            $options['score_gradient_2'] = Helpers::adjust_hex_brightness( $accent_color, 20 );
+            $options['color_high']       = $accent_color;
+            $options['color_mid']        = Helpers::adjust_hex_brightness( $accent_color, -10 );
+            $options['color_low']        = Helpers::adjust_hex_brightness( $accent_color, -25 );
+            $options['accent_color']     = $accent_color;
+        }
+
         Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'bloc_notation_jeu' );
 
         return Frontend::get_template_html(
             'shortcode-rating-block',
             array(
-                                'options'       => Helpers::get_plugin_options(),
-                                'average_score' => $average_score,
-                                'scores'        => $score_map,
-                                'category_scores' => $category_scores,
-                                'category_definitions' => Helpers::get_rating_category_definitions(),
-                        )
+                'options'              => $options,
+                'average_score'        => $average_score,
+                'scores'               => $score_map,
+                'category_scores'      => $category_scores,
+                'category_definitions' => Helpers::get_rating_category_definitions(),
+            )
         );
+    }
+
+    private function normalize_bool_attribute( $value ) {
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_numeric( $value ) ) {
+            return intval( $value ) === 1;
+        }
+
+        if ( is_string( $value ) ) {
+            $normalized = strtolower( trim( $value ) );
+
+            if ( in_array( $normalized, array( '1', 'true', 'on', 'yes', 'oui' ), true ) ) {
+                return true;
+            }
+
+            if ( in_array( $normalized, array( '0', 'false', 'off', 'no', 'non' ), true ) ) {
+                return false;
+            }
+        }
+
+        return null;
     }
 }

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -13,14 +13,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$options          = \JLG\Notation\Helpers::get_plugin_options();
-$score_max        = \JLG\Notation\Helpers::get_score_max( $options );
-$score_max_label  = number_format_i18n( $score_max );
+$options = isset( $options ) && is_array( $options )
+    ? $options
+    : \JLG\Notation\Helpers::get_plugin_options();
+
+$score_max       = \JLG\Notation\Helpers::get_score_max( $options );
+$score_max_label = number_format_i18n( $score_max );
+$score_layout    = isset( $options['score_layout'] ) && $options['score_layout'] === 'circle' ? 'circle' : 'text';
+$animations_on   = ! empty( $options['enable_animations'] );
+
+$style_variables = array(
+    '--jlg-score-gradient-1' => isset( $options['score_gradient_1'] ) ? $options['score_gradient_1'] : '',
+    '--jlg-score-gradient-2' => isset( $options['score_gradient_2'] ) ? $options['score_gradient_2'] : '',
+    '--jlg-color-high'       => isset( $options['color_high'] ) ? $options['color_high'] : '',
+    '--jlg-color-mid'        => isset( $options['color_mid'] ) ? $options['color_mid'] : '',
+    '--jlg-color-low'        => isset( $options['color_low'] ) ? $options['color_low'] : '',
+);
+
+$style_rules = array();
+foreach ( $style_variables as $var => $value ) {
+    if ( is_string( $value ) && $value !== '' ) {
+        $style_rules[] = $var . ':' . $value;
+    }
+}
+
+$style_attribute = ! empty( $style_rules ) ? ' style="' . esc_attr( implode( ';', $style_rules ) ) . '"' : '';
 ?>
 
-<div class="review-box-jlg<?php echo $options['enable_animations'] ? ' jlg-animate' : ''; ?>">
+<div class="review-box-jlg<?php echo $animations_on ? ' jlg-animate' : ''; ?>"<?php echo $style_attribute; ?>>
     <div class="global-score-wrapper">
-        <?php if ( $options['score_layout'] === 'circle' ) : ?>
+        <?php if ( $score_layout === 'circle' ) : ?>
             <div class="score-circle">
                 <div class="score-value"><?php echo esc_html( number_format_i18n( $average_score, 1 ) ); ?></div>
                 <div class="score-label"><?php esc_html_e( 'Note Globale', 'notation-jlg' ); ?></div>

--- a/plugin-notation-jeux_V4/tests/BlocksRegistrationTest.php
+++ b/plugin-notation-jeux_V4/tests/BlocksRegistrationTest.php
@@ -79,6 +79,14 @@ if (!function_exists('wp_set_script_translations')) {
     }
 }
 
+if (!function_exists('do_shortcode')) {
+    function do_shortcode($shortcode) {
+        $GLOBALS['jlg_test_last_shortcode'] = $shortcode;
+
+        return '[rendered]' . $shortcode;
+    }
+}
+
 class BlocksRegistrationTest extends TestCase
 {
     protected function setUp(): void
@@ -146,5 +154,24 @@ class BlocksRegistrationTest extends TestCase
             $this->assertArrayHasKey('render_callback', $found_registration['args']);
             $this->assertSame([$blocks, $config['callback']], $found_registration['args']['render_callback']);
         }
+    }
+
+    public function test_render_rating_block_supports_attribute_overrides(): void
+    {
+        $blocks = new \JLG\Notation\Blocks();
+
+        $GLOBALS['jlg_test_last_shortcode'] = null;
+
+        $result = $blocks->render_rating_block([
+            'postId'        => 42,
+            'scoreLayout'   => 'circle',
+            'showAnimations' => false,
+            'accentColor'   => '#ABCDEF',
+        ]);
+
+        $expected_shortcode = '[bloc_notation_jeu post_id="42" score_layout="circle" animations="non" accent_color="#abcdef"]';
+
+        $this->assertSame($expected_shortcode, $GLOBALS['jlg_test_last_shortcode']);
+        $this->assertSame('[rendered]' . $expected_shortcode, $result);
     }
 }


### PR DESCRIPTION
## Summary
- add layout, animation, and accent color attributes to the rating block metadata and editor UI
- map the new block attributes to shortcode parameters and allow the rating shortcode to override plugin options
- update the rating block template styling and extend block registration tests to cover the overrides

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dee5576d30832ea7f8248f030ed572