### PR TITLE
Import WP_Query in shortcode classes

### DIFF
--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -4,6 +4,7 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
+use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;

--- a/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
@@ -10,6 +10,7 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
+use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;


### PR DESCRIPTION
## Summary
- import the global WP_Query class in the Game Explorer and Summary Display shortcodes to avoid relying on the local namespace

## Testing
- composer test *(fails: existing test suite requires additional WordPress stubs such as DateTime and shortcode helpers)*
- vendor/bin/phpunit tests/ShortcodeSummarySortingTest.php


------
https://chatgpt.com/codex/tasks/task_e_68dfc1da6520832e985f4f3e87441084