### PR TITLE
Add score display mode selection to rating block outputs

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -52,8 +52,8 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 ### Shortcodes disponibles
 
-- `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
-- `[bloc_notation_jeu]` - Bloc de notation principal
+- `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+- `[bloc_notation_jeu]` - Bloc de notation principal. Attributs : `post_id` (ID du test), `score_layout` (`text` ou `circle`), `animations` (`oui`/`non`), `accent_color` et `display_mode` (`absolute` ou `percent`) pour choisir entre une note affichée en valeur absolue ou en pourcentage.
 - `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher, utilise l'article courant sinon), `champs` (liste de champs séparés par des virgules) et `titre`.
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 - `[jlg_points_forts_faibles]` - Points positifs et négatifs
@@ -76,7 +76,8 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 Le plugin propose désormais une collection complète de blocs dynamiques pour l'éditeur moderne :
 
 - **Bloc de notation** (`notation-jlg/rating-block`) : sélectionnez un test publié ou laissez vide pour utiliser l'article
-  courant.
+  courant, choisissez la disposition (`texte` ou `cercle`), activez ou non les animations et décidez du format du score
+  (valeur absolue ou pourcentage).
 - **Points forts / faibles** (`notation-jlg/pros-cons`) et **Tagline bilingue** (`notation-jlg/tagline`) : affichent
   automatiquement les métadonnées du test.
 - **Fiche technique** (`notation-jlg/game-info`) : choisissez les champs à afficher, personnalisez le titre et ciblez un
@@ -84,8 +85,8 @@ Le plugin propose désormais une collection complète de blocs dynamiques pour l
 - **Notation utilisateurs** (`notation-jlg/user-rating`) : insère le module de vote interactif.
 - **Tableau récapitulatif** (`notation-jlg/summary-display`) : contrôlez le nombre d'éléments, la disposition (table ou
   grille), les colonnes et les filtres par défaut.
-- **Bloc tout-en-un** (`notation-jlg/all-in-one`) : activez ou non chaque sous-section, choisissez le style et la couleur
-  d'accent pour un rendu cohérent.
+- **Bloc tout-en-un** (`notation-jlg/all-in-one`) : activez ou non chaque sous-section, choisissez le style, la couleur
+  d'accent et le format du score (valeur absolue ou pourcentage) pour un rendu cohérent.
 - **Game Explorer** (`notation-jlg/game-explorer`) : définissez le tri initial, les filtres disponibles et les paramètres de
   préfiltrage (catégorie, plateforme, lettre).
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -49,8 +49,8 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 = Shortcodes disponibles =
 
-* `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`. Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
-* `[bloc_notation_jeu]` - Bloc de notation principal
+* `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+* `[bloc_notation_jeu]` - Bloc de notation principal. Attributs : `post_id` (ID du test), `score_layout` (`text` ou `circle`), `animations` (`oui`/`non`), `accent_color` et `display_mode` (`absolute` ou `percent`) pour choisir entre une note affichée en valeur absolue ou en pourcentage.
 * `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher ; sinon l'article courant est utilisé), `champs` (liste de champs séparés par des virgules) et `titre`.
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue
 * `[jlg_points_forts_faibles]` - Points positifs et négatifs
@@ -73,7 +73,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 Le plugin expose huit blocs dynamiques prêts à l'emploi :
 
 * **Bloc de notation** (`notation-jlg/rating-block`) — choisissez l'article ciblé ou laissez le champ vide pour utiliser le
-  contenu courant.
+  contenu courant, définissez la disposition (`texte` ou `cercle`), activez/désactivez les animations et sélectionnez le format du score (valeur absolue ou pourcentage).
 * **Points forts / faibles** (`notation-jlg/pros-cons`) et **Tagline bilingue** (`notation-jlg/tagline`) — affichent
   automatiquement les métadonnées saisies dans la fiche test.
 * **Fiche technique** (`notation-jlg/game-info`) — sélection des champs via cases à cocher, titre personnalisable et
@@ -81,8 +81,7 @@ Le plugin expose huit blocs dynamiques prêts à l'emploi :
 * **Notation utilisateurs** (`notation-jlg/user-rating`) — intègre le module de vote AJAX pour les lecteurs.
 * **Tableau récapitulatif** (`notation-jlg/summary-display`) — réglage du nombre d'entrées, du layout (table ou grille), des
   colonnes visibles et des filtres par défaut.
-* **Bloc tout-en-un** (`notation-jlg/all-in-one`) — activez/désactivez chaque sous-bloc, modifiez le style et la couleur
-  d'accent ainsi que les titres.
+* **Bloc tout-en-un** (`notation-jlg/all-in-one`) — activez/désactivez chaque sous-bloc, modifiez le style, la couleur d'accent, les titres et le format du score (valeur absolue ou pourcentage).
 * **Game Explorer** (`notation-jlg/game-explorer`) — configurez le tri initial, les filtres proposés et les paramètres de
   préfiltrage (catégorie, plateforme, lettre).
 

--- a/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/all-in-one/block.json
@@ -31,6 +31,11 @@
       "type": "string",
       "default": "moderne"
     },
+    "scoreDisplay": {
+      "type": "string",
+      "default": "absolute",
+      "enum": ["absolute", "percent"]
+    },
     "accentColor": {
       "type": "string",
       "default": ""

--- a/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/rating-block/block.json
@@ -24,6 +24,11 @@
       "type": "string",
       "default": ""
     },
+    "scoreDisplay": {
+      "type": "string",
+      "default": "absolute",
+      "enum": ["absolute", "percent"]
+    },
     "showAnimations": {
       "type": "boolean",
       "default": true

--- a/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/all-in-one.js
@@ -94,6 +94,17 @@
                                 setAttributes({ style: value || 'moderne' });
                             },
                         }),
+                        createElement(SelectControl, {
+                            label: __('Affichage du score', 'notation-jlg'),
+                            value: attributes.scoreDisplay || 'absolute',
+                            options: [
+                                { value: 'absolute', label: __('Valeur absolue', 'notation-jlg') },
+                                { value: 'percent', label: __('Pourcentage', 'notation-jlg') },
+                            ],
+                            onChange: function (value) {
+                                setAttributes({ scoreDisplay: value || 'absolute' });
+                            },
+                        }),
                         createElement(ToggleControl, {
                             label: __('Afficher la notation', 'notation-jlg'),
                             checked: typeof attributes.showRating === 'boolean' ? attributes.showRating : true,
@@ -184,6 +195,7 @@
                             showProsCons: typeof attributes.showProsCons === 'boolean' ? attributes.showProsCons : true,
                             showTagline: typeof attributes.showTagline === 'boolean' ? attributes.showTagline : true,
                             style: attributes.style || 'moderne',
+                            scoreDisplay: attributes.scoreDisplay || 'absolute',
                             accentColor: attributes.accentColor || '',
                             prosTitle: attributes.prosTitle || '',
                             consTitle: attributes.consTitle || '',

--- a/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/rating-block.js
@@ -99,6 +99,17 @@
                                 setAttributes({ scoreLayout: value || 'text' });
                             },
                         }),
+                        createElement(SelectControl, {
+                            label: __('Affichage du score', 'notation-jlg'),
+                            value: attributes.scoreDisplay || 'absolute',
+                            options: [
+                                { value: 'absolute', label: __('Valeur absolue', 'notation-jlg') },
+                                { value: 'percent', label: __('Pourcentage', 'notation-jlg') },
+                            ],
+                            onChange: function (value) {
+                                setAttributes({ scoreDisplay: value || 'absolute' });
+                            },
+                        }),
                         createElement(ToggleControl, {
                             label: __('Afficher les animations', 'notation-jlg'),
                             checked: typeof attributes.showAnimations === 'boolean' ? attributes.showAnimations : true,
@@ -117,6 +128,7 @@
                         attributes: {
                             postId: attributes.postId || 0,
                             scoreLayout: attributes.scoreLayout || 'text',
+                            scoreDisplay: attributes.scoreDisplay || 'absolute',
                             showAnimations: typeof attributes.showAnimations === 'boolean' ? attributes.showAnimations : true,
                             accentColor: attributes.accentColor || '',
                         },

--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -357,6 +357,13 @@ class Blocks {
             }
         }
 
+        if ( ! empty( $attributes['scoreDisplay'] ) && is_string( $attributes['scoreDisplay'] ) ) {
+            $display_mode = sanitize_key( $attributes['scoreDisplay'] );
+            if ( in_array( $display_mode, array( 'absolute', 'percent' ), true ) ) {
+                $atts['display_mode'] = $display_mode;
+            }
+        }
+
         if ( array_key_exists( 'showAnimations', $attributes ) ) {
             $is_enabled          = (bool) $attributes['showAnimations'];
             $atts['animations'] = $is_enabled ? 'oui' : 'non';
@@ -481,6 +488,13 @@ class Blocks {
             $style = sanitize_key( $attributes['style'] );
             if ( in_array( $style, array( 'moderne', 'classique', 'compact' ), true ) ) {
                 $atts['style'] = $style;
+            }
+        }
+
+        if ( ! empty( $attributes['scoreDisplay'] ) && is_string( $attributes['scoreDisplay'] ) ) {
+            $display_mode = sanitize_key( $attributes['scoreDisplay'] );
+            if ( in_array( $display_mode, array( 'absolute', 'percent' ), true ) ) {
+                $atts['display_mode'] = $display_mode;
             }
         }
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
@@ -23,6 +23,7 @@ class RatingBlock {
                 'score_layout' => '',
                 'animations'   => '',
                 'accent_color' => '',
+                'display_mode' => '',
             ),
             $atts,
             'bloc_notation_jeu'
@@ -120,6 +121,28 @@ class RatingBlock {
         $css_variables       = $this->build_css_variables( $options );
         $score_max           = Helpers::get_score_max( $options );
 
+        $display_mode = is_string( $atts['display_mode'] ) ? sanitize_key( $atts['display_mode'] ) : '';
+        if ( ! in_array( $display_mode, array( 'absolute', 'percent' ), true ) ) {
+            $display_mode = 'absolute';
+        }
+
+        $average_percentage = null;
+        if ( $score_max > 0 ) {
+            $average_percentage = max( 0, min( 100, ( $average_score / $score_max ) * 100 ) );
+        }
+
+        $category_percentages = array();
+        if ( $score_max > 0 ) {
+            foreach ( $category_scores as $category_score ) {
+                if ( isset( $category_score['id'], $category_score['score'] ) ) {
+                    $category_percentages[ (string) $category_score['id'] ] = max(
+                        0,
+                        min( 100, ( (float) $category_score['score'] / $score_max ) * 100 )
+                    );
+                }
+            }
+        }
+
         Frontend::mark_shortcode_rendered( $shortcode_tag ?: 'bloc_notation_jeu' );
 
         return Frontend::get_template_html(
@@ -127,10 +150,13 @@ class RatingBlock {
             array(
                 'options'              => $options,
                 'average_score'        => $average_score,
+                'average_score_percentage' => $average_percentage,
                 'scores'               => $score_map,
                 'category_scores'      => $category_scores,
+                'category_percentages' => $category_percentages,
                 'category_definitions' => Helpers::get_rating_category_definitions(),
                 'score_layout'         => $resolved_score_layout,
+                'display_mode'         => $display_mode,
                 'animations_enabled'   => $animations_enabled,
                 'css_variables'        => $css_variables,
                 'score_max'            => $score_max,

--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -810,3 +810,62 @@ msgstr ""
 #, php-format
 msgid "/%s"
 msgstr ""
+
+#: assets/js/blocks/all-in-one.js:98
+#: assets/js/blocks/rating-block.js:103
+msgid "Affichage du score"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:101
+#: assets/js/blocks/rating-block.js:107
+msgid "Valeur absolue"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:102
+#: assets/js/blocks/rating-block.js:108
+msgid "Pourcentage"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:36
+#: templates/shortcode-rating-block.php:63
+msgctxt "global percentage score"
+msgid "%s %%"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:41
+#: templates/shortcode-rating-block.php:68
+msgid "Note globale : %1$s %%, soit %2$s sur %3$s"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:47
+#: templates/shortcode-rating-block.php:74
+msgid "Équivalent à %1$s sur %2$s"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:57
+#: templates/shortcode-rating-block.php:89
+msgid "Note globale : %1$s sur %2$s"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:63
+#: templates/shortcode-all-in-one.php:147
+#: templates/shortcode-rating-block.php:95
+#: templates/shortcode-rating-block.php:152
+msgid "Correspond à %s %%"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:133
+#: templates/shortcode-rating-block.php:137
+msgctxt "category percentage score"
+msgid "%s %%"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:138
+#: templates/shortcode-rating-block.php:142
+msgid "%1$s : %2$s %%, soit %3$s sur %4$s"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:147
+#: templates/shortcode-rating-block.php:152
+msgid "%1$s : %2$s sur %3$s"
+msgstr ""


### PR DESCRIPTION
## Summary
- add score display controls to the rating and all-in-one blocks and propagate the `display_mode` attribute to their shortcodes
- compute and expose percentage values in the rating-related shortcodes and render accessible absolute/percent score variants in both templates
- refresh localisation strings and user documentation to describe the new display mode options

## Testing
- php -l plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
- php -l plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
- php -l plugin-notation-jeux_V4/includes/Blocks.php
- php -l plugin-notation-jeux_V4/templates/shortcode-rating-block.php
- php -l plugin-notation-jeux_V4/templates/shortcode-all-in-one.php

------
https://chatgpt.com/codex/tasks/task_e_68dff827c968832ea58d74161b070f1b