### PR TITLE
Improve Game Explorer loading feedback

### DIFF
--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -461,11 +461,7 @@
             return;
         }
 
-        if (isBusy) {
-            resultsNode.setAttribute('aria-busy', 'true');
-        } else {
-            resultsNode.removeAttribute('aria-busy');
-        }
+        resultsNode.setAttribute('aria-busy', isBusy ? 'true' : 'false');
     }
 
     function focusUpdatedResults(refs) {

--- a/plugin-notation-jeux_V4/docs/game-explorer-loading-overlay.md
+++ b/plugin-notation-jeux_V4/docs/game-explorer-loading-overlay.md
@@ -1,0 +1,16 @@
+# Game Explorer – Surcouche de chargement
+
+## Contexte
+- La grille met désormais à disposition l'attribut `data-loading-text` côté PHP afin que le message "Chargement…" reste disponible même sans initialisation JavaScript.
+- Le script `game-explorer.js` synchronise ce texte avec la localisation front (`strings.loading`) et maintient `aria-busy` à jour pour les lecteurs d'écran.
+
+## Vérification visuelle
+1. Forcer la classe `is-loading` sur `.jlg-game-explorer` (ou déclencher une requête AJAX via les filtres) et confirmer l'apparition de la bulle centrée avec le message traduit.
+2. En mode sombre (palette par défaut), contrôler le contraste : le fond semi-opaque `rgba(15, 23, 42, 0.92)` reste lisible avec la couleur de texte `var(--jlg-ge-text)`.
+3. En mode clair (thème hôte), ajuster les variables CSS du conteneur (`--jlg-ge-card-bg`, `--jlg-ge-text`, etc.) et s'assurer que la pseudo-surcouche hérite bien de ces valeurs, conservant un contraste suffisant.
+4. Vérifier que la grille repasse automatiquement en `aria-busy="false"` une fois le fragment AJAX injecté.
+
+## Notes d'accessibilité
+- `role="status"` + `aria-live="polite"` sont conservés : l'annonce "Chargement…" est relayée pendant la requête puis le contenu final est vocalisé.
+- Ne pas retirer `aria-busy` côté DOM : le script alterne explicitement entre `true` et `false` pour éviter les annonces fantômes.
+- Le focus est recentré sur le premier élément interactif disponible après chaque rafraîchissement pour réduire la désorientation clavier.

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -445,6 +445,7 @@ $reset_url = remove_query_arg( array_values( $namespaced_keys ), '' );
     <div
         class="jlg-ge-results"
         data-role="results"
+        data-loading-text="<?php echo esc_attr__( 'Chargement…', 'notation-jlg' ); ?>"
         role="status"
         aria-live="polite"
         aria-busy="false"


### PR DESCRIPTION
## Summary
- expose the localized loading message on the Game Explorer results container so the overlay can render even before JS kicks in
- keep `aria-busy` toggled between `true` and `false` in the Game Explorer script to match live region announcements
- document the visual and accessibility checklist for the loading overlay in the docs

## Testing
- `composer test` *(fails: baseline shortcode/unit tests expect WP_Query::args mock)*
- `composer cs` *(fails: pre-existing PHPCS alignment warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a4482da0832ea0009a8e67e8910c