### PR TITLE
Add configurable allowed post types in settings

### DIFF
--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -884,41 +884,76 @@ class Helpers {
      * @return string[] List of sanitized post type identifiers.
      */
     public static function get_allowed_post_types() {
-        $defaults         = self::get_default_settings();
-        $default_post_types = isset( $defaults['allowed_post_types'] ) && is_array( $defaults['allowed_post_types'] )
-            ? $defaults['allowed_post_types']
-            : array( 'post' );
+        $defaults = self::get_default_settings();
 
-        $options    = self::get_plugin_options();
-        $post_types = isset( $options['allowed_post_types'] ) ? $options['allowed_post_types'] : $default_post_types;
+        $default_post_types = self::sanitize_post_type_list(
+            isset( $defaults['allowed_post_types'] ) ? $defaults['allowed_post_types'] : array( 'post' )
+        );
 
-        if ( is_string( $post_types ) ) {
+        if ( empty( $default_post_types ) ) {
+            $default_post_types = array( 'post' );
+        }
+
+        $options          = self::get_plugin_options();
+        $configured_types = isset( $options['allowed_post_types'] )
+            ? $options['allowed_post_types']
+            : $default_post_types;
+
+        $base_post_types = self::sanitize_post_type_list( $configured_types );
+
+        if ( empty( $base_post_types ) ) {
+            $base_post_types = $default_post_types;
+        }
+
+        $filtered_post_types = apply_filters( 'jlg_rated_post_types', $base_post_types );
+
+        if ( ! is_array( $filtered_post_types ) ) {
+            $filtered_post_types = $base_post_types;
+        } else {
+            $filtered_post_types = self::sanitize_post_type_list( $filtered_post_types );
+
+            if ( empty( $filtered_post_types ) ) {
+                $filtered_post_types = $base_post_types;
+            }
+        }
+
+        if ( empty( $filtered_post_types ) ) {
+            $filtered_post_types = $default_post_types;
+        }
+
+        if ( empty( $filtered_post_types ) ) {
+            $filtered_post_types = array( 'post' );
+        }
+
+        return $filtered_post_types;
+    }
+
+    private static function sanitize_post_type_list( $post_types ) {
+        if ( is_string( $post_types ) || is_numeric( $post_types ) ) {
             $post_types = array( $post_types );
         }
 
         if ( ! is_array( $post_types ) ) {
-            $post_types = $default_post_types;
+            return array();
         }
 
-        $post_types = array_values( array_filter( array_map( 'sanitize_key', $post_types ) ) );
+        $sanitized = array();
 
-        if ( empty( $post_types ) ) {
-            $post_types = $default_post_types;
+        foreach ( $post_types as $type ) {
+            if ( is_array( $type ) ) {
+                continue;
+            }
+
+            $key = sanitize_key( (string) $type );
+
+            if ( $key === '' ) {
+                continue;
+            }
+
+            $sanitized[] = $key;
         }
 
-        $post_types = apply_filters( 'jlg_rated_post_types', $post_types );
-
-        if ( ! is_array( $post_types ) ) {
-            $post_types = $default_post_types;
-        }
-
-        $post_types = array_values( array_filter( array_map( 'sanitize_key', $post_types ) ) );
-
-        if ( empty( $post_types ) ) {
-            $post_types = $default_post_types;
-        }
-
-        return array_values( array_unique( $post_types ) );
+        return array_values( array_unique( $sanitized ) );
     }
 
     public static function flush_plugin_options_cache() {

--- a/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
+++ b/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
@@ -110,24 +110,80 @@ class FormRenderer {
 
         $selected = array_map( 'sanitize_key', $selected );
 
-        $post_types = \get_post_types( array( 'public' => true ), 'objects' );
+        $choices = array();
 
-        if ( ! is_array( $post_types ) ) {
-            $post_types = array();
+        if ( isset( $args['choices'] ) && is_array( $args['choices'] ) ) {
+            foreach ( $args['choices'] as $slug => $label ) {
+                $slug = sanitize_key( (string) $slug );
+
+                if ( $slug === '' ) {
+                    continue;
+                }
+
+                if ( ! is_string( $label ) ) {
+                    $label = '';
+                }
+
+                $label = trim( $label );
+
+                if ( $label === '' ) {
+                    $label = ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+                }
+
+                $choices[ $slug ] = $label;
+            }
+        }
+
+        if ( empty( $choices ) && function_exists( 'get_post_types' ) ) {
+            $post_types = \get_post_types( array( 'public' => true ), 'objects' );
+
+            if ( is_array( $post_types ) ) {
+                foreach ( $post_types as $slug => $post_type ) {
+                    $slug = sanitize_key( (string) $slug );
+
+                    if ( $slug === '' ) {
+                        continue;
+                    }
+
+                    $label = '';
+
+                    if ( isset( $post_type->labels->singular_name ) && is_string( $post_type->labels->singular_name ) ) {
+                        $label = trim( $post_type->labels->singular_name );
+                    }
+
+                    if ( $label === '' && isset( $post_type->label ) && is_string( $post_type->label ) ) {
+                        $label = trim( $post_type->label );
+                    }
+
+                    if ( $label === '' ) {
+                        $label = ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+                    }
+
+                    $choices[ $slug ] = $label;
+                }
+            }
+        }
+
+        if ( empty( $choices ) ) {
+            $choices = array( 'post' => 'post' );
+        }
+
+        $size = count( $choices );
+        if ( $size < 4 ) {
+            $size = 4;
+        } elseif ( $size > 12 ) {
+            $size = 12;
         }
 
         printf(
-            '<select name="%s[%s][]" id="%s" multiple="multiple" size="6" class="regular-text">',
+            '<select name="%s[%s][]" id="%s" multiple="multiple" size="%d" class="regular-text">',
             esc_attr( self::$option_name ),
             esc_attr( $field_id ),
-            esc_attr( $field_id )
+            esc_attr( $field_id ),
+            (int) $size
         );
 
-        foreach ( $post_types as $slug => $post_type ) {
-            $label = isset( $post_type->labels->singular_name ) && $post_type->labels->singular_name
-                ? $post_type->labels->singular_name
-                : $post_type->label;
-
+        foreach ( $choices as $slug => $label ) {
             printf(
                 '<option value="%s"%s>%s</option>',
                 esc_attr( $slug ),

--- a/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminMetaboxesAllowedPostTypesTest.php
@@ -29,7 +29,8 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
             $GLOBALS['jlg_test_posts'],
             $GLOBALS['jlg_test_meta'],
             $GLOBALS['jlg_test_meta_updates'],
-            $GLOBALS['jlg_test_transients']
+            $GLOBALS['jlg_test_transients'],
+            $GLOBALS['jlg_test_registered_post_types']
         );
         $_POST = [];
 
@@ -40,11 +41,14 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
 
     public function test_register_metaboxes_respects_allowed_post_types(): void
     {
-        add_filter('jlg_rated_post_types', static function ($types) {
-            $types[] = 'jlg_review';
+        register_post_type('jlg_review', [
+            'public' => true,
+            'labels' => [
+                'singular_name' => 'Critique JLG',
+            ],
+        ]);
 
-            return $types;
-        });
+        $this->configureAllowedPostTypes(['post', 'jlg_review']);
 
         $post_id = 123;
         $post = new WP_Post([
@@ -63,11 +67,14 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
 
     public function test_save_meta_data_persists_notes_and_details_for_allowed_types(): void
     {
-        add_filter('jlg_rated_post_types', static function ($types) {
-            $types[] = 'jlg_review';
+        register_post_type('jlg_review', [
+            'public' => true,
+            'labels' => [
+                'singular_name' => 'Critique JLG',
+            ],
+        ]);
 
-            return $types;
-        });
+        $this->configureAllowedPostTypes(['post', 'jlg_review']);
 
         $post_id = 456;
         $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
@@ -118,5 +125,15 @@ class AdminMetaboxesAllowedPostTypesTest extends TestCase
         $this->assertSame('Un jeu exceptionnel', $saved_meta['_jlg_tagline_fr']);
         $this->assertSame('An exceptional game', $saved_meta['_jlg_tagline_en']);
         $this->assertSame(['PC', 'Xbox One'], $saved_meta['_jlg_plateformes']);
+    }
+
+    private function configureAllowedPostTypes(array $types): void
+    {
+        $defaults = \JLG\Notation\Helpers::get_default_settings();
+        $defaults['allowed_post_types'] = array_values($types);
+
+        $GLOBALS['jlg_test_options']['notation_jlg_settings'] = $defaults;
+
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
     }
 }


### PR DESCRIPTION
## Summary
- expose public post types in the settings UI so administrators can select which content types support JLG ratings
- persist and sanitise the configured list while ensuring helper logic falls back to user-selected values before applying filters
- update form rendering and unit tests with a deterministic post-type registry stub to cover the new behaviour

## Testing
- `composer test` *(fails: phpunit not available in PATH in this environment)*
- `./vendor/bin/phpunit` *(fails: WordPress runtime stubs are incomplete for the full suite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df96877f88832e8c224ae6dcafba16