### PR TITLE
Expose OpenCritic metascores across explorer, summary, and widget

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/game-explorer.css
+++ b/plugin-notation-jeux_V4/assets/css/game-explorer.css
@@ -481,6 +481,29 @@
     flex-wrap: wrap;
     gap: 0.4rem;
 }
+.jlg-ge-opencritic {
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+.jlg-ge-opencritic .jlg-opencritic-chip {
+    background-color: var(--jlg-opencritic-bg, rgba(148, 163, 184, 0.18));
+    border-color: var(--jlg-opencritic-border, rgba(148, 163, 184, 0.4));
+    color: var(--jlg-opencritic-color, var(--jlg-ge-text));
+}
+.jlg-ge-opencritic__link {
+    color: var(--jlg-ge-text);
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-decoration: none;
+}
+.jlg-ge-opencritic__link:hover,
+.jlg-ge-opencritic__link:focus-visible {
+    color: var(--jlg-opencritic-color, var(--jlg-ge-accent));
+    text-decoration: underline;
+}
 
 .jlg-ge-badge {
     font-size: 0.75rem;

--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -87,9 +87,9 @@
     .jlg-game-card,
     .jlg-game-card:hover,
     .jlg-game-card:focus-visible,
-    .jlg-game-card img,
-    .jlg-game-card:hover img,
-    .jlg-game-card:focus-visible img,
+    .jlg-game-card__image,
+    .jlg-game-card:hover .jlg-game-card__image,
+    .jlg-game-card:focus-visible .jlg-game-card__image,
     .jlg-user-star,
     .jlg-user-star:hover,
     .jlg-user-star.hover,
@@ -165,16 +165,37 @@
 
 @keyframes jlg-summary-spinner{0%{transform:translate(-50%,-50%) rotate(0deg);}100%{transform:translate(-50%,-50%) rotate(360deg);}}
 .jlg-summary-grid-wrapper{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
-.jlg-game-card{position:relative;display:block;overflow:hidden;border-radius:8px;box-shadow:0 4px 6px rgba(0,0,0,.3);transition:all .2s ease;}
+.jlg-game-card{position:relative;display:flex;flex-direction:column;overflow:hidden;border-radius:8px;box-shadow:0 4px 6px rgba(0,0,0,.3);transition:transform .2s ease,box-shadow .2s ease;background-color:var(--jlg-table-row-bg-color);}
+.jlg-game-card__main{position:relative;display:block;overflow:hidden;border-radius:8px 8px 0 0;flex:1 1 auto;}
+.jlg-game-card__image{width:100%;height:100%;object-fit:cover;transition:transform .3s ease;display:block;}
 .jlg-game-card:hover{transform:translateY(-5px);box-shadow:0 8px 12px rgba(0,0,0,.4);}
-.jlg-game-card img{width:100%;height:100%;object-fit:cover;transition:transform .3s ease;}
-.jlg-game-card:hover img{transform:scale(1.05);}
+.jlg-game-card:hover .jlg-game-card__image{transform:scale(1.05);}
+.jlg-game-card__opencritic{padding:0.75rem 1rem 1rem;display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;background-color:var(--jlg-table-row-bg-color);}
+.jlg-game-card__opencritic-link{font-size:0.85rem;}
 .jlg-game-card-score{position:absolute;top:10px;right:10px;z-index:2;background:rgba(0,0,0,.8);color:#fff;font-weight:bold;font-size:1.2rem;padding:5px 10px;border-radius:6px;backdrop-filter:blur(5px);}
 .jlg-game-card-title span{color:#fff;font-weight:600;text-decoration:none;font-size:1.1rem;}
 .jlg-pagination{text-align:center;margin-top:20px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;}
 .jlg-pagination .page-numbers{padding:8px 12px;margin:0 2px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color-secondary);color:var(--jlg-secondary-text-color);text-decoration:none;border-radius:4px;}
 .jlg-pagination .page-numbers:hover,
 .jlg-pagination .page-numbers.current{background-color:var(--jlg-score-gradient-1);border-color:var(--jlg-score-gradient-1);color:#fff;}
+
+/* OpenCritic badges */
+.jlg-opencritic-chip{--jlg-opencritic-color:#94a3b8;--jlg-opencritic-bg:rgba(148,163,184,0.16);--jlg-opencritic-border:rgba(148,163,184,0.38);display:inline-flex;align-items:center;gap:0.35rem;padding:0.3rem 0.65rem;border-radius:9999px;border:1px solid var(--jlg-opencritic-border);background-color:var(--jlg-opencritic-bg);color:var(--jlg-opencritic-color);font-size:0.8125rem;font-weight:600;line-height:1.2;letter-spacing:0.01em;}
+.jlg-opencritic-chip__score{font-size:1rem;line-height:1;}
+.jlg-opencritic-chip__label{text-transform:uppercase;letter-spacing:0.06em;font-size:0.7rem;}
+.jlg-opencritic-link,
+.jlg-opencritic-chip__link{color:var(--jlg-opencritic-color,currentColor);font-weight:600;text-decoration:none;font-size:0.8rem;}
+.jlg-opencritic-link:hover,
+.jlg-opencritic-link:focus-visible,
+.jlg-opencritic-chip__link:hover,
+.jlg-opencritic-chip__link:focus-visible{text-decoration:underline;}
+
+/* Widget latest reviews */
+.jlg-widget-review-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:0.75rem;}
+.jlg-widget-review{display:flex;flex-direction:column;gap:0.4rem;}
+.jlg-widget-review__meta{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;}
+.jlg-widget-review__title{font-weight:600;display:inline-block;}
+.jlg-widget-review__link{font-size:0.8rem;}
 
 @media (max-width:768px){
     .jlg-summary-table{border:0;background-color:transparent;}

--- a/plugin-notation-jeux_V4/assets/js/blocks/summary-display.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/summary-display.js
@@ -37,6 +37,7 @@
         { value: 'titre', label: __('Titre du jeu', 'notation-jlg') },
         { value: 'date', label: __('Date', 'notation-jlg') },
         { value: 'note', label: __('Note moyenne', 'notation-jlg') },
+        { value: 'opencritic', label: __('Score OpenCritic', 'notation-jlg') },
         { value: 'developpeur', label: __('Développeur', 'notation-jlg') },
         { value: 'editeur', label: __('Éditeur', 'notation-jlg') },
     ];

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -412,6 +412,36 @@
         container.dataset.totalItems = String(total);
     }
 
+    function enhanceOpenCriticLinks(root) {
+        if (!root) {
+            return;
+        }
+
+        const links = root.querySelectorAll('[data-opencritic-title]');
+        if (!links.length) {
+            return;
+        }
+
+        const template = typeof strings.openCriticViewFor === 'string' ? strings.openCriticViewFor : '';
+        const fallback = typeof strings.openCriticView === 'string' ? strings.openCriticView : '';
+
+        links.forEach((link) => {
+            const title = link.getAttribute('data-opencritic-title') || '';
+            if (title === '') {
+                return;
+            }
+
+            if (template && template.indexOf('%s') !== -1) {
+                link.setAttribute('aria-label', template.replace('%s', title));
+                return;
+            }
+
+            if (fallback) {
+                link.setAttribute('aria-label', fallback + ' – ' + title);
+            }
+        });
+    }
+
     function updateActiveFilters(container, config, refs) {
         const state = config.state;
         const letterButtons = container.querySelectorAll('.jlg-ge-letter-nav button[data-letter]');
@@ -794,6 +824,7 @@
                     }
                     setResultsBusyState(refs.resultsNode, false);
                     updatePaginationAccessibility(refs);
+                    enhanceOpenCriticLinks(refs.resultsNode);
                 }
 
                 if (responseData.state) {
@@ -1029,6 +1060,8 @@
                 refreshResults(container, config, refs);
             });
         }
+
+        enhanceOpenCriticLinks(refs.resultsNode);
 
         updateActiveFilters(container, config, refs);
         updateCount(container, config.state);

--- a/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
@@ -190,6 +190,75 @@ class Metaboxes {
         echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée.', 'notation-jlg' ) . '</p>';
         echo '</div>';
 
+        $opencritic_display = Helpers::get_opencritic_display_data( $post->ID );
+        $opencritic_id       = get_post_meta( $post->ID, '_jlg_opencritic_id', true );
+        $opencritic_slug     = get_post_meta( $post->ID, '_jlg_opencritic_slug', true );
+        $opencritic_title    = get_post_meta( $post->ID, '_jlg_opencritic_title', true );
+
+        echo '<div class="jlg-opencritic-meta" style="margin-bottom:20px;">';
+        echo '<h3>' . esc_html__( '🌐 OpenCritic', 'notation-jlg' ) . '</h3>';
+        echo '<p class="description" style="margin:4px 0 12px;">' . esc_html__( 'Associez la fiche OpenCritic correspondante pour synchroniser automatiquement le metascore.', 'notation-jlg' ) . '</p>';
+        echo '<label for="jlg_opencritic_id"><strong>' . esc_html__( 'Identifiant OpenCritic', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<input type="text" id="jlg_opencritic_id" name="jlg_opencritic_id" value="' . esc_attr( $opencritic_id ) . '" style="width:100%;" placeholder="1234">';
+        echo '<input type="hidden" id="jlg_opencritic_slug" name="jlg_opencritic_slug" value="' . esc_attr( $opencritic_slug ) . '">';
+        echo '<input type="hidden" id="jlg_opencritic_title" name="jlg_opencritic_title" value="' . esc_attr( $opencritic_title ) . '">';
+        echo '<p class="description" style="margin:5px 0 10px;">' . esc_html__( 'Laissez vide pour supprimer le lien. Tapez quelques lettres puis utilisez la recherche pour préremplir.', 'notation-jlg' ) . '</p>';
+
+        echo '<div class="jlg-opencritic-search" style="margin-bottom:12px;">';
+        echo '<label for="jlg_opencritic_search"><strong>' . esc_html__( 'Recherche OpenCritic', 'notation-jlg' ) . '</strong></label><br>';
+        echo '<div style="display:flex; gap:0.5rem; align-items:center;">';
+        echo '<input type="text" id="jlg_opencritic_search" value="" style="flex:1;" placeholder="' . esc_attr__( 'Nom du jeu…', 'notation-jlg' ) . '">';
+        echo '<button type="button" class="button" id="jlg-opencritic-search-button">' . esc_html__( 'Rechercher', 'notation-jlg' ) . '</button>';
+        echo '</div>';
+        echo '<div id="jlg-opencritic-search-results" class="jlg-opencritic-results" style="margin-top:8px;"></div>';
+        echo '</div>';
+
+        if ( is_array( $opencritic_display ) && ! empty( $opencritic_display['status_label'] ) ) {
+            $status_color      = isset( $opencritic_display['status_color'] ) ? (string) $opencritic_display['status_color'] : '#94a3b8';
+            $status_background = isset( $opencritic_display['status_background'] ) && $opencritic_display['status_background'] !== ''
+                ? $opencritic_display['status_background']
+                : Helpers::hex_to_rgba( $status_color, 0.16 );
+            $status_border     = isset( $opencritic_display['status_border'] ) && $opencritic_display['status_border'] !== ''
+                ? $opencritic_display['status_border']
+                : Helpers::hex_to_rgba( $status_color, 0.38 );
+
+            $badge_style = sprintf(
+                ' style="--jlg-opencritic-color:%1$s;--jlg-opencritic-bg:%2$s;--jlg-opencritic-border:%3$s;"',
+                esc_attr( $status_color ),
+                esc_attr( $status_background ),
+                esc_attr( $status_border )
+            );
+
+            echo '<div class="jlg-opencritic-status" style="display:flex; flex-direction:column; gap:6px;">';
+            echo '<span class="jlg-opencritic-badge"' . $badge_style . '>';
+            $score_display = isset( $opencritic_display['score_display'] ) && $opencritic_display['score_display'] !== ''
+                ? $opencritic_display['score_display']
+                : '—';
+            echo '<span class="jlg-opencritic-badge__score">' . esc_html( $score_display ) . '</span>';
+            echo '<span class="jlg-opencritic-badge__label">' . esc_html( $opencritic_display['status_label'] ) . '</span>';
+            echo '</span>';
+
+            if ( ! empty( $opencritic_display['synced_at_display'] ) ) {
+                echo '<span class="description" style="margin:0;">' . sprintf(
+                    /* translators: %s is the human readable sync date. */
+                    esc_html__( 'Dernière synchronisation : %s', 'notation-jlg' ),
+                    esc_html( $opencritic_display['synced_at_display'] )
+                ) . '</span>';
+            }
+
+            if ( ! empty( $opencritic_display['url'] ) ) {
+                echo '<a href="' . esc_url( $opencritic_display['url'] ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Voir sur OpenCritic', 'notation-jlg' ) . '</a>';
+            }
+
+            if ( ! empty( $opencritic_display['last_error'] ) ) {
+                echo '<span class="notice notice-error" style="display:block; padding:6px 8px;">' . esc_html( $opencritic_display['last_error'] ) . '</span>';
+            }
+
+            echo '</div>';
+        }
+
+        echo '</div>';
+
         // Fiche technique
         echo '<h3>' . esc_html__( '📋 Fiche Technique', 'notation-jlg' ) . '</h3>';
         echo '<div style="display:grid; grid-template-columns:repeat(3,1fr); gap:15px; margin-bottom:20px;">';
@@ -486,6 +555,42 @@ class Metaboxes {
                     update_post_meta( $post_id, '_jlg_cta_label', $cta_label );
                     update_post_meta( $post_id, '_jlg_cta_url', esc_url_raw( $validated_url ) );
                 }
+            }
+
+            $raw_opencritic_id    = isset( $_POST['jlg_opencritic_id'] ) ? wp_unslash( $_POST['jlg_opencritic_id'] ) : '';
+            $raw_opencritic_slug  = isset( $_POST['jlg_opencritic_slug'] ) ? wp_unslash( $_POST['jlg_opencritic_slug'] ) : '';
+            $raw_opencritic_title = isset( $_POST['jlg_opencritic_title'] ) ? wp_unslash( $_POST['jlg_opencritic_title'] ) : '';
+
+            $normalized_id = is_string( $raw_opencritic_id ) ? preg_replace( '/[^0-9]/', '', $raw_opencritic_id ) : '';
+            $normalized_id = $normalized_id !== '' ? (string) absint( $normalized_id ) : '';
+
+            $normalized_slug = is_string( $raw_opencritic_slug ) ? sanitize_title( $raw_opencritic_slug ) : '';
+            $normalized_name = is_string( $raw_opencritic_title ) ? sanitize_text_field( $raw_opencritic_title ) : '';
+
+            $current_id = get_post_meta( $post_id, '_jlg_opencritic_id', true );
+
+            if ( $normalized_id === '' ) {
+                if ( $current_id !== '' ) {
+                    Helpers::reset_opencritic_metadata( $post_id, true );
+                }
+            } else {
+                update_post_meta( $post_id, '_jlg_opencritic_id', $normalized_id );
+
+                if ( $normalized_slug !== '' ) {
+                    update_post_meta( $post_id, '_jlg_opencritic_slug', $normalized_slug );
+                } else {
+                    delete_post_meta( $post_id, '_jlg_opencritic_slug' );
+                }
+
+                if ( $normalized_name !== '' ) {
+                    update_post_meta( $post_id, '_jlg_opencritic_title', $normalized_name );
+                }
+
+                if ( (string) $current_id !== $normalized_id ) {
+                    Helpers::reset_opencritic_metadata( $post_id );
+                }
+
+                Helpers::schedule_opencritic_sync( $post_id, 30 );
             }
 
             // Plateformes (checkboxes)

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -241,7 +241,7 @@ class Settings {
         }
 
         // API Key
-        if ( $key === 'rawg_api_key' ) {
+        if ( $key === 'rawg_api_key' || $key === 'opencritic_api_key' ) {
             return sanitize_text_field( $value );
         }
 
@@ -1141,10 +1141,23 @@ class Settings {
             'notation_jlg_page',
             'jlg_api_section',
             array(
-				'id'   => 'rawg_api_key',
-				'type' => 'text',
-				'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs',
-			)
+                                'id'   => 'rawg_api_key',
+                                'type' => 'text',
+                                'desc' => 'Obtenez votre clé API gratuite sur rawg.io/apidocs',
+                        )
+        );
+
+        add_settings_field(
+            'opencritic_api_key',
+            __( 'Clé API OpenCritic', 'notation-jlg' ),
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_api_section',
+            array(
+                'id'   => 'opencritic_api_key',
+                'type' => 'text',
+                'desc' => __( 'Générez une clé développeur sur opencritic.com/developers.', 'notation-jlg' ),
+            )
         );
 
         // Section 15: Debug

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -168,12 +168,16 @@ class Assets {
 					'loadingText'        => __( 'Chargement...', 'notation-jlg' ),
 					'searchButtonLabel'  => __( 'Rechercher', 'notation-jlg' ),
 					'securityFailed'     => __( 'Vérification de sécurité échouée. Actualisez la page.', 'notation-jlg' ),
-					'selectLabel'        => __( 'Choisir', 'notation-jlg' ),
-					'communicationError' => __( 'Erreur de communication.', 'notation-jlg' ),
-					'filledMessage'      => __( 'Fiche technique remplie !', 'notation-jlg' ),
-					'notAvailableLabel'  => __( 'N/A', 'notation-jlg' ),
-				);
-			}
+                                'selectLabel'        => __( 'Choisir', 'notation-jlg' ),
+                                'communicationError' => __( 'Erreur de communication.', 'notation-jlg' ),
+                                'filledMessage'      => __( 'Fiche technique remplie !', 'notation-jlg' ),
+                                'notAvailableLabel'  => __( 'N/A', 'notation-jlg' ),
+                                'openCriticNoResults' => __( 'Aucun résultat OpenCritic.', 'notation-jlg' ),
+                                'openCriticScoreLabel' => __( 'Score', 'notation-jlg' ),
+                                'openCriticLinked'     => __( 'Jeu OpenCritic associé !', 'notation-jlg' ),
+                                'openCriticViewLink'   => __( 'Voir sur OpenCritic', 'notation-jlg' ),
+                        );
+                    }
         );
 
         $this->register_localization(
@@ -188,11 +192,13 @@ class Assets {
 						'noResults'     => esc_html__( 'Aucun jeu ne correspond à votre sélection.', 'notation-jlg' ),
 						'reset'         => esc_html__( 'Réinitialiser les filtres', 'notation-jlg' ),
 						'genericError'  => esc_html__( 'Impossible de charger les jeux pour le moment.', 'notation-jlg' ),
-						'countSingular' => esc_html__( '%d jeu', 'notation-jlg' ),
-						'countPlural'   => esc_html__( '%d jeux', 'notation-jlg' ),
-					),
-				);
-			}
+                                                'countSingular' => esc_html__( '%d jeu', 'notation-jlg' ),
+                                                'countPlural'   => esc_html__( '%d jeux', 'notation-jlg' ),
+                                                'openCriticView'    => esc_html__( 'Voir sur OpenCritic', 'notation-jlg' ),
+                                                'openCriticViewFor' => esc_html__( 'Voir la fiche OpenCritic de %s', 'notation-jlg' ),
+                                        ),
+                                );
+                        }
         );
     }
 }

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -1174,6 +1174,7 @@ class GameExplorer {
                     'availability_label' => $availability_data['label'],
                     'timestamp'          => get_post_time( 'U', true, $post ),
                     'search_haystack'    => isset( $post_info['search_haystack'] ) ? $post_info['search_haystack'] : '',
+                    'opencritic'         => Helpers::get_opencritic_display_data( $post_id ),
                 );
             }
             wp_reset_postdata();

--- a/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
@@ -370,6 +370,17 @@ class SummaryDisplay {
                     'aliases'  => array( 'note' ),
                 ),
             ),
+            'opencritic'  => array(
+                'label'    => __( 'Score OpenCritic', 'notation-jlg' ),
+                'sortable' => true,
+                'sort'     => array(
+                    'key'      => 'opencritic',
+                    'orderby'  => 'meta_value_num',
+                    'meta_key' => '_jlg_opencritic_score',
+                    'type'     => 'NUMERIC',
+                    'aliases'  => array( 'opencritic', 'opencritic_score' ),
+                ),
+            ),
             'developpeur' => array(
                 'label'    => __( 'Développeur', 'notation-jlg' ),
                 'sortable' => true,

--- a/plugin-notation-jeux_V4/includes/Utils/OpenCriticClient.php
+++ b/plugin-notation-jeux_V4/includes/Utils/OpenCriticClient.php
@@ -1,0 +1,594 @@
+<?php
+/**
+ * Lightweight client to communicate with the OpenCritic API.
+ *
+ * @package JLG_Notation\Utils
+ */
+
+namespace JLG\Notation\Utils;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+class OpenCriticClient {
+private const DEFAULT_API_BASE   = 'https://api.opencritic.com/api';
+private const CACHE_PREFIX       = 'jlg_opencritic_';
+private const DEFAULT_SEARCH_TTL = 3;
+private const DEFAULT_GAME_TTL   = 12;
+
+/**
+ * API key provided by the site owner.
+ *
+ * @var string
+ */
+private $api_key = '';
+
+/**
+ * Indicates whether the client is running in mock mode.
+ *
+ * @var bool
+ */
+private $mock_mode = false;
+
+/**
+ * Base URL for the API.
+ *
+ * @var string
+ */
+private $api_base = '';
+
+/**
+ * Constructor.
+ *
+ * @param string $api_key Optional API key to authenticate requests.
+ */
+public function __construct( $api_key = '' ) {
+$this->api_key   = is_string( $api_key ) ? trim( (string) $api_key ) : '';
+$this->mock_mode = $this->api_key === '';
+$default_base    = apply_filters( 'jlg_opencritic_api_base', self::DEFAULT_API_BASE );
+$this->api_base  = is_string( $default_base ) && $default_base !== ''
+? rtrim( $default_base, '/' )
+: self::DEFAULT_API_BASE;
+}
+
+/**
+ * Indicates whether the client operates with mock data.
+ *
+ * @return bool
+ */
+public function is_mock_mode() {
+return $this->mock_mode;
+}
+
+/**
+ * Searches the OpenCritic catalogue for games matching the provided query.
+ *
+ * @param string $query Search keywords.
+ * @param int    $limit Maximum number of results to return.
+ *
+ * @return array<int, array<string, mixed>>|WP_Error
+ */
+public function search_games( $query, $limit = 8 ) {
+$query = is_string( $query ) ? trim( wp_unslash( $query ) ) : '';
+$limit = (int) $limit;
+
+if ( $limit <= 0 ) {
+$limit = 8;
+}
+
+$limit = min( max( 1, $limit ), 20 );
+
+if ( $query === '' ) {
+return new WP_Error( 'opencritic_invalid_query', __( 'La requête de recherche est vide.', 'notation-jlg' ) );
+}
+
+$cache_key = $this->build_cache_key( 'search', array( $query, $limit ) );
+$cached    = get_transient( $cache_key );
+
+if ( $cached !== false && is_array( $cached ) ) {
+return $cached;
+}
+
+if ( $this->mock_mode ) {
+$mock = $this->generate_mock_results( $query, $limit );
+$this->set_transient( $cache_key, $mock, self::DEFAULT_SEARCH_TTL, 'search' );
+
+return $mock;
+}
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+return new WP_Error( 'opencritic_http_unavailable', __( 'La fonction HTTP de WordPress est indisponible.', 'notation-jlg' ) );
+}
+
+$endpoint = trailingslashit( $this->api_base ) . 'game/search';
+$url      = add_query_arg(
+array(
+'criteria' => rawurlencode( $query ),
+'limit'    => $limit,
+),
+$endpoint
+);
+
+$args = apply_filters(
+'jlg_opencritic_http_request_args',
+array(
+'timeout' => 10,
+'headers' => $this->build_headers(),
+),
+'game/search',
+$query
+);
+
+$response = wp_remote_get( $url, $args );
+
+if ( is_wp_error( $response ) ) {
+return $response;
+}
+
+$status_code = (int) wp_remote_retrieve_response_code( $response );
+
+if ( $status_code < 200 || $status_code >= 300 ) {
+return new WP_Error(
+'opencritic_http_error',
+sprintf(
+/* translators: %d: HTTP status code returned by the OpenCritic API. */
+__( 'La requête OpenCritic a échoué avec le code %d.', 'notation-jlg' ),
+$status_code
+)
+);
+}
+
+$body    = wp_remote_retrieve_body( $response );
+$decoded = json_decode( $body, true );
+
+if ( ! is_array( $decoded ) ) {
+return new WP_Error( 'opencritic_invalid_payload', __( 'Réponse OpenCritic invalide : JSON non valide.', 'notation-jlg' ) );
+}
+
+$normalized = $this->normalize_search_payload( $decoded );
+
+$this->set_transient( $cache_key, $normalized, self::DEFAULT_SEARCH_TTL, 'search' );
+
+return $normalized;
+}
+
+/**
+ * Retrieves detailed information for a specific game.
+ *
+ * @param int|string $game_id OpenCritic numeric identifier.
+ *
+ * @return array<string, mixed>|WP_Error
+ */
+public function get_game_details( $game_id ) {
+$identifier = $this->sanitize_identifier( $game_id );
+
+if ( $identifier <= 0 ) {
+return new WP_Error( 'opencritic_invalid_identifier', __( 'Identifiant OpenCritic invalide.', 'notation-jlg' ) );
+}
+
+$cache_key = $this->build_cache_key( 'game', $identifier );
+$cached    = get_transient( $cache_key );
+
+if ( $cached !== false && is_array( $cached ) ) {
+return $cached;
+}
+
+if ( $this->mock_mode ) {
+$mock = $this->generate_mock_game( $identifier );
+$this->set_transient( $cache_key, $mock, self::DEFAULT_GAME_TTL, 'game' );
+
+return $mock;
+}
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+return new WP_Error( 'opencritic_http_unavailable', __( 'La fonction HTTP de WordPress est indisponible.', 'notation-jlg' ) );
+}
+
+$endpoint = sprintf( '%s/game/%d', rtrim( $this->api_base, '/' ), $identifier );
+$args     = apply_filters(
+'jlg_opencritic_http_request_args',
+array(
+'timeout' => 10,
+'headers' => $this->build_headers(),
+),
+'game',
+$identifier
+);
+
+$response = wp_remote_get( $endpoint, $args );
+
+if ( is_wp_error( $response ) ) {
+return $response;
+}
+
+$status_code = (int) wp_remote_retrieve_response_code( $response );
+
+if ( $status_code < 200 || $status_code >= 300 ) {
+return new WP_Error(
+'opencritic_http_error',
+sprintf(
+/* translators: %d: HTTP status code returned by the OpenCritic API. */
+__( 'La requête OpenCritic a échoué avec le code %d.', 'notation-jlg' ),
+$status_code
+)
+);
+}
+
+$body    = wp_remote_retrieve_body( $response );
+$decoded = json_decode( $body, true );
+
+if ( ! is_array( $decoded ) ) {
+return new WP_Error( 'opencritic_invalid_payload', __( 'Réponse OpenCritic invalide : JSON non valide.', 'notation-jlg' ) );
+}
+
+$normalized = $this->normalize_game_entry( $decoded );
+
+if ( empty( $normalized ) ) {
+return new WP_Error( 'opencritic_game_not_found', __( 'Jeu introuvable sur OpenCritic.', 'notation-jlg' ) );
+}
+
+$this->set_transient( $cache_key, $normalized, self::DEFAULT_GAME_TTL, 'game' );
+
+return $normalized;
+}
+
+/**
+ * Builds the public URL for a specific game.
+ *
+ * @param array<string, mixed> $game Game payload.
+ * @return string
+ */
+public function build_game_url( $game ) {
+$identifier = 0;
+$slug       = '';
+
+if ( is_array( $game ) ) {
+if ( isset( $game['id'] ) ) {
+$identifier = $this->sanitize_identifier( $game['id'] );
+}
+
+if ( isset( $game['slug'] ) && is_string( $game['slug'] ) ) {
+$slug = sanitize_title( $game['slug'] );
+}
+}
+
+if ( $identifier <= 0 ) {
+return '';
+}
+
+$url = sprintf( 'https://opencritic.com/game/%d', $identifier );
+
+if ( $slug !== '' ) {
+$url .= '/' . rawurlencode( $slug );
+}
+
+return apply_filters( 'jlg_opencritic_game_url', $url, $identifier, $slug, $game );
+}
+
+/**
+ * Normalizes the payload returned by the API for search queries.
+ *
+ * @param array<string, mixed> $payload Raw decoded payload.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+private function normalize_search_payload( array $payload ) {
+$entries = array();
+
+if ( isset( $payload['results'] ) && is_array( $payload['results'] ) ) {
+$entries = $payload['results'];
+} elseif ( isset( $payload['items'] ) && is_array( $payload['items'] ) ) {
+$entries = $payload['items'];
+} else {
+$entries = $payload;
+}
+
+$normalized = array();
+
+foreach ( $entries as $entry ) {
+if ( ! is_array( $entry ) ) {
+continue;
+}
+
+$normalized_entry = $this->normalize_game_entry( $entry );
+
+if ( empty( $normalized_entry ) ) {
+continue;
+}
+
+$normalized[] = $normalized_entry;
+}
+
+return $normalized;
+}
+
+/**
+ * Normalizes a single game entry.
+ *
+ * @param array<string, mixed> $entry Raw game entry.
+ *
+ * @return array<string, mixed>
+ */
+private function normalize_game_entry( array $entry ) {
+$id = 0;
+
+if ( isset( $entry['id'] ) ) {
+$id = $this->sanitize_identifier( $entry['id'] );
+}
+
+if ( $id <= 0 ) {
+return array();
+}
+
+$name = '';
+if ( isset( $entry['name'] ) && is_string( $entry['name'] ) ) {
+$name = sanitize_text_field( $entry['name'] );
+}
+
+$slug = '';
+if ( isset( $entry['slug'] ) && is_string( $entry['slug'] ) ) {
+$slug = sanitize_title( $entry['slug'] );
+} elseif ( $name !== '' ) {
+$slug = sanitize_title( $name );
+}
+
+$score = null;
+if ( isset( $entry['topCriticScore'] ) ) {
+$score = $this->normalize_score( $entry['topCriticScore'] );
+} elseif ( isset( $entry['score'] ) ) {
+$score = $this->normalize_score( $entry['score'] );
+}
+
+$tier = '';
+if ( isset( $entry['tier'] ) && is_string( $entry['tier'] ) ) {
+$tier = sanitize_text_field( $entry['tier'] );
+}
+
+$release_date = '';
+$release_year = null;
+
+if ( isset( $entry['firstReleaseDate'] ) ) {
+$release_date = $this->normalize_date( $entry['firstReleaseDate'] );
+}
+
+if ( isset( $entry['first_release_date'] ) && $release_date === '' ) {
+$release_date = $this->normalize_date( $entry['first_release_date'] );
+}
+
+if ( isset( $entry['releaseDate'] ) && $release_date === '' ) {
+$release_date = $this->normalize_date( $entry['releaseDate'] );
+}
+
+if ( $release_date !== '' ) {
+$timestamp = strtotime( $release_date );
+if ( $timestamp ) {
+$release_year = (int) gmdate( 'Y', $timestamp );
+}
+}
+
+$url = $this->build_game_url(
+array(
+'id'   => $id,
+'slug' => $slug,
+)
+);
+
+return array(
+'id'                => $id,
+'name'              => $name,
+'slug'              => $slug,
+'topCriticScore'    => $score,
+'tier'              => $tier,
+'firstReleaseDate'  => $release_date,
+'releaseYear'       => $release_year,
+'url'               => $url,
+'is_mock'           => $this->mock_mode,
+);
+}
+
+/**
+ * Normalizes date strings accepted by the API.
+ *
+ * @param mixed $value Raw value.
+ *
+ * @return string
+ */
+private function normalize_date( $value ) {
+if ( is_numeric( $value ) ) {
+$timestamp = (int) $value;
+if ( $timestamp > 0 ) {
+return gmdate( 'Y-m-d', $timestamp );
+}
+}
+
+if ( is_string( $value ) && $value !== '' ) {
+$value = trim( $value );
+if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $value ) ) {
+return $value;
+}
+
+$timestamp = strtotime( $value );
+if ( $timestamp ) {
+return gmdate( 'Y-m-d', $timestamp );
+}
+}
+
+return '';
+}
+
+/**
+ * Normalizes a score value (0-100 range expected).
+ *
+ * @param mixed $value Raw value.
+ *
+ * @return float|null
+ */
+private function normalize_score( $value ) {
+if ( is_array( $value ) ) {
+return null;
+}
+
+if ( $value === null || $value === '' ) {
+return null;
+}
+
+if ( is_string( $value ) ) {
+$value = str_replace( ',', '.', $value );
+}
+
+if ( ! is_numeric( $value ) ) {
+return null;
+}
+
+$score = (float) $value;
+if ( $score < 0 ) {
+$score = 0.0;
+}
+
+if ( $score > 100 ) {
+$score = 100.0;
+}
+
+return round( $score, 1 );
+}
+
+/**
+ * Builds HTTP headers for API requests.
+ *
+ * @return array<string, string>
+ */
+private function build_headers() {
+$headers = array(
+'Accept'     => 'application/json',
+'User-Agent' => 'JLG-Notation/5.0 (+https://opencritic.com)',
+);
+
+if ( $this->api_key !== '' ) {
+$headers['X-API-Key'] = $this->api_key;
+}
+
+return apply_filters( 'jlg_opencritic_request_headers', $headers, $this->api_key );
+}
+
+/**
+ * Generates mock search results when no API key is configured.
+ *
+ * @param string $query Search query.
+ * @param int    $limit Number of results.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+private function generate_mock_results( $query, $limit ) {
+$results = array();
+
+for ( $index = 0; $index < $limit; $index++ ) {
+$identifier = 1000 + $index + wp_rand( 0, 50 );
+$name       = sprintf( '%s – Mock %d', $query, $index + 1 );
+$score      = 60 + ( $index * 5 ) % 30;
+
+$results[] = array(
+'id'               => $identifier,
+'name'             => $name,
+'slug'             => sanitize_title( $name ),
+'topCriticScore'   => (float) $score,
+'tier'             => 'Mock',
+'firstReleaseDate' => gmdate( 'Y-m-d', strtotime( '-' . ( $index * 120 ) . ' days' ) ),
+'releaseYear'      => (int) gmdate( 'Y', strtotime( '-' . ( $index * 120 ) . ' days' ) ),
+'url'              => $this->build_game_url(
+array(
+'id'   => $identifier,
+'slug' => sanitize_title( $name ),
+)
+),
+'is_mock'          => true,
+);
+}
+
+return $results;
+}
+
+/**
+ * Generates a mock game payload.
+ *
+ * @param int $identifier Game identifier.
+ *
+ * @return array<string, mixed>
+ */
+private function generate_mock_game( $identifier ) {
+$name  = sprintf( 'Mock Game %d', $identifier );
+$score = 75 + ( $identifier % 15 );
+
+return array(
+'id'               => $identifier,
+'name'             => $name,
+'slug'             => sanitize_title( $name ),
+'topCriticScore'   => (float) $score,
+'tier'             => 'Mock',
+'firstReleaseDate' => gmdate( 'Y-m-d', strtotime( '-180 days' ) ),
+'releaseYear'      => (int) gmdate( 'Y', strtotime( '-180 days' ) ),
+'url'              => $this->build_game_url(
+array(
+'id'   => $identifier,
+'slug' => sanitize_title( $name ),
+)
+),
+'is_mock'          => true,
+);
+}
+
+/**
+ * Creates a cache key for the given parameters.
+ *
+ * @param string       $type Identifier for the cache segment.
+ * @param int|array    $data Data to hash.
+ *
+ * @return string
+ */
+private function build_cache_key( $type, $data ) {
+$hash = md5( wp_json_encode( array( $type, $data ) ) );
+
+return self::CACHE_PREFIX . $hash;
+}
+
+/**
+ * Stores the provided value inside a transient.
+ *
+ * @param string $cache_key Cache key.
+ * @param mixed  $value     Cached value.
+ * @param int    $fallback  Default TTL in hours.
+ * @param string $type      Cache segment type.
+ */
+private function set_transient( $cache_key, $value, $fallback, $type ) {
+$hours = (int) apply_filters( 'jlg_opencritic_cache_hours', $fallback, $type, $cache_key );
+
+if ( $hours <= 0 ) {
+return;
+}
+
+$expiration = $hours * ( defined( 'HOUR_IN_SECONDS' ) ? HOUR_IN_SECONDS : 3600 );
+set_transient( $cache_key, $value, $expiration );
+}
+
+/**
+ * Sanitizes a game identifier.
+ *
+ * @param mixed $identifier Raw identifier.
+ *
+ * @return int
+ */
+private function sanitize_identifier( $identifier ) {
+if ( is_numeric( $identifier ) ) {
+return absint( $identifier );
+}
+
+if ( is_string( $identifier ) ) {
+$identifier = preg_replace( '/[^0-9]/', '', $identifier );
+return absint( $identifier );
+}
+
+return 0;
+}
+}

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -100,6 +100,7 @@ final class JLG_Plugin_De_Notation_Main {
         add_action( 'updated_post_meta', array( $helpers_class, 'maybe_handle_rating_meta_change' ), 10, 4 );
         add_action( 'deleted_post_meta', array( $helpers_class, 'maybe_handle_rating_meta_change' ), 10, 4 );
         add_action( 'transition_post_status', array( $helpers_class, 'maybe_clear_rated_post_ids_cache_for_status_change' ), 20, 3 );
+        add_action( $helpers_class::OPENCRITIC_SYNC_HOOK, array( $helpers_class, 'sync_opencritic_score' ), 10, 1 );
 
         $game_explorer_class = \JLG\Notation\Shortcodes\GameExplorer::class;
 
@@ -174,6 +175,7 @@ final class JLG_Plugin_De_Notation_Main {
         if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
             wp_clear_scheduled_hook( 'jlg_process_v5_migration' );
             wp_clear_scheduled_hook( \JLG\Notation\Helpers::SCORE_SCALE_EVENT_HOOK );
+            wp_clear_scheduled_hook( \JLG\Notation\Helpers::OPENCRITIC_SYNC_HOOK );
         }
 
         delete_option( 'jlg_migration_v5_queue' );

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -27,6 +27,16 @@ if ( ! in_array( $sort_order, array( 'ASC', 'DESC' ), true ) ) {
     $sort_order = 'DESC';
 }
 $query_params = isset( $query_params ) && is_array( $query_params ) ? $query_params : array();
+$opencritic_strings = isset( $opencritic_strings ) && is_array( $opencritic_strings ) ? $opencritic_strings : array();
+$opencritic_view_label = isset( $opencritic_strings['view_label'] ) && $opencritic_strings['view_label'] !== ''
+    ? $opencritic_strings['view_label']
+    : esc_html__( 'Voir sur OpenCritic', 'notation-jlg' );
+$opencritic_view_label_for = isset( $opencritic_strings['view_label_for'] ) && $opencritic_strings['view_label_for'] !== ''
+    ? $opencritic_strings['view_label_for']
+    : esc_html__( 'Voir la fiche OpenCritic de %s', 'notation-jlg' );
+$opencritic_score_fallback = isset( $opencritic_strings['score_fallback'] ) && $opencritic_strings['score_fallback'] !== ''
+    ? $opencritic_strings['score_fallback']
+    : esc_html__( 'N/A', 'notation-jlg' );
 
 $namespaced_keys = array(
     'orderby'      => isset( $request_keys['orderby'] ) ? $request_keys['orderby'] : 'orderby',
@@ -144,6 +154,32 @@ if ( empty( $games ) ) {
         $availability_label  = isset( $game['availability_label'] ) ? $game['availability_label'] : '';
         $availability_status = isset( $game['availability'] ) ? $game['availability'] : '';
         $excerpt             = isset( $game['excerpt'] ) ? $game['excerpt'] : '';
+        $opencritic          = isset( $game['opencritic'] ) && is_array( $game['opencritic'] ) ? $game['opencritic'] : array();
+        $opencritic_status   = isset( $opencritic['status'] ) ? $opencritic['status'] : 'unlinked';
+        $opencritic_label    = isset( $opencritic['status_label'] ) ? $opencritic['status_label'] : '';
+        $opencritic_score    = isset( $opencritic['score_display'] ) ? $opencritic['score_display'] : '';
+        $opencritic_url      = isset( $opencritic['url'] ) ? $opencritic['url'] : '';
+        $opencritic_title    = isset( $opencritic['title'] ) && $opencritic['title'] !== '' ? $opencritic['title'] : $title;
+        $opencritic_color    = isset( $opencritic['status_color'] ) && $opencritic['status_color'] !== ''
+            ? $opencritic['status_color']
+            : '#94a3b8';
+        $opencritic_bg       = isset( $opencritic['status_background'] ) && $opencritic['status_background'] !== ''
+            ? $opencritic['status_background']
+            : 'rgba(148, 163, 184, 0.16)';
+        $opencritic_border   = isset( $opencritic['status_border'] ) && $opencritic['status_border'] !== ''
+            ? $opencritic['status_border']
+            : 'rgba(148, 163, 184, 0.38)';
+        $opencritic_style    = sprintf(
+            '--jlg-opencritic-color:%1$s;--jlg-opencritic-bg:%2$s;--jlg-opencritic-border:%3$s;',
+            $opencritic_color,
+            $opencritic_bg,
+            $opencritic_border
+        );
+        $should_display_opencritic = $opencritic_status !== 'unlinked';
+        $opencritic_link_label     = $opencritic_view_label;
+        if ( $opencritic_view_label_for !== '' && strpos( $opencritic_view_label_for, '%s' ) !== false ) {
+            $opencritic_link_label = sprintf( $opencritic_view_label_for, $opencritic_title );
+        }
         ?>
         <article class="jlg-ge-card" data-post-id="<?php echo esc_attr( $game['post_id'] ); ?>">
             <a class="jlg-ge-card__media" href="<?php echo esc_url( $permalink ); ?>">
@@ -222,6 +258,30 @@ if ( empty( $games ) ) {
                         </span>
                     <?php endif; ?>
                 </div>
+                <?php if ( $should_display_opencritic ) : ?>
+                    <div class="jlg-ge-opencritic" data-opencritic-status="<?php echo esc_attr( $opencritic_status ); ?>">
+                        <span class="jlg-opencritic-chip" style="<?php echo esc_attr( $opencritic_style ); ?>">
+                            <span class="jlg-opencritic-chip__score">
+                                <?php echo esc_html( $opencritic_score !== '' ? $opencritic_score : $opencritic_score_fallback ); ?>
+                            </span>
+                            <?php if ( $opencritic_label !== '' ) : ?>
+                                <span class="jlg-opencritic-chip__label"><?php echo esc_html( $opencritic_label ); ?></span>
+                            <?php endif; ?>
+                        </span>
+                        <?php if ( $opencritic_url !== '' ) : ?>
+                            <a
+                                class="jlg-ge-opencritic__link jlg-opencritic-link"
+                                href="<?php echo esc_url( $opencritic_url ); ?>"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                data-opencritic-title="<?php echo esc_attr( $opencritic_title ); ?>"
+                                aria-label="<?php echo esc_attr( $opencritic_link_label ); ?>"
+                            >
+                                <?php echo esc_html( $opencritic_view_label ); ?>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
             </div>
         </article>
     <?php endforeach; ?>

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -10,12 +10,61 @@ if ( ! empty( $title ) ) {
 }
 
 if ( $latest_reviews->have_posts() ) {
-    echo '<ul>';
+    $opencritic_map     = isset( $opencritic_map ) && is_array( $opencritic_map ) ? $opencritic_map : array();
+    $opencritic_strings = isset( $opencritic_strings ) && is_array( $opencritic_strings ) ? $opencritic_strings : array();
+    $opencritic_view_label = isset( $opencritic_strings['view_label'] ) && $opencritic_strings['view_label'] !== ''
+        ? $opencritic_strings['view_label']
+        : esc_html__( 'Voir sur OpenCritic', 'notation-jlg' );
+    $opencritic_view_label_for = isset( $opencritic_strings['view_label_for'] ) && $opencritic_strings['view_label_for'] !== ''
+        ? $opencritic_strings['view_label_for']
+        : esc_html__( 'Voir la fiche OpenCritic de %s', 'notation-jlg' );
+    $opencritic_score_fallback = isset( $opencritic_strings['score_fallback'] ) && $opencritic_strings['score_fallback'] !== ''
+        ? $opencritic_strings['score_fallback']
+        : esc_html__( 'N/A', 'notation-jlg' );
+
+    echo '<ul class="jlg-widget-review-list">';
     while ( $latest_reviews->have_posts() ) {
         $latest_reviews->the_post();
         $post_id    = get_the_ID();
         $game_title = \JLG\Notation\Helpers::get_game_title( $post_id );
-        echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( $game_title ) . '</a></li>';
+        $opencritic  = isset( $opencritic_map[ $post_id ] ) ? $opencritic_map[ $post_id ] : \JLG\Notation\Helpers::get_opencritic_display_data( $post_id );
+        $status      = isset( $opencritic['status'] ) ? $opencritic['status'] : 'unlinked';
+        $label       = isset( $opencritic['status_label'] ) ? $opencritic['status_label'] : '';
+        $score       = isset( $opencritic['score_display'] ) ? $opencritic['score_display'] : '';
+        $url         = isset( $opencritic['url'] ) ? $opencritic['url'] : '';
+        $title_value = isset( $opencritic['title'] ) && $opencritic['title'] !== '' ? $opencritic['title'] : $game_title;
+        $color       = isset( $opencritic['status_color'] ) && $opencritic['status_color'] !== '' ? $opencritic['status_color'] : '#94a3b8';
+        $bg          = isset( $opencritic['status_background'] ) && $opencritic['status_background'] !== '' ? $opencritic['status_background'] : 'rgba(148, 163, 184, 0.16)';
+        $border      = isset( $opencritic['status_border'] ) && $opencritic['status_border'] !== '' ? $opencritic['status_border'] : 'rgba(148, 163, 184, 0.38)';
+        $style       = sprintf( '--jlg-opencritic-color:%1$s;--jlg-opencritic-bg:%2$s;--jlg-opencritic-border:%3$s;', $color, $bg, $border );
+        $link_label  = $opencritic_view_label;
+        if ( $opencritic_view_label_for !== '' && strpos( $opencritic_view_label_for, '%s' ) !== false ) {
+            $link_label = sprintf( $opencritic_view_label_for, $title_value );
+        }
+        $display_opencritic = $status !== 'unlinked';
+
+        echo '<li class="jlg-widget-review">';
+        echo '<a class="jlg-widget-review__title" href="' . esc_url( get_permalink() ) . '">' . esc_html( $game_title ) . '</a>';
+
+        if ( $display_opencritic ) {
+            echo '<div class="jlg-widget-review__meta" data-opencritic-status="' . esc_attr( $status ) . '">';
+            echo '<span class="jlg-opencritic-chip" style="' . esc_attr( $style ) . '">';
+            echo '<span class="jlg-opencritic-chip__score">' . esc_html( $score !== '' ? $score : $opencritic_score_fallback ) . '</span>';
+            if ( $label !== '' ) {
+                echo '<span class="jlg-opencritic-chip__label">' . esc_html( $label ) . '</span>';
+            }
+            echo '</span>';
+
+            if ( $url !== '' ) {
+                echo '<a class="jlg-opencritic-link jlg-widget-review__link" href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer" data-opencritic-title="' . esc_attr( $title_value ) . '" aria-label="' . esc_attr( $link_label ) . '">';
+                echo esc_html( $opencritic_view_label );
+                echo '</a>';
+            }
+
+            echo '</div>';
+        }
+
+        echo '</li>';
     }
     echo '</ul>';
 } else {


### PR DESCRIPTION
## Summary
- attach OpenCritic display data to Game Explorer payloads and expose localized strings for front-end templates
- render OpenCritic badges and outbound links across the Game Explorer, summary table, and latest reviews widget with refreshed styling
- add an OpenCritic column option to the summary shortcode and Gutenberg block, keeping sorting wired to the stored metascore

## Testing
- composer test *(fails: phpunit not installed in container)*
- composer cs *(fails: phpcs not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1492e625c832ea2150af4217c40b9