### PR TITLE
Fix reflection imports in Validator utility

### DIFF
--- a/plugin-notation-jeux_V4/includes/Utils/Validator.php
+++ b/plugin-notation-jeux_V4/includes/Utils/Validator.php
@@ -4,6 +4,8 @@ namespace JLG\Notation\Utils;
 
 use DateTime;
 use JLG\Notation\Helpers;
+use ReflectionException;
+use ReflectionMethod;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;


### PR DESCRIPTION
## Summary
- import the Reflection classes used by the Validator utility to prevent namespace resolution issues

## Testing
- composer test *(fails: phpunit not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a4459b40832ebafd1892a2d9e4f4