### PR TITLE
Add visible labels to all-in-one language buttons

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -73,16 +73,17 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     width: auto;
     height: auto;
-    padding: 0;
+    padding: 4px 8px;
     border: 0;
     background: transparent;
     cursor: pointer;
     opacity: 0.4;
     transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
     filter: grayscale(50%);
-    border-radius: 4px;
+    border-radius: 9999px;
 }
 
 .jlg-aio-flag img {
@@ -91,6 +92,22 @@
     display: block;
     min-height: 18px;
     pointer-events: none;
+}
+
+.jlg-aio-flag-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--jlg-aio-tagline-color, #111827);
+    line-height: 1;
+}
+
+.jlg-aio-flag .screen-reader-text {
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
 }
 
 .jlg-aio-flag.active {
@@ -107,6 +124,20 @@
 .jlg-aio-flag:focus-visible {
     outline: 2px solid var(--jlg-aio-tagline-color, #111827);
     outline-offset: 2px;
+}
+
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+    word-wrap: normal !important;
 }
 
 @media (max-width: 480px) {

--- a/plugin-notation-jeux_V4/assets/js/tagline-switcher.js
+++ b/plugin-notation-jeux_V4/assets/js/tagline-switcher.js
@@ -4,7 +4,11 @@ jQuery(document).ready(function($) {
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     var toggleTagline = function($trigger) {
-        var selectedLang = $trigger.data('lang');
+        var selectedLang = $trigger.attr('data-lang');
+
+        if (!selectedLang) {
+            return;
+        }
         var $taglineBlock = $trigger.closest('.jlg-tagline-block');
 
         if ($trigger.hasClass('active')) {

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -38,6 +38,7 @@ $data_attributes  = sprintf(
                 aria-label="<?php echo esc_attr__( 'Français', 'notation-jlg' ); ?>"
             >
                 <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/fr.svg' ); ?>" alt="">
+                <span class="jlg-aio-flag-label"><?php echo esc_html__( 'Français', 'notation-jlg' ); ?></span>
             </button>
             <button
                 type="button"
@@ -47,6 +48,7 @@ $data_attributes  = sprintf(
                 aria-label="<?php echo esc_attr__( 'English', 'notation-jlg' ); ?>"
             >
                 <img src="<?php echo esc_url( JLG_NOTATION_PLUGIN_URL . 'assets/flags/gb.svg' ); ?>" alt="">
+                <span class="jlg-aio-flag-label"><?php echo esc_html__( 'English', 'notation-jlg' ); ?></span>
             </button>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- add textual labels to the all-in-one shortcode language buttons for accessibility
- adjust the all-in-one stylesheet to style the new labels and provide screen-reader-only helpers
- make the tagline switcher rely on the data-lang attribute rather than the flag image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df968a4368832ebf730c7108e6be29