### PR TITLE
Use dynamic score max label in summary table

### DIFF
--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -421,14 +421,13 @@ else :
                                             if ( $score_value === null ) {
                                                 echo esc_html__( 'N/A', 'notation-jlg' );
                                             } else {
-                                                $formatted_score = esc_html( number_format_i18n( $score_value, 1 ) );
-                                                $max_score       = esc_html( $score_max_label );
+                                                $formatted_score = number_format_i18n( $score_value, 1 );
 
                                                 printf(
                                                     /* translators: %1$s: category score value. %2$s: maximum rating value. */
                                                     esc_html__( '%1$s / %2$s', 'notation-jlg' ),
-                                                    $formatted_score,
-                                                    $max_score
+                                                    esc_html( $formatted_score ),
+                                                    esc_html( $score_max_label )
                                                 );
                                             }
 


### PR DESCRIPTION
## Summary
- ensure category score rows in the summary table reuse the computed maximum score label
- simplify the printf call by escaping values at output time to avoid redundant variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfccf02d3c832e98f6ddc1a0080c73