### PR TITLE
Improve summary content live region handling

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
+++ b/plugin-notation-jeux_V4/assets/js/summary-table-sort.js
@@ -271,6 +271,14 @@ jQuery(document).ready(function($) {
         var settings = options || {};
         var shouldUpdateHistory = settings.updateHistory !== false;
 
+        var $content = $wrapper.find('.jlg-summary-content');
+        if ($content.length) {
+            $content.attr('aria-busy', 'true');
+            if (!$content.is('[tabindex]')) {
+                $content.attr('tabindex', '-1');
+            }
+        }
+
         var currentRequest = $wrapper.data('ajaxRequest');
         if (currentRequest && typeof currentRequest.abort === 'function') {
             currentRequest.abort();
@@ -395,6 +403,10 @@ jQuery(document).ready(function($) {
         jqXHR.done(function(response) {
             if (!response || !response.success || !response.data) {
                 showError($wrapper, jlgSummarySort.strings.genericError);
+                if ($content.length) {
+                    $content.attr('aria-busy', 'false');
+                    $content.trigger('focus');
+                }
                 return;
             }
 
@@ -403,6 +415,8 @@ jQuery(document).ready(function($) {
 
             if ($content.length) {
                 $content.html(html);
+                $content.attr('aria-busy', 'false');
+                $content.trigger('focus');
             }
 
             updateState($wrapper, response.data.state || {});
@@ -415,9 +429,16 @@ jQuery(document).ready(function($) {
                 return;
             }
             showError($wrapper, jlgSummarySort.strings.genericError);
+            if ($content.length) {
+                $content.attr('aria-busy', 'false');
+                $content.trigger('focus');
+            }
         }).always(function() {
             $wrapper.removeClass('jlg-summary-loading');
             $wrapper.removeData('ajaxRequest');
+            if ($content.length && $content.attr('aria-busy') === 'true') {
+                $content.attr('aria-busy', 'false');
+            }
         });
     }
 

--- a/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-summary-display.php
@@ -154,7 +154,7 @@ $letters = range( 'A', 'Z' );
         </div>
     <?php endif; ?>
 
-    <div class="jlg-summary-content">
+    <div class="jlg-summary-content" role="status" aria-live="polite" aria-busy="false">
         <?php
         echo \JLG\Notation\Frontend::get_template_html(
             'summary-table-fragment',


### PR DESCRIPTION
## Summary
- add a polite live region to the summary content container
- toggle aria-busy and focus management when refreshing the summary via AJAX requests

## Testing
- not run (explain why): manual screen reader testing is not available in this environment

------
https://chatgpt.com/codex/tasks/task_e_68dfdd143f84832ea59cd1921261e85e