### PR TITLE
Improve Game Explorer pagination accessibility

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -31,7 +31,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 - **SEO optimisé** : Support schema.org pour les rich snippets Google
 - **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
 - **Sélecteur de couleurs enrichi** : Profitez du color picker WordPress avec saisie libre (y compris `transparent` lorsque pris en charge)
-- **Accessibilité renforcée** : Les animations respectent la préférence système *réduire les mouvements*
+- **Accessibilité renforcée** : Les animations respectent la préférence système *réduire les mouvements* et la navigation du Game Explorer annonce désormais la page active (`aria-current`) tout en proposant des repères de focus visibles, y compris sur mobile
 - **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 - **Responsive** : Parfaitement adapté mobile et tablette
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -28,7 +28,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 * **SEO optimisé** : Support schema.org pour les rich snippets Google
 * **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
 * **Sélecteur de couleurs enrichi** : Profitez du color picker WordPress avec saisie libre (y compris `transparent` lorsque pris en charge)
-* **Accessibilité renforcée** : Les animations respectent la préférence système "réduire les mouvements"
+* **Accessibilité renforcée** : Les animations respectent la préférence système "réduire les mouvements" et la navigation du Game Explorer annonce désormais la page active (aria-current) tout en proposant des repères de focus visibles, y compris sur mobile
 * **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
 * **Responsive** : Parfaitement adapté mobile et tablette
 

--- a/plugin-notation-jeux_V4/assets/css/game-explorer.css
+++ b/plugin-notation-jeux_V4/assets/css/game-explorer.css
@@ -99,6 +99,17 @@
     cursor: not-allowed;
 }
 
+.jlg-ge-letter-nav button:focus-visible,
+.jlg-ge-pagination button:focus-visible,
+.jlg-ge-reset:focus-visible {
+    background: var(--jlg-ge-accent);
+    border-color: var(--jlg-ge-accent);
+    color: #0f172a;
+    outline: 3px solid rgba(96, 165, 250, 0.85);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(15, 23, 42, 0.65);
+}
+
 .jlg-ge-count {
     font-size: 0.9rem;
     color: var(--jlg-ge-text-muted);
@@ -272,6 +283,13 @@
 .jlg-ge-card__title a {
     color: var(--jlg-ge-text);
     text-decoration: none;
+}
+
+.jlg-ge-card__media:focus-visible,
+.jlg-ge-card__title a:focus-visible {
+    outline: 3px solid rgba(96, 165, 250, 0.85);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(15, 23, 42, 0.6);
 }
 
 .jlg-ge-card__title a:hover {

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -454,6 +454,39 @@
         }
     }
 
+    function updatePaginationAccessibility(refs) {
+        if (!refs || !refs.resultsNode) {
+            return;
+        }
+
+        const pagination = refs.resultsNode.querySelector('[data-role="pagination"]');
+        if (!pagination) {
+            return;
+        }
+
+        const buttons = pagination.querySelectorAll('button[data-page]');
+        buttons.forEach((button) => {
+            const isControlButton = button.classList.contains('jlg-ge-page--prev')
+                || button.classList.contains('jlg-ge-page--next');
+
+            if (isControlButton) {
+                if (button.disabled) {
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.removeAttribute('aria-disabled');
+                }
+                button.removeAttribute('aria-current');
+                return;
+            }
+
+            if (button.classList.contains('is-active') || button.disabled) {
+                button.setAttribute('aria-current', 'page');
+            } else {
+                button.removeAttribute('aria-current');
+            }
+        });
+    }
+
     function bindPagination(container, config, refs) {
         if (!refs.resultsNode) {
             return;
@@ -483,6 +516,8 @@
                 refreshResults(container, config, refs);
             });
         });
+
+        updatePaginationAccessibility(refs);
     }
 
     function refreshResults(container, config, refs, options = {}) {
@@ -558,6 +593,7 @@
                         refs.resultsNode.innerHTML = '<p>' + empty + '</p>';
                     }
                     setResultsBusyState(refs.resultsNode, false);
+                    updatePaginationAccessibility(refs);
                 }
 
                 if (responseData.state) {

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -215,8 +215,10 @@ $current_page = isset( $pagination['current'] ) ? (int) $pagination['current'] :
 $total_pages  = isset( $pagination['total'] ) ? (int) $pagination['total'] : 0;
 
 if ( $total_pages > 1 ) :
-    $prev_page = max( 1, $current_page - 1 );
-    $next_page = min( $total_pages, $current_page + 1 );
+    $prev_page      = max( 1, $current_page - 1 );
+    $next_page      = min( $total_pages, $current_page + 1 );
+    $prev_disabled  = ( $current_page <= 1 );
+    $next_disabled  = ( $current_page >= $total_pages );
     ?>
     <nav class="jlg-ge-pagination" data-role="pagination" aria-label="<?php esc_attr_e( 'Navigation des pages du Game Explorer', 'notation-jlg' ); ?>">
         <form method="get" class="jlg-ge-pagination__form">
@@ -230,7 +232,7 @@ if ( $total_pages > 1 ) :
                 data-page="<?php echo esc_attr( $prev_page ); ?>"
                 name="<?php echo esc_attr( $namespaced_keys['paged'] ); ?>"
                 value="<?php echo esc_attr( $prev_page ); ?>"
-                <?php disabled( $current_page <= 1 ); ?>
+                <?php disabled( $prev_disabled ); ?><?php echo $prev_disabled ? ' aria-disabled="true"' : ''; ?>
             >
                 <?php esc_html_e( 'Précédent', 'notation-jlg' ); ?>
             </button>
@@ -246,7 +248,7 @@ if ( $total_pages > 1 ) :
                             class="<?php echo esc_attr( $is_active ? 'is-active' : '' ); ?>"
                             name="<?php echo esc_attr( $namespaced_keys['paged'] ); ?>"
                             value="<?php echo esc_attr( $page ); ?>"
-                            <?php disabled( $is_active ); ?>
+                            <?php disabled( $is_active ); ?><?php echo $is_active ? ' aria-current="page"' : ''; ?>
                         >
                             <?php echo esc_html( $page ); ?>
                         </button>
@@ -259,7 +261,7 @@ if ( $total_pages > 1 ) :
                 data-page="<?php echo esc_attr( $next_page ); ?>"
                 name="<?php echo esc_attr( $namespaced_keys['paged'] ); ?>"
                 value="<?php echo esc_attr( $next_page ); ?>"
-                <?php disabled( $current_page >= $total_pages ); ?>
+                <?php disabled( $next_disabled ); ?><?php echo $next_disabled ? ' aria-disabled="true"' : ''; ?>
             >
                 <?php esc_html_e( 'Suivant', 'notation-jlg' ); ?>
             </button>


### PR DESCRIPTION
## Summary
- add aria-current/aria-disabled attributes to the Game Explorer pagination markup
- update the Game Explorer script to refresh pagination ARIA state after AJAX updates
- improve focus-visible styling for interactive elements and document the accessibility changes

## Testing
- php -l plugin-notation-jeux_V4/templates/game-explorer-fragment.php

------
https://chatgpt.com/codex/tasks/task_e_68dee553aee4832eabba044e49853558