### PR TITLE
Add reusable admin card styling

### DIFF
--- a/plugin-notation-jeux_V4/admin/templates/admin-page.php
+++ b/plugin-notation-jeux_V4/admin/templates/admin-page.php
@@ -10,7 +10,7 @@ $tab_content = $variables['tab_content'] ?? '';
         <h1><?php echo esc_html($page_title); ?></h1>
     <?php endif; ?>
     <?php echo $tab_navigation; ?>
-    <div style="background:#fff; padding:20px; margin-top:20px; border-radius:8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+    <div class="jlg-admin-card">
         <?php echo $tab_content; ?>
     </div>
 </div>

--- a/plugin-notation-jeux_V4/assets/css/admin.css
+++ b/plugin-notation-jeux_V4/assets/css/admin.css
@@ -1,0 +1,25 @@
+.jlg-admin-card {
+    background-color: var(--wp-admin-surface-color, #fff);
+    color: var(--wp-admin-page-content-text, #1d2327);
+    padding: 20px;
+    margin-top: 20px;
+    border-radius: 8px;
+    border: 1px solid var(--wp-admin-border-color, #c3c4c7);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+body.is-dark-theme .jlg-admin-card {
+    background-color: var(--wp-admin-surface-color, #1d2327);
+    color: var(--wp-admin-page-content-text, #f0f0f1);
+    border-color: var(--wp-admin-border-color, #3c434a);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+body.is-dark-theme .jlg-admin-card a {
+    color: var(--wp-admin-theme-color, #72aee6);
+}
+
+body.is-dark-theme .jlg-admin-card a:hover,
+body.is-dark-theme .jlg-admin-card a:focus {
+    color: var(--wp-admin-theme-color-darker-10, #1d8fd1);
+}

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -43,6 +43,15 @@ class Assets {
         $version = defined( 'JLG_NOTATION_VERSION' ) ? JLG_NOTATION_VERSION : false;
 
         wp_enqueue_style( 'wp-color-picker' );
+
+        wp_register_style(
+            'jlg-admin-styles',
+            JLG_NOTATION_PLUGIN_URL . 'assets/css/admin.css',
+            array(),
+            $version
+        );
+
+        wp_enqueue_style( 'jlg-admin-styles' );
         wp_enqueue_script( 'wp-color-picker' );
 
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- replace the admin page card inline styles with a reusable class
- add an admin stylesheet that relies on WordPress color variables and dark theme support
- enqueue the stylesheet on the plugin's admin screens after the color picker assets

## Testing
- php -l admin/templates/admin-page.php
- php -l includes/Assets.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd32c3234832e8eeff623b675f8d1