### PR TITLE
Add checkbox controls for Game Explorer filters

### DIFF
--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -215,7 +215,16 @@ class GameExplorer {
             $columns = 3;
         }
 
-        $filters = isset( $options['game_explorer_filters'] ) ? $options['game_explorer_filters'] : 'letter,category,platform,availability';
+        $filters_option = isset( $options['game_explorer_filters'] )
+            ? $options['game_explorer_filters']
+            : Helpers::get_default_game_explorer_filters();
+
+        $filters_list = Helpers::normalize_game_explorer_filters(
+            $filters_option,
+            Helpers::get_default_game_explorer_filters()
+        );
+
+        $filters = implode( ',', $filters_list );
         $score_position = Helpers::normalize_game_explorer_score_position(
             $options['game_explorer_score_position'] ?? ''
         );
@@ -287,20 +296,14 @@ class GameExplorer {
     }
 
     protected static function normalize_filters( $filters_string ) {
-        $allowed    = array( 'letter', 'category', 'platform', 'availability', 'search' );
+        $allowed        = Helpers::get_game_explorer_allowed_filters();
+        $default_filters = Helpers::get_default_game_explorer_filters();
+        $list            = Helpers::normalize_game_explorer_filters( $filters_string, $default_filters );
+
         $normalized = array();
 
-        if ( is_string( $filters_string ) ) {
-            $parts = array_filter( array_map( 'trim', explode( ',', strtolower( $filters_string ) ) ) );
-            foreach ( $parts as $part ) {
-                if ( in_array( $part, $allowed, true ) ) {
-                    $normalized[ $part ] = true;
-                }
-            }
-        }
-
-        if ( empty( $normalized ) ) {
-            $normalized = array_fill_keys( array( 'letter', 'category', 'platform', 'availability' ), true );
+        foreach ( $allowed as $filter_key ) {
+            $normalized[ $filter_key ] = in_array( $filter_key, $list, true );
         }
 
         return $normalized;

--- a/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
+++ b/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
@@ -76,6 +76,58 @@ class FormRenderer {
         self::render_description( $args );
     }
 
+    public static function checkbox_group_field( $args ) {
+        $options  = Helpers::get_plugin_options();
+        $defaults = Helpers::get_default_settings();
+        $field_id = $args['id'];
+
+        $choices = isset( $args['options'] ) && is_array( $args['options'] )
+            ? $args['options']
+            : array();
+
+        $selected = $options[ $field_id ] ?? ( $defaults[ $field_id ] ?? array() );
+
+        if ( $field_id === 'game_explorer_filters' ) {
+            $selected = Helpers::normalize_game_explorer_filters(
+                $selected,
+                Helpers::get_default_game_explorer_filters()
+            );
+        } else {
+            if ( is_string( $selected ) ) {
+                $selected = array( $selected );
+            }
+
+            if ( ! is_array( $selected ) ) {
+                $selected = array();
+            }
+
+            $selected = array_values( array_unique( array_filter( array_map( 'sanitize_key', $selected ) ) ) );
+        }
+
+        if ( empty( $choices ) ) {
+            return;
+        }
+
+        echo '<div class="jlg-checkbox-group">';
+
+        foreach ( $choices as $choice_key => $choice_label ) {
+            $choice_id = sprintf( '%s_%s', $field_id, $choice_key );
+            printf(
+                '<label for="%1$s" class="jlg-checkbox-group__item"><input type="checkbox" name="%2$s[%3$s][]" id="%1$s" value="%4$s" %5$s /> %6$s</label>',
+                esc_attr( $choice_id ),
+                esc_attr( self::$option_name ),
+                esc_attr( $field_id ),
+                esc_attr( $choice_key ),
+                checked( in_array( $choice_key, $selected, true ), true, false ),
+                esc_html( $choice_label )
+            );
+        }
+
+        echo '</div>';
+
+        self::render_description( $args );
+    }
+
     public static function select_field( $args ) {
         $options = Helpers::get_plugin_options();
         $value   = $options[ $args['id'] ] ?? '';

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -628,7 +628,7 @@ class FrontendGameExplorerAjaxTest extends TestCase
     {
         $defaults = \JLG\Notation\Helpers::get_default_settings();
         $defaults['game_explorer_posts_per_page'] = 2;
-        $defaults['game_explorer_filters'] = 'letter,category,platform,availability,search';
+        $defaults['game_explorer_filters'] = \JLG\Notation\Helpers::get_default_game_explorer_filters();
         $defaults['game_explorer_score_position'] = \JLG\Notation\Helpers::normalize_game_explorer_score_position('');
 
         $GLOBALS['jlg_test_options']['notation_jlg_settings'] = $defaults;


### PR DESCRIPTION
## Summary
- replace the Game Explorer filter settings text field with a predefined checkbox group and normalize submitted values during sanitization
- update helper defaults and shortcode processing to work with the array-based filter configuration and migrate legacy string values
- extend the form renderer and related tests to cover the new checkbox list behaviour

## Testing
- composer test *(fails: phpunit not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df9687aa04832e81a44808751828d0