### PR TITLE
Fix block editor animations in previews

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/blocks-editor.css
+++ b/plugin-notation-jeux_V4/assets/css/blocks-editor.css
@@ -12,3 +12,23 @@
 .notation-jlg-block-preview .components-placeholder {
     width: 100%;
 }
+
+.editor-styles-wrapper .review-box-jlg.jlg-animate .rating-bar {
+    width: var(--rating-percent, 0%);
+}
+
+.editor-styles-wrapper .review-box-jlg.jlg-animate .score-circle,
+.editor-styles-wrapper .review-box-jlg.jlg-animate .global-score-text {
+    opacity: 1;
+    transform: none;
+}
+
+.editor-styles-wrapper .jlg-all-in-one-block.animate-in .jlg-aio-score-bar {
+    width: var(--bar-width) !important;
+}
+
+.editor-styles-wrapper .jlg-all-in-one-block.animate-in .jlg-aio-score-value,
+.editor-styles-wrapper .jlg-all-in-one-block.animate-in .jlg-aio-score-item {
+    opacity: 1;
+    transform: none;
+}


### PR DESCRIPTION
## Summary
- ensure animated rating and all-in-one blocks display their full styles in the editor preview
- mark dynamic block previews as visible once server-rendered to avoid dormant animations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff82706c4832ea950a298d8172bbc