### PR TITLE
Add loading overlay and spinner to summary table

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -75,6 +75,14 @@
         transition: none !important;
     }
 
+    .jlg-summary-wrapper .jlg-summary-content::before {
+        transition: none !important;
+    }
+
+    .jlg-summary-wrapper .jlg-summary-loading-indicator {
+        animation: none !important;
+    }
+
     .jlg-game-card,
     .jlg-game-card:hover,
     .jlg-game-card:focus-visible,
@@ -147,6 +155,14 @@
 .jlg-summary-table th.sorted a{color:var(--jlg-score-gradient-1);}
 .jlg-summary-table tbody tr:hover{background-color:var(--jlg-table-row-hover-color);}
 .jlg-summary-table td a{color:var(--jlg-table-link-color);font-weight:500;text-decoration:none;}
+.jlg-summary-wrapper .jlg-summary-content{position:relative;}
+.jlg-summary-wrapper .jlg-summary-content::before{content:"";position:absolute;inset:0;background:var(--jlg-summary-overlay-color,rgba(15,23,42,.35));opacity:0;transition:opacity .2s ease;pointer-events:none;border-radius:inherit;z-index:1;}
+.jlg-summary-wrapper.jlg-summary-loading{cursor:progress;}
+.jlg-summary-wrapper.jlg-summary-loading .jlg-summary-content{pointer-events:none;}
+.jlg-summary-wrapper.jlg-summary-loading .jlg-summary-content::before{opacity:1;pointer-events:auto;}
+.jlg-summary-wrapper .jlg-summary-loading-indicator{position:absolute;top:50%;left:50%;width:2.75rem;height:2.75rem;border-radius:9999px;border:3px solid rgba(255,255,255,.35);border-top-color:var(--jlg-score-gradient-1);border-right-color:var(--jlg-border-color);border-bottom-color:var(--jlg-border-color);border-left-color:var(--jlg-border-color);transform:translate(-50%,-50%);animation:jlg-summary-spinner .75s linear infinite;z-index:2;pointer-events:none;background:transparent;box-sizing:border-box;}
+
+@keyframes jlg-summary-spinner{0%{transform:translate(-50%,-50%) rotate(0deg);}100%{transform:translate(-50%,-50%) rotate(360deg);}}
 .jlg-summary-grid-wrapper{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-game-card{position:relative;display:block;overflow:hidden;border-radius:8px;box-shadow:0 4px 6px rgba(0,0,0,.3);transition:all .2s ease;}
 .jlg-game-card:hover{transform:translateY(-5px);box-shadow:0 8px 12px rgba(0,0,0,.4);}

--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -80,6 +80,25 @@ jQuery(document).ready(function($) {
         }
     }
 
+    function toggleLoadingIndicator($wrapper, isLoading) {
+        var $content = $wrapper.find('.jlg-summary-content');
+
+        if (!$content.length) {
+            return;
+        }
+
+        if (isLoading) {
+            if (!$content.children('.jlg-summary-loading-indicator').length) {
+                $('<div>', {
+                    'class': 'jlg-summary-loading-indicator',
+                    'aria-hidden': 'true',
+                }).appendTo($content);
+            }
+        } else {
+            $content.children('.jlg-summary-loading-indicator').remove();
+        }
+    }
+
     function getCurrentState($wrapper) {
         return {
             orderby: ($wrapper.attr('data-orderby') || 'date').toString(),
@@ -383,6 +402,7 @@ jQuery(document).ready(function($) {
         requestData[getRequestKey($wrapper, 'genre_filter')] = genreFilter;
 
         $wrapper.addClass('jlg-summary-loading');
+        toggleLoadingIndicator($wrapper, true);
 
         var jqXHR = $.ajax({
             url: ajaxUrl,
@@ -417,6 +437,7 @@ jQuery(document).ready(function($) {
             showError($wrapper, jlgSummarySort.strings.genericError);
         }).always(function() {
             $wrapper.removeClass('jlg-summary-loading');
+            toggleLoadingIndicator($wrapper, false);
             $wrapper.removeData('ajaxRequest');
         });
     }


### PR DESCRIPTION
## Summary
- add a semi-transparent overlay and spinner styles for summary wrappers, respecting reduced-motion preferences
- update the summary table sorting script to inject and remove the loading indicator during AJAX refreshes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd326b810832ea89e937def5d94b7