### PR TITLE
Handle editor placeholder for rating block with empty scores

### DIFF
--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -369,6 +369,10 @@ class Blocks {
             }
         }
 
+        if ( class_exists( Frontend::class ) ) {
+            Frontend::mark_shortcode_rendered( 'bloc_notation_jeu' );
+        }
+
         return $this->render_shortcode( 'bloc_notation_jeu', $atts );
     }
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
@@ -48,6 +48,20 @@ class RatingBlock {
         // Sécurité : ne s'exécute que si des notes existent
         $average_score = Helpers::get_average_score_for_post( $post_id );
         if ( $average_score === null ) {
+            if ( $this->is_editor_preview_context() ) {
+                $shortcode_handle = $shortcode_tag ?: 'bloc_notation_jeu';
+
+                Frontend::mark_shortcode_rendered( $shortcode_handle );
+
+                return Frontend::get_template_html(
+                    'shortcode-rating-block-empty',
+                    array(
+                        'post'    => $post,
+                        'post_id' => $post_id,
+                    )
+                );
+            }
+
             return '';
         }
 
@@ -166,5 +180,25 @@ class RatingBlock {
         }
 
         return null;
+    }
+
+    private function is_editor_preview_context() {
+        if ( ! function_exists( 'is_admin' ) || ! is_admin() ) {
+            return false;
+        }
+
+        $doing_ajax = function_exists( 'wp_doing_ajax' )
+            ? wp_doing_ajax()
+            : ( defined( 'DOING_AJAX' ) && DOING_AJAX );
+
+        if ( $doing_ajax ) {
+            return true;
+        }
+
+        if ( function_exists( 'doing_filter' ) && doing_filter( 'rest_request_after_callbacks' ) ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Placeholder template displayed when no rating data is available.
+ *
+ * @package notation-jlg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="jlg-rating-block-empty notice notice-info">
+    <p>
+        <?php
+        echo esc_html__(
+            'Aucune note n’est disponible pour le moment. Utilisez la metabox « Notation JLG » pour saisir les notes du test.',
+            'notation-jlg'
+        );
+        ?>
+    </p>
+</div>

--- a/plugin-notation-jeux_V4/tests/ShortcodeRatingBlockRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeRatingBlockRenderTest.php
@@ -28,7 +28,10 @@ class ShortcodeRatingBlockRenderTest extends TestCase
             $GLOBALS['jlg_test_posts'],
             $GLOBALS['jlg_test_meta'],
             $GLOBALS['jlg_test_options'],
-            $GLOBALS['jlg_test_current_post_id']
+            $GLOBALS['jlg_test_current_post_id'],
+            $GLOBALS['jlg_test_is_admin'],
+            $GLOBALS['jlg_test_doing_ajax'],
+            $GLOBALS['jlg_test_doing_filters']
         );
 
         \JLG\Notation\Helpers::flush_plugin_options_cache();
@@ -89,6 +92,26 @@ class ShortcodeRatingBlockRenderTest extends TestCase
         $this->assertStringContainsString('jlg-animate', $output, 'Animations should follow plugin settings.');
         $this->assertMatchesRegularExpression('/style=\"[^\"]*--jlg-score-gradient-1:#123123/i', $output, 'Default accent colors should surface in CSS variables.');
         $this->assertMatchesRegularExpression('/style=\"[^\"]*--jlg-color-low:#345678/i', $output);
+    }
+
+    public function test_render_outputs_placeholder_in_editor_when_scores_missing(): void
+    {
+        $post_id = 1203;
+        $this->seedPost($post_id);
+
+        $GLOBALS['jlg_test_is_admin'] = true;
+        $GLOBALS['jlg_test_doing_filters'] = [
+            'rest_request_after_callbacks' => true,
+        ];
+
+        $shortcode = new \JLG\Notation\Shortcodes\RatingBlock();
+        $output = $shortcode->render([
+            'post_id' => (string) $post_id,
+        ]);
+
+        $this->assertNotSame('', $output, 'Editor preview should render placeholder markup.');
+        $this->assertStringContainsString('jlg-rating-block-empty', $output, 'Placeholder class should be present.');
+        $this->assertStringContainsString('Notation JLG', $output, 'Metabox reference should guide editors.');
     }
 
     private function seedPost(int $post_id): void

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -112,6 +112,21 @@ if (!function_exists('is_admin')) {
     }
 }
 
+if (!function_exists('doing_filter')) {
+    /**
+     * Minimal doing_filter stub so tests can emulate REST rendering context.
+     */
+    function doing_filter($hook = null) {
+        if (!is_string($hook) || $hook === '') {
+            return false;
+        }
+
+        $flags = $GLOBALS['jlg_test_doing_filters'] ?? [];
+
+        return !empty($flags[$hook]);
+    }
+}
+
 if (!function_exists('wp_next_scheduled')) {
     /**
      * Expose scheduled events for assertions via $GLOBALS['jlg_test_scheduled_events'].


### PR DESCRIPTION
## Summary
- detect the block editor preview context in the rating shortcode and render a placeholder template when no scores are available
- add a localized empty-state template and ensure the dynamic block still enqueues frontend assets for styling/scripts
- extend the test bootstrap and rating block test suite with coverage for the empty editor state

## Testing
- composer test *(fails: suite expects a full WordPress stack; numerous pre-existing tests error because core classes/functions are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defbd41f44832eaf19a2f9389e5a19