### PR TITLE
Add global WordPress class imports to Frontend

### DIFF
--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -2,6 +2,9 @@
 
 namespace JLG\Notation;
 
+use Exception;
+use WP_Post;
+use WP_Query;
 use JLG\Notation\Helpers;
 use JLG\Notation\Shortcodes\AllInOne;
 use JLG\Notation\Shortcodes\GameExplorer;


### PR DESCRIPTION
## Summary
- import global Exception, WP_Post, and WP_Query symbols in Frontend to ensure fully-qualified references

## Testing
- composer test *(fails: existing test suite expects additional WordPress helpers such as JLG\\Notation\\Utils\\DateTime and patched remove_query_arg())*

------
https://chatgpt.com/codex/tasks/task_e_68e05a7518f0832ea256f9e0dcc64da8