### PR TITLE
Add badge for extra platforms in game explorer cards

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/game-explorer.css
+++ b/plugin-notation-jeux_V4/assets/css/game-explorer.css
@@ -495,6 +495,13 @@
     border-color: rgba(148, 163, 184, 0.2);
 }
 
+.jlg-ge-badge--more {
+    background: rgba(15, 23, 42, 0.12);
+    border-color: rgba(15, 23, 42, 0.28);
+    color: var(--jlg-ge-text);
+    font-weight: 600;
+}
+
 .jlg-ge-badge--genre {
     background: rgba(96, 165, 250, 0.15);
     border-color: rgba(96, 165, 250, 0.25);

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -137,6 +137,9 @@ if ( empty( $games ) ) {
         $developer           = isset( $game['developer'] ) ? $game['developer'] : '';
         $publisher           = isset( $game['publisher'] ) ? $game['publisher'] : '';
         $platforms           = isset( $game['platforms'] ) && is_array( $game['platforms'] ) ? $game['platforms'] : array();
+        $platform_count      = count( $platforms );
+        $display_platforms   = array_slice( $platforms, 0, 4 );
+        $extra_platforms     = max( 0, $platform_count - count( $display_platforms ) );
         $genre               = isset( $game['genre'] ) ? $game['genre'] : '';
         $availability_label  = isset( $game['availability_label'] ) ? $game['availability_label'] : '';
         $availability_status = isset( $game['availability'] ) ? $game['availability'] : '';
@@ -194,9 +197,22 @@ if ( empty( $games ) ) {
                     <?php endif; ?>
                 </dl>
                 <div class="jlg-ge-card__badges">
-                    <?php foreach ( array_slice( $platforms, 0, 4 ) as $platform_label ) : ?>
+                    <?php foreach ( $display_platforms as $platform_label ) : ?>
                         <span class="jlg-ge-badge jlg-ge-badge--platform"><?php echo esc_html( $platform_label ); ?></span>
                     <?php endforeach; ?>
+                    <?php if ( $extra_platforms > 0 ) : ?>
+                        <?php
+                        $more_badge_label = sprintf( __( '+%d', 'notation-jlg' ), $extra_platforms );
+                        $more_badge_aria  = sprintf(
+                            /* translators: %d: number of additional platforms. */
+                            _n( '+%d plateforme', '+%d plateformes', $extra_platforms, 'notation-jlg' ),
+                            $extra_platforms
+                        );
+                        ?>
+                        <span class="jlg-ge-badge jlg-ge-badge--platform jlg-ge-badge--more" aria-label="<?php echo esc_attr( $more_badge_aria ); ?>">
+                            <?php echo esc_html( $more_badge_label ); ?>
+                        </span>
+                    <?php endif; ?>
                     <?php if ( $genre !== '' ) : ?>
                         <span class="jlg-ge-badge jlg-ge-badge--genre"><?php echo esc_html( $genre ); ?></span>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- compute platform counts before rendering game explorer badges to display an overflow badge with translated labels when necessary
- add styles for the overflow badge to keep it visually consistent with existing badges

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd32b1d18832eac5528786f654086