### PR TITLE
Add CTA metadata controls to all-in-one block

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
+++ b/plugin-notation-jeux_V4/admin/templates/tabs/shortcodes.php
@@ -37,6 +37,8 @@ if (!defined('ABSPATH')) exit;
             <li><strong>cta_rel</strong> : Attribut <code>rel</code> (défaut : <code>nofollow sponsored</code>)</li>
         </ul>
 
+        <p style="margin-top:10px;">Les options <code>cta_label</code> et <code>cta_url</code> remplacent celles saisies dans la section <em>Taglines &amp; CTA</em> de la métabox.</p>
+
         <h4>Exemples d'utilisation :</h4>
         <pre style="background:#fff; padding:10px; border:1px solid #ddd; border-radius:3px;">
 <span style="color:#666;">// Bloc complet avec tous les éléments (recommandé)</span>

--- a/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
@@ -144,6 +144,7 @@
                             onChange: function (value) {
                                 setAttributes({ ctaLabel: value || '' });
                             },
+                            help: __('Laissez vide pour utiliser le texte défini dans la métabox.', 'notation-jlg'),
                         }),
                         createElement(TextControl, {
                             label: __('URL du bouton', 'notation-jlg'),
@@ -152,7 +153,7 @@
                             onChange: function (value) {
                                 setAttributes({ ctaUrl: value || '' });
                             },
-                            help: __('Utilisez une URL absolue (https://...)', 'notation-jlg'),
+                            help: __('Utilisez une URL absolue (https://...) ou laissez vide pour utiliser la métabox.', 'notation-jlg'),
                         }),
                         createElement(TextControl, {
                             label: __('Attribut role', 'notation-jlg'),

--- a/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
@@ -190,19 +190,6 @@ class Metaboxes {
         echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée.', 'notation-jlg' ) . '</p>';
         echo '</div>';
 
-        echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px; margin-bottom:20px;">';
-        echo '<div>';
-        echo '<label for="jlg_cta_label"><strong>' . esc_html__( 'Texte du bouton CTA', 'notation-jlg' ) . ' :</strong></label><br>';
-        echo '<input type="text" id="jlg_cta_label" name="jlg_cta_label" value="' . esc_attr( $meta['cta_label'] ?? '' ) . '" style="width:100%;" placeholder="' . esc_attr__( 'Découvrir le jeu', 'notation-jlg' ) . '">';
-        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Laisser vide pour ne pas afficher de bouton.', 'notation-jlg' ) . '</p>';
-        echo '</div>';
-        echo '<div>';
-        echo '<label for="jlg_cta_url"><strong>' . esc_html__( 'URL du bouton CTA', 'notation-jlg' ) . ' :</strong></label><br>';
-        echo '<input type="url" id="jlg_cta_url" name="jlg_cta_url" value="' . esc_attr( $meta['cta_url'] ?? '' ) . '" style="width:100%;" placeholder="https://">';
-        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Utilisez une URL absolue commençant par https://', 'notation-jlg' ) . '</p>';
-        echo '</div>';
-        echo '</div>';
-
         // Fiche technique
         echo '<h3>' . esc_html__( '📋 Fiche Technique', 'notation-jlg' ) . '</h3>';
         echo '<div style="display:grid; grid-template-columns:repeat(3,1fr); gap:15px; margin-bottom:20px;">';
@@ -267,7 +254,7 @@ class Metaboxes {
         echo '</div>';
 
         // Taglines
-        echo '<h3>' . esc_html__( '💬 Taglines', 'notation-jlg' ) . '</h3>';
+        echo '<h3>' . esc_html__( '💬 Taglines & CTA', 'notation-jlg' ) . '</h3>';
         echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px; margin-bottom:20px;">';
         echo '<div>';
         echo '<label><strong>' . esc_html__( 'Française :', 'notation-jlg' ) . '</strong></label><br>';
@@ -276,6 +263,18 @@ class Metaboxes {
         echo '<div>';
         echo '<label><strong>' . esc_html__( 'Anglaise :', 'notation-jlg' ) . '</strong></label><br>';
         echo '<textarea name="jlg_tagline_en" rows="3" style="width:100%;">' . esc_textarea( $meta['tagline_en'] ?? '' ) . '</textarea>';
+        echo '</div>';
+        echo '<div style="grid-column: 1 / -1; display:grid; grid-template-columns:1fr 1fr; gap:15px;">';
+        echo '<div>';
+        echo '<label for="jlg_cta_label"><strong>' . esc_html__( 'Texte du bouton CTA', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="text" id="jlg_cta_label" name="jlg_cta_label" value="' . esc_attr( $meta['cta_label'] ?? '' ) . '" style="width:100%;" placeholder="' . esc_attr__( 'Découvrir le jeu', 'notation-jlg' ) . '">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Obligatoire si vous renseignez une URL.', 'notation-jlg' ) . '</p>';
+        echo '</div>';
+        echo '<div>';
+        echo '<label for="jlg_cta_url"><strong>' . esc_html__( 'URL du bouton CTA', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="url" id="jlg_cta_url" name="jlg_cta_url" value="' . esc_attr( $meta['cta_url'] ?? '' ) . '" style="width:100%;" placeholder="https://">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Renseignez une URL absolue (https://...).', 'notation-jlg' ) . '</p>';
+        echo '</div>';
         echo '</div>';
         echo '</div>';
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -11,6 +11,7 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
+use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
@@ -118,7 +119,7 @@ class AllInOne {
         $atts['cta_label']            = sanitize_text_field( $atts['cta_label'] );
         $atts['cta_url']              = esc_url_raw( $atts['cta_url'] );
         $atts['cta_role']             = sanitize_key( $atts['cta_role'] );
-        $atts['cta_rel']              = sanitize_text_field( $atts['cta_rel'] );
+        $atts['cta_rel']              = trim( sanitize_text_field( $atts['cta_rel'] ) );
 
         if ( $atts['cta_url'] !== '' && ! wp_http_validate_url( $atts['cta_url'] ) ) {
             $atts['cta_url'] = '';
@@ -157,8 +158,12 @@ class AllInOne {
         $cta_label     = get_post_meta( $post_id, '_jlg_cta_label', true );
         $cta_url       = get_post_meta( $post_id, '_jlg_cta_url', true );
 
-        $cta_label = is_string( $cta_label ) ? trim( $cta_label ) : '';
+        $cta_label = is_string( $cta_label ) ? sanitize_text_field( $cta_label ) : '';
+        $cta_label = $cta_label !== '' ? trim( $cta_label ) : '';
         $cta_url   = is_string( $cta_url ) ? trim( $cta_url ) : '';
+        if ( $cta_url !== '' && ! wp_http_validate_url( $cta_url ) ) {
+            $cta_url = '';
+        }
 
         if ( $atts['cta_label'] !== '' ) {
             $cta_label = $atts['cta_label'];


### PR DESCRIPTION
## Summary
- move the CTA inputs into the Taglines & CTA metabox section with validation for absolute URLs and non-empty labels
- sanitise and load CTA metadata in the all-in-one shortcode while supporting attribute overrides
- document the CTA overrides in the shortcode tab and clarify the Gutenberg block controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deedec2534832eab2f7159c0f785f3