### PR TITLE
Use computed max score label in summary table

### DIFF
--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -422,7 +422,7 @@ else :
                                                 echo esc_html__( 'N/A', 'notation-jlg' );
                                             } else {
                                                 $formatted_score = esc_html( number_format_i18n( $score_value, 1 ) );
-                                                $max_score       = esc_html( '10' );
+                                                $max_score       = esc_html( $score_max_label );
 
                                                 printf(
                                                     /* translators: %1$s: category score value. %2$s: maximum rating value. */


### PR DESCRIPTION
## Summary
- reuse the precomputed maximum score label when rendering category columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc1d80a2c832e80b4c71bd81fb70e