### PR TITLE
Use global WP_Query in shortcodes

### DIFF
--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -4,7 +4,6 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
-use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
@@ -1041,7 +1040,7 @@ class GameExplorer {
             $query_args['orderby'] = 'title';
         }
 
-        $query = new WP_Query( $query_args );
+        $query = new \WP_Query( $query_args );
 
         $games = array();
         if ( $query->have_posts() ) {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
@@ -10,7 +10,6 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
-use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
@@ -275,7 +274,7 @@ class SummaryDisplay {
         }
 
         try {
-            $query = new WP_Query( $args );
+            $query = new \WP_Query( $args );
         } finally {
             if ( $letter_filter_active ) {
                 self::clear_letter_filter();


### PR DESCRIPTION
## Summary
- instantiate the game explorer shortcode query with the fully-qualified WordPress query class
- instantiate the summary display shortcode query with the fully-qualified WordPress query class

## Testing
- composer test *(fails: depends on WordPress test scaffolding that is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfccf2aa68832eac7bb34c80f678d3