### PR TITLE
Add admin insights for rated posts

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/admin.css
+++ b/plugin-notation-jeux_V4/assets/css/admin.css
@@ -23,3 +23,115 @@ body.is-dark-theme .jlg-admin-card a:hover,
 body.is-dark-theme .jlg-admin-card a:focus {
     color: var(--wp-admin-theme-color-darker-10, #1d8fd1);
 }
+
+.jlg-admin-insights {
+    margin-bottom: 24px;
+}
+
+.jlg-admin-insights__description {
+    color: var(--wp-admin-page-content-meta, #50575e);
+    margin: 0 0 12px;
+}
+
+.jlg-admin-insights__grid {
+    display: grid;
+    gap: 16px;
+}
+
+@media (min-width: 782px) {
+    .jlg-admin-insights__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.jlg-admin-insight-card {
+    background: var(--wp-admin-surface-color, #fff);
+    border: 1px solid var(--wp-admin-border-color, #dcdcde);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.jlg-admin-insight-card__value {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.jlg-admin-insight-card__legend {
+    margin: 0;
+    color: var(--wp-admin-page-content-meta, #50575e);
+}
+
+.jlg-score-distribution {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.jlg-score-distribution__item {
+    display: grid;
+    gap: 6px;
+}
+
+.jlg-score-distribution__label {
+    font-weight: 600;
+}
+
+.jlg-score-distribution__bar {
+    display: block;
+    height: 6px;
+    background: var(--wp-admin-border-color, #dcdcde);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.jlg-score-distribution__bar-fill {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, #2563eb, #8b5cf6);
+}
+
+.jlg-score-distribution__value {
+    font-size: 0.9rem;
+    color: var(--wp-admin-page-content-meta, #50575e);
+}
+
+.jlg-platform-ranking {
+    list-style: decimal inside;
+    margin: 0;
+    padding-left: 1rem;
+    display: grid;
+    gap: 6px;
+}
+
+.jlg-platform-ranking__item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+@media (min-width: 600px) {
+    .jlg-platform-ranking__item {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: 8px;
+    }
+}
+
+.jlg-platform-ranking__name {
+    font-weight: 600;
+}
+
+.jlg-platform-ranking__score {
+    font-variant-numeric: tabular-nums;
+}
+
+.jlg-platform-ranking__count {
+    color: var(--wp-admin-page-content-meta, #50575e);
+}

--- a/plugin-notation-jeux_V4/includes/Admin/Menu.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Menu.php
@@ -10,6 +10,7 @@ namespace JLG\Notation\Admin;
 
 use JLG\Notation\Helpers;
 use JLG\Notation\Utils\TemplateLoader;
+use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
@@ -114,9 +115,10 @@ class Menu {
             return TemplateLoader::get_admin_template(
                 'tabs/posts-list',
                 array(
-					'has_rated_posts' => false,
-					'empty_state'     => $empty_state,
-				)
+                                        'has_rated_posts' => false,
+                                        'empty_state'     => $empty_state,
+                                        'insights'        => Helpers::get_posts_score_insights( array() ),
+                                )
             );
         }
 
@@ -213,19 +215,20 @@ class Menu {
         return TemplateLoader::get_admin_template(
             'tabs/posts-list',
             array(
-				'has_rated_posts'    => true,
-				'empty_state'        => $empty_state,
-				'stats'              => array(
-					'total_items'   => $total_items,
-					'current_page'  => $current_page,
-					'total_pages'   => $total_pages,
-					'display_count' => count( $posts ),
-				),
-				'columns'            => $this->get_sortable_columns( $orderby, $order ),
-				'posts'              => $posts,
-				'pagination'         => $pagination,
-				'print_button_label' => __( '🖨️ Imprimer cette liste', 'notation-jlg' ),
-			)
+                                'has_rated_posts'    => true,
+                                'empty_state'        => $empty_state,
+                                'stats'              => array(
+                                        'total_items'   => $total_items,
+                                        'current_page'  => $current_page,
+                                        'total_pages'   => $total_pages,
+                                        'display_count' => count( $posts ),
+                                ),
+                                'insights'           => Helpers::get_posts_score_insights( $rated_posts ),
+                                'columns'            => $this->get_sortable_columns( $orderby, $order ),
+                                'posts'              => $posts,
+                                'pagination'         => $pagination,
+                                'print_button_label' => __( '🖨️ Imprimer cette liste', 'notation-jlg' ),
+                        )
         );
     }
 

--- a/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('_x')) {
+    function _x($text, $context, $domain = 'default')
+    {
+        unset($context, $domain);
+
+        return (string) $text;
+    }
+}
+
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain = 'default')
+    {
+        unset($domain);
+
+        return $number === 1 ? $single : $plural;
+    }
+}
+
+if (!class_exists('WP_Query')) {
+    class WP_Query
+    {
+        public $posts = [];
+        public $post_count = 0;
+        public $found_posts = 0;
+        public $max_num_pages = 1;
+
+        private $current_index = 0;
+
+        public function __construct($args = [])
+        {
+            $post_ids = isset($args['post__in']) ? (array) $args['post__in'] : [];
+            $per_page = isset($args['posts_per_page']) ? (int) $args['posts_per_page'] : count($post_ids);
+            $all_posts = $GLOBALS['jlg_test_posts'] ?? [];
+
+            foreach ($post_ids as $post_id) {
+                if (isset($all_posts[$post_id])) {
+                    $this->posts[] = $all_posts[$post_id];
+                }
+            }
+
+            if ($per_page > 0) {
+                $this->posts = array_slice($this->posts, 0, $per_page);
+            }
+
+            $this->post_count = count($this->posts);
+            $this->found_posts = $this->post_count;
+        }
+
+        public function have_posts()
+        {
+            return $this->current_index < $this->post_count;
+        }
+
+        public function the_post()
+        {
+            $post = $this->posts[$this->current_index] ?? null;
+
+            if ($post instanceof WP_Post) {
+                $GLOBALS['post'] = $post;
+                $GLOBALS['jlg_test_current_post_id'] = $post->ID;
+            }
+
+            $this->current_index++;
+        }
+    }
+}
+
+if (!function_exists('paginate_links')) {
+    function paginate_links($args = [])
+    {
+        unset($args);
+
+        return '<nav class="pagination">1</nav>';
+    }
+}
+
+if (!function_exists('get_edit_post_link')) {
+    function get_edit_post_link($post_id)
+    {
+        return 'https://example.com/wp-admin/post.php?action=edit&post=' . (int) $post_id;
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post_id)
+    {
+        return 'https://example.com/?p=' . (int) $post_id;
+    }
+}
+
+if (!function_exists('get_the_category')) {
+    function get_the_category($post_id)
+    {
+        $categories = $GLOBALS['jlg_test_categories'] ?? [];
+
+        return $categories[$post_id] ?? [];
+    }
+}
+
+if (!function_exists('wp_reset_postdata')) {
+    function wp_reset_postdata()
+    {
+        unset($GLOBALS['post'], $GLOBALS['jlg_test_current_post_id']);
+    }
+}
+
+require_once __DIR__ . '/../includes/Admin/Menu.php';
+
+class AdminPostsListInsightsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET = [];
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_categories'] = [];
+        $GLOBALS['jlg_test_transients'] = [];
+
+        update_option('notation_jlg_settings', \JLG\Notation\Helpers::get_default_settings());
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+    }
+
+    public function test_get_posts_list_tab_content_includes_insights_cards(): void
+    {
+        $posts = [
+            101 => new WP_Post([
+                'ID' => 101,
+                'post_title' => 'Test A',
+                'post_date' => '2024-01-10 10:00:00',
+            ]),
+            102 => new WP_Post([
+                'ID' => 102,
+                'post_title' => 'Test B',
+                'post_date' => '2024-01-12 12:00:00',
+            ]),
+            103 => new WP_Post([
+                'ID' => 103,
+                'post_title' => 'Test C',
+                'post_date' => '2024-01-15 15:00:00',
+            ]),
+        ];
+
+        $GLOBALS['jlg_test_posts'] = $posts;
+
+        $GLOBALS['jlg_test_categories'][101] = [(object) ['name' => 'Action']];
+        $GLOBALS['jlg_test_categories'][102] = [(object) ['name' => 'RPG']];
+        $GLOBALS['jlg_test_categories'][103] = [(object) ['name' => 'Switch']];
+
+        update_post_meta(101, '_jlg_average_score', 8.5);
+        update_post_meta(102, '_jlg_average_score', 6.0);
+        update_post_meta(103, '_jlg_average_score', 9.0);
+
+        update_post_meta(101, '_jlg_plateformes', ['PC', 'PlayStation 5']);
+        update_post_meta(102, '_jlg_plateformes', 'PC');
+        update_post_meta(103, '_jlg_plateformes', ['Nintendo Switch']);
+
+        set_transient('jlg_rated_post_ids_v1', array_keys($posts));
+
+        $menu = new \JLG\Notation\Admin\Menu();
+
+        $reflection = new ReflectionClass($menu);
+        $method = $reflection->getMethod('get_posts_list_tab_content');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($menu);
+
+        $this->assertStringContainsString('Synthèse des notes', $html);
+        $this->assertStringContainsString('Score moyen', $html);
+        $this->assertStringContainsString('7.8', $html);
+        $this->assertStringContainsString('Médiane', $html);
+        $this->assertStringContainsString('Nintendo Switch', $html);
+        $this->assertStringContainsString('Classement par plateforme', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- compute average, median, score distribution and platform rankings for rated posts via a new helper
- surface the aggregated insights at the top of the admin “Articles Notés” tab with accessible markup and styling
- cover the new data plumbing with a PHPUnit test and fix the WP_Query import for the admin menu

## Testing
- `composer test -- tests/AdminPostsListInsightsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e149327a98832eb2cf58b0833cdf4d