### PR TITLE
Add REST controllers and shared data helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
 3. **Configurer l’onglet Réglages** (`Notation – JLG > Réglages`) pour ajuster libellés, présentation de la note globale, thèmes clair/sombre, couleurs sémantiques, effets neon/pulsation et modules optionnels. La section *Contenus* permet désormais de sélectionner les types de publications (articles, CPT publics…) autorisés pour la notation ; au besoin, un développeur peut toujours compléter ou restreindre cette liste via le filtre PHP `jlg_rated_post_types`.
 4. **Gérer les plateformes** dans l’onglet dédié afin d’ajouter, trier, supprimer ou réinitialiser la liste proposée dans les metaboxes.
 5. **Saisir la clé RAWG (facultatif)** dans la section *API* des réglages pour activer le remplissage automatique des données de jeu.
+6. **Définir la clé publique REST** dans le même onglet pour autoriser les intégrations externes à interroger les endpoints JSON du plugin. Toute requête GET vers l'API doit présenter cette clé (paramètre `public_key` ou en-tête `X-JLG-Public-Key`).
 
 ## Utilisation au quotidien
 - **Shortcodes principaux** :
@@ -29,6 +30,19 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
 - **Modules optionnels** : activer/désactiver la notation utilisateurs, les taglines, les animations de barres ou le schema SEO JSON-LD directement depuis l’onglet Réglages.
 - **CSS personnalisé** et réglages précis pour le tableau récapitulatif ou les vignettes (espacements, bordures, alternance de lignes).
 - **Notation des lecteurs** : personnalisez couleurs et textes du module dédié lorsque `Notation utilisateurs` est actif.
+
+## API REST
+Le plugin expose une API REST maison (`/wp-json/notation-jlg/v1/`) offrant les mêmes payloads JSON que les handlers AJAX historiques.
+
+| Endpoint | Méthode | Authentification | Description |
+| --- | --- | --- | --- |
+| `/game-explorer` | GET | Clé publique via `public_key` ou en-tête `X-JLG-Public-Key` | Retourne le HTML fragmenté, l'état de pagination et la configuration du Game Explorer. |
+| `/summary` | GET | Clé publique via `public_key` ou en-tête `X-JLG-Public-Key` | Retourne les fragments HTML et l'état du tableau récapitulatif (`jlg_tableau_recap`). |
+| `/user-rating` | POST | Jeton + nonce (`token`, `nonce`) | Enregistre un vote lecteur et renvoie la nouvelle moyenne/compte. |
+
+Pour les routes GET, la clé publique est définie dans *Notation – JLG > Réglages > API*. Les paramètres de tri/filtre acceptés sont identiques à ceux envoyés par le JavaScript du plugin (ex: `orderby`, `order`, `categorie`, `lettre`, `plateforme`, etc.).
+
+Pour le vote REST (`/user-rating`), transmettez au minimum `token`, `nonce`, `post_id` et `rating` (1 à 5). Le nonce est généré côté front via `wp_create_nonce( 'jlg_user_rating_nonce_' . $token )`.
 
 ## Ressources développeur
 - **Composer** : `composer.json` définit PHP >=7.4 et fournit les scripts `composer test`, `composer cs`, `composer cs-fix` pour lancer PHPUnit et PHPCS (WPCS).

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -106,7 +106,8 @@ Ces points d'extension facilitent la conservation de vos surcharges lors des mis
 2. Uploadez le dossier `plugin-notation-jeux` dans `/wp-content/plugins/`
 3. Activez le plugin depuis le menu 'Extensions' de WordPress
 4. Configurez le plugin dans 'Notation - JLG' > 'Réglages'. La section *Contenus* vous permet de choisir les types de publications (articles, CPT publics…) autorisés pour la notation ; si besoin, un développeur peut ajuster cette liste via le filtre PHP `jlg_rated_post_types`.
-5. Créez votre premier test avec notation !
+5. Rendez-vous dans l'onglet *API* pour saisir la clé RAWG (facultatif) et définir la **clé publique REST**. Cette dernière est requise pour interroger les endpoints JSON (`/wp-json/notation-jlg/v1/*`). Fournissez-la via le paramètre `public_key` ou l'en-tête `X-JLG-Public-Key` pour les requêtes GET.
+6. Créez votre premier test avec notation !
 
 == Tests manuels de sécurité CSS ==
 
@@ -143,6 +144,17 @@ Oui, vous pouvez activer/désactiver individuellement : notation utilisateurs, t
 = Comment obtenir une clé API RAWG ? =
 
 Créez un compte gratuit sur rawg.io/apidocs et copiez votre clé dans les réglages du plugin.
+
+
+== API REST ==
+
+Le plugin expose une API sous `/wp-json/notation-jlg/v1/` dont les réponses correspondent aux chargements AJAX historiques.
+
+* `/game-explorer` (GET) — nécessite la clé publique configurée dans *Notation – JLG > Réglages > API*. Retourne le fragment HTML, l'état de pagination et la configuration du Game Explorer.
+* `/summary` (GET) — même authentification que ci-dessus, renvoie le fragment HTML et l'état (`orderby`, `order`, `paged`, filtres) du tableau récapitulatif.
+* `/user-rating` (POST) — attend les paramètres `token`, `nonce`, `post_id` et `rating` (1 à 5). Le nonce doit être généré côté front via `wp_create_nonce( 'jlg_user_rating_nonce_' . $token )`.
+
+Les paramètres de tri/filtre (`orderby`, `order`, `categorie`, `lettre`, `plateforme`, etc.) acceptés par les routes GET sont identiques à ceux transmis par les scripts JavaScript du plugin.
 
 == Screenshots ==
 

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -1141,10 +1141,23 @@ class Settings {
             'notation_jlg_page',
             'jlg_api_section',
             array(
-				'id'   => 'rawg_api_key',
-				'type' => 'text',
-				'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs',
-			)
+                                'id'   => 'rawg_api_key',
+                                'type' => 'text',
+                                'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs',
+                        )
+        );
+
+        add_settings_field(
+            'rest_public_key',
+            'Clé publique REST',
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_api_section',
+            array(
+                                'id'   => 'rest_public_key',
+                                'type' => 'text',
+                                'desc' => 'Requise pour les requêtes REST externes (ex: /wp-json/notation-jlg/v1/*).',
+                        )
         );
 
         // Section 15: Debug

--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -567,10 +567,30 @@ class Helpers {
             'custom_css'                   => '',
             'seo_schema_enabled'           => 1,
             'debug_mode_enabled'           => 0,
+            'rest_public_key'              => '',
             'rawg_api_key'                 => '',
         );
 
         return self::$default_settings_cache;
+    }
+
+    /**
+     * Returns the configured public key used to authorise REST read requests.
+     *
+     * @return string
+     */
+    public static function get_rest_public_key() {
+        $options = self::get_plugin_options();
+
+        $key = isset( $options['rest_public_key'] ) ? $options['rest_public_key'] : '';
+
+        if ( ! is_string( $key ) ) {
+            $key = '';
+        }
+
+        $key = sanitize_text_field( $key );
+
+        return $key;
     }
 
     public static function get_plugin_options( $force_refresh = false ) {

--- a/plugin-notation-jeux_V4/includes/REST/GameExplorerController.php
+++ b/plugin-notation-jeux_V4/includes/REST/GameExplorerController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace JLG\Notation\REST;
+
+use JLG\Notation\Helpers;
+use JLG\Notation\Shortcodes\GameExplorer;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GameExplorerController extends WP_REST_Controller {
+
+    public function __construct() {
+        $this->namespace = 'notation-jlg/v1';
+        $this->rest_base = 'game-explorer';
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_items' ),
+                    'permission_callback' => array( $this, 'check_permissions' ),
+                ),
+            )
+        );
+    }
+
+    public function check_permissions( WP_REST_Request $request ) {
+        $expected_key = Helpers::get_rest_public_key();
+
+        if ( $expected_key === '' ) {
+            return new WP_Error(
+                'jlg_rest_public_key_missing',
+                esc_html__( 'Aucune clé publique REST n\'est configurée.', 'notation-jlg' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $provided = $request->get_param( 'public_key' );
+        if ( is_string( $provided ) ) {
+            $provided = sanitize_text_field( $provided );
+        } else {
+            $provided = '';
+        }
+
+        if ( $provided !== '' && hash_equals( $expected_key, $provided ) ) {
+            return true;
+        }
+
+        $header = $request->get_header( 'x-jlg-public-key' );
+        if ( is_string( $header ) && $header !== '' && hash_equals( $expected_key, sanitize_text_field( $header ) ) ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'jlg_rest_forbidden',
+            esc_html__( 'Clé publique REST invalide.', 'notation-jlg' ),
+            array( 'status' => 403 )
+        );
+    }
+
+    public function get_items( WP_REST_Request $request ) {
+        if ( ! class_exists( GameExplorer::class ) ) {
+            return $this->error_to_response(
+                new WP_Error(
+                    'jlg_rest_missing_feature',
+                    esc_html__( 'Le module Game Explorer est indisponible.', 'notation-jlg' ),
+                    array( 'status' => 500 )
+                )
+            );
+        }
+
+        $params = $request->get_params();
+        if ( ! is_array( $params ) ) {
+            $params = array();
+        }
+
+        $atts   = GameExplorer::prepare_interactive_atts( $params );
+        $result = GameExplorer::prepare_interactive_response( $atts, $params );
+
+        return rest_ensure_response( $result['response'] );
+    }
+}

--- a/plugin-notation-jeux_V4/includes/REST/SummaryController.php
+++ b/plugin-notation-jeux_V4/includes/REST/SummaryController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace JLG\Notation\REST;
+
+use JLG\Notation\Helpers;
+use JLG\Notation\Shortcodes\SummaryDisplay;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SummaryController extends WP_REST_Controller {
+
+    public function __construct() {
+        $this->namespace = 'notation-jlg/v1';
+        $this->rest_base = 'summary';
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => array( $this, 'get_items' ),
+                    'permission_callback' => array( $this, 'check_permissions' ),
+                ),
+            )
+        );
+    }
+
+    public function check_permissions( WP_REST_Request $request ) {
+        $expected_key = Helpers::get_rest_public_key();
+
+        if ( $expected_key === '' ) {
+            return new WP_Error(
+                'jlg_rest_public_key_missing',
+                esc_html__( 'Aucune clé publique REST n\'est configurée.', 'notation-jlg' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        $provided = $request->get_param( 'public_key' );
+        if ( is_string( $provided ) ) {
+            $provided = sanitize_text_field( $provided );
+        } else {
+            $provided = '';
+        }
+
+        if ( $provided !== '' && hash_equals( $expected_key, $provided ) ) {
+            return true;
+        }
+
+        $header = $request->get_header( 'x-jlg-public-key' );
+        if ( is_string( $header ) && $header !== '' && hash_equals( $expected_key, sanitize_text_field( $header ) ) ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'jlg_rest_forbidden',
+            esc_html__( 'Clé publique REST invalide.', 'notation-jlg' ),
+            array( 'status' => 403 )
+        );
+    }
+
+    public function get_items( WP_REST_Request $request ) {
+        if ( ! class_exists( SummaryDisplay::class ) ) {
+            return $this->error_to_response(
+                new WP_Error(
+                    'jlg_rest_missing_feature',
+                    esc_html__( 'Le tableau récapitulatif est indisponible.', 'notation-jlg' ),
+                    array( 'status' => 500 )
+                )
+            );
+        }
+
+        $params = $request->get_params();
+        if ( ! is_array( $params ) ) {
+            $params = array();
+        }
+
+        $result = SummaryDisplay::prepare_interactive_response( $params );
+
+        return rest_ensure_response( $result['response'] );
+    }
+}

--- a/plugin-notation-jeux_V4/includes/REST/UserRatingController.php
+++ b/plugin-notation-jeux_V4/includes/REST/UserRatingController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace JLG\Notation\REST;
+
+use JLG\Notation\Frontend;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class UserRatingController extends WP_REST_Controller {
+
+    public function __construct() {
+        $this->namespace = 'notation-jlg/v1';
+        $this->rest_base = 'user-rating';
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                array(
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => array( $this, 'create_item' ),
+                    'permission_callback' => array( $this, 'check_permissions' ),
+                ),
+            )
+        );
+    }
+
+    public function check_permissions( WP_REST_Request $request ) {
+        $token = Frontend::normalize_user_rating_token( $request->get_param( 'token' ) );
+        if ( $token === '' ) {
+            return new WP_Error(
+                'jlg_missing_token',
+                esc_html__( 'Jeton de sécurité manquant ou invalide.', 'notation-jlg' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $nonce = $request->get_param( 'nonce' );
+        if ( ! is_string( $nonce ) || ! wp_verify_nonce( $nonce, 'jlg_user_rating_nonce_' . $token ) ) {
+            return new WP_Error(
+                'jlg_invalid_nonce',
+                esc_html__( 'La vérification de sécurité a échoué.', 'notation-jlg' ),
+                array( 'status' => 403 )
+            );
+        }
+
+        return true;
+    }
+
+    public function create_item( WP_REST_Request $request ) {
+        $frontend = Frontend::get_instance();
+        if ( ! ( $frontend instanceof Frontend ) ) {
+            $frontend = new Frontend();
+        }
+
+        $payload = array(
+            'token'   => $request->get_param( 'token' ),
+            'nonce'   => $request->get_param( 'nonce' ),
+            'post_id' => $request->get_param( 'post_id' ),
+            'rating'  => $request->get_param( 'rating' ),
+        );
+
+        $result = $frontend->process_user_rating_submission( $payload );
+
+        if ( is_wp_error( $result ) ) {
+            return $this->error_to_response( $result );
+        }
+
+        return rest_ensure_response( $result );
+    }
+}

--- a/plugin-notation-jeux_V4/includes/Utils/Validator.php
+++ b/plugin-notation-jeux_V4/includes/Utils/Validator.php
@@ -2,6 +2,7 @@
 
 namespace JLG\Notation\Utils;
 
+use DateTime;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -86,8 +86,29 @@ final class JLG_Plugin_De_Notation_Main {
         add_action( 'jlg_queue_average_rebuild', array( $this, 'queue_additional_posts_for_migration' ) );
         add_action( \JLG\Notation\Helpers::SCORE_SCALE_EVENT_HOOK, array( $this, 'process_score_scale_migration_batch' ) );
         add_action( 'init', array( $this, 'ensure_migration_schedule' ) );
+        add_action( 'rest_api_init', array( $this, 'register_rest_controllers' ) );
         register_activation_hook( __FILE__, array( $this, 'on_activation' ) );
         register_deactivation_hook( __FILE__, array( $this, 'on_deactivation' ) );
+    }
+
+    public function register_rest_controllers() {
+        $controllers = array(
+            '\\JLG\\Notation\\REST\\GameExplorerController',
+            '\\JLG\\Notation\\REST\\SummaryController',
+            '\\JLG\\Notation\\REST\\UserRatingController',
+        );
+
+        foreach ( $controllers as $controller_class ) {
+            if ( ! class_exists( $controller_class ) ) {
+                continue;
+            }
+
+            $controller = new $controller_class();
+
+            if ( $controller instanceof \WP_REST_Controller ) {
+                $controller->register_routes();
+            }
+        }
     }
 
     private function load_dependencies() {

--- a/plugin-notation-jeux_V4/tests/RestUserRatingControllerTest.php
+++ b/plugin-notation-jeux_V4/tests/RestUserRatingControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class RestUserRatingControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_POST   = [];
+        $_COOKIE = [];
+        $_SERVER = [];
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta']  = [];
+    }
+
+    public function test_check_permissions_requires_token(): void
+    {
+        $controller = new \JLG\Notation\REST\UserRatingController();
+        $request    = new WP_REST_Request();
+
+        $result = $controller->check_permissions($request);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('jlg_missing_token', $result->get_error_code());
+    }
+
+    public function test_create_item_records_vote_and_returns_stats(): void
+    {
+        $controller = new \JLG\Notation\REST\UserRatingController();
+        new \JLG\Notation\Frontend();
+
+        $post_id = 321;
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'           => $post_id,
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+            'post_content' => '[notation_utilisateurs_jlg]',
+        ]);
+
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.42';
+
+        $token = str_repeat('a', 32);
+        $nonce = wp_create_nonce('jlg_user_rating_nonce_' . $token);
+
+        $request = new WP_REST_Request([
+            'token'   => $token,
+            'nonce'   => $nonce,
+            'post_id' => (string) $post_id,
+            'rating'  => '5',
+        ]);
+
+        $response = $controller->create_item($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $data = $response->get_data();
+
+        $this->assertSame('5.00', $data['new_average'] ?? null);
+        $this->assertSame(1, $data['new_count'] ?? null);
+
+        $this->assertArrayHasKey($post_id, $GLOBALS['jlg_test_meta']);
+        $this->assertArrayHasKey('_jlg_user_rating_avg', $GLOBALS['jlg_test_meta'][$post_id]);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce REST controllers for Game Explorer, Summary, and user ratings with route registration and permission checks
- refactor shortcode data preparation so AJAX and REST endpoints share response builders
- document the new REST endpoints, expose REST public-key settings, and add PHPUnit coverage for the user rating controller

## Testing
- `composer test`
- `composer cs`


------
https://chatgpt.com/codex/tasks/task_e_68e0ea11ac6c832eb9f097c02e4ef106