### PR TITLE
Add responsive filters toggle to game explorer

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/game-explorer.css
+++ b/plugin-notation-jeux_V4/assets/css/game-explorer.css
@@ -189,7 +189,9 @@
         display: none;
     }
 
-    .jlg-ge-filters-panel.is-collapsed {
+    .jlg-ge-filters-panel.is-collapsed,
+    .jlg-ge-filters-panel[aria-hidden="true"],
+    .jlg-ge-filters-wrapper[data-expanded="false"] .jlg-ge-filters-panel {
         display: none;
     }
 }
@@ -216,7 +218,8 @@
         z-index: 1000;
     }
 
-    .jlg-ge-filters-backdrop.is-active {
+    .jlg-ge-filters-backdrop.is-active,
+    .jlg-ge-filters-backdrop[data-active="true"] {
         opacity: 1;
         visibility: visible;
     }
@@ -237,13 +240,17 @@
         z-index: 1001;
     }
 
-    .jlg-ge-filters-panel.is-collapsed {
+    .jlg-ge-filters-panel.is-collapsed,
+    .jlg-ge-filters-wrapper[data-expanded="false"] .jlg-ge-filters-panel,
+    .jlg-ge-filters-panel[aria-hidden="true"] {
         transform: translateY(100%);
         opacity: 0;
         visibility: hidden;
     }
 
-    .jlg-ge-filters-panel:not(.is-collapsed) {
+    .jlg-ge-filters-panel:not(.is-collapsed),
+    .jlg-ge-filters-panel[data-expanded="true"],
+    .jlg-ge-filters-wrapper[data-expanded="true"] .jlg-ge-filters-panel {
         transform: translateY(0);
         opacity: 1;
         visibility: visible;

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -506,18 +506,25 @@
         const wrapper = refs.filtersWrapper;
         const backdrop = refs.filtersBackdrop;
 
-        toggle.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+        const expandedValue = nextExpanded ? 'true' : 'false';
+
+        toggle.setAttribute('aria-expanded', expandedValue);
+        toggle.dataset.expanded = expandedValue;
+
         panel.setAttribute('aria-hidden', nextExpanded ? 'false' : 'true');
+        panel.dataset.expanded = expandedValue;
         panel.classList.toggle('is-collapsed', !nextExpanded);
 
         if (wrapper) {
             wrapper.classList.toggle('is-expanded', nextExpanded);
+            wrapper.dataset.expanded = expandedValue;
         }
 
         if (backdrop) {
             const showBackdrop = nextExpanded && !!state.isMobile;
             backdrop.classList.toggle('is-active', showBackdrop);
             backdrop.setAttribute('aria-hidden', showBackdrop ? 'false' : 'true');
+            backdrop.dataset.active = showBackdrop ? 'true' : 'false';
         }
 
         if (nextExpanded) {
@@ -572,7 +579,18 @@
 
         toggle.setAttribute('aria-controls', panelId);
         toggle.setAttribute('aria-expanded', 'true');
+        toggle.dataset.expanded = 'true';
+
         panel.setAttribute('aria-hidden', 'false');
+        panel.dataset.expanded = 'true';
+
+        if (refs.filtersWrapper) {
+            refs.filtersWrapper.dataset.expanded = 'true';
+        }
+
+        if (refs.filtersBackdrop) {
+            refs.filtersBackdrop.dataset.active = 'false';
+        }
 
         const applyMobileState = (isMobile) => {
             state.isMobile = !!isMobile;

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -247,13 +247,18 @@ $reset_url = remove_query_arg( array_values( $namespaced_keys ) );
 
     <?php if ( $has_filters ) : ?>
         <?php $filters_panel_id = $container_id . '-filters'; ?>
-        <div class="jlg-ge-filters-wrapper" data-role="filters-wrapper">
+        <div
+            class="jlg-ge-filters-wrapper"
+            data-role="filters-wrapper"
+            data-expanded="true"
+        >
             <button
                 type="button"
                 class="jlg-ge-filters-toggle"
                 data-role="filters-toggle"
                 aria-expanded="true"
                 aria-controls="<?php echo esc_attr( $filters_panel_id ); ?>"
+                data-expanded="true"
             >
                 <span class="jlg-ge-filters-toggle__label"><?php esc_html_e( 'Filtres', 'notation-jlg' ); ?></span>
             </button>
@@ -263,6 +268,7 @@ $reset_url = remove_query_arg( array_values( $namespaced_keys ) );
                 id="<?php echo esc_attr( $filters_panel_id ); ?>"
                 data-role="filters-panel"
                 aria-hidden="false"
+                data-expanded="true"
             >
                 <div class="jlg-ge-filters" data-role="filters">
                     <form method="get" class="jlg-ge-filters__form" data-role="filters-form">


### PR DESCRIPTION
## Summary
- wrap the filter controls in an accessible toggle container with default expanded state
- update the game explorer script to keep aria and data attributes in sync when opening or closing the panel
- extend the stylesheet so the filters panel and backdrop react to the new expanded state on desktop and mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9688c6f8832e8d2ba6cb32002310