### PR TITLE
Add score insights shortcode and block

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -65,6 +65,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs avec histogramme dynamique (barres accessibles ARIA, mise à jour en temps réel après chaque vote)
 - `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les en-têtes permettent désormais de trier par titre, date, note moyenne ainsi que par métadonnées développeur/éditeur via les paramètres `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
 - `[jlg_game_explorer]` - Game Explorer interactif affichant vos tests sous forme de cartes. Attributs disponibles : `posts_per_page` (nombre d'entrées par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour préfiltrer le rendu. La navigation (lettres, filtres, tri et pagination) fonctionne désormais également sans JavaScript via des requêtes GET accessibles. Sur mobile, les filtres sont regroupés dans un panneau masquable pour laisser plus d'espace aux résultats tout en restant utilisables sans JavaScript.
+- `[jlg_score_insights]` - Tableau de bord statistique mettant en avant moyenne, médiane, histogramme et plateformes dominantes sur une période donnée. Attributs : `time_range` (`all`, `last_30_days`, `last_90_days`, `last_365_days`), `platform` (slug enregistré dans Notation → Plateformes), `platform_limit` (1 à 10 plateformes affichées) et `title` pour personnaliser l'entête.
 
 ### Utilisation dans les widgets et blocs
 
@@ -94,6 +95,7 @@ Le plugin propose désormais une collection complète de blocs dynamiques pour l
   d'accent et le format du score (valeur absolue ou pourcentage) pour un rendu cohérent.
 - **Game Explorer** (`notation-jlg/game-explorer`) : définissez le tri initial, les filtres disponibles et les paramètres de
   préfiltrage (catégorie, plateforme, lettre).
+- **Score Insights** (`notation-jlg/score-insights`) : ajustez la période analysée, filtrez par plateforme et limitez le classement pour générer une synthèse accessible (moyenne, médiane, histogramme, top plateformes).
 
 Chaque bloc repose sur le rendu PHP historique (shortcodes) et marque automatiquement l'exécution via
 `JLG_Frontend::mark_shortcode_rendered()` afin que les assets nécessaires soient chargés, y compris dans l'éditeur.

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -62,6 +62,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs avec histogramme dynamique (barres accessibles ARIA, mise à jour en temps réel après chaque vote)
 * `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les entêtes sont triables par titre, date, note moyenne et métadonnées développeur/éditeur via `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
 * `[jlg_game_explorer]` - Game Explorer interactif avec cartes et filtres dynamiques. Attributs : `posts_per_page` (nombre d'articles par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour forcer un filtrage initial. La navigation (lettres, filtres, tri et pagination) reste pleinement fonctionnelle sans JavaScript grâce à des requêtes GET accessibles. Sur mobile, les filtres se replient dans un panneau masquable pour libérer l'écran tout en conservant l'accessibilité sans JavaScript.
+* `[jlg_score_insights]` - Tableau de bord statistique mettant en avant moyenne, médiane, histogramme et plateformes dominantes sur une période donnée. Attributs : `time_range` (`all`, `last_30_days`, `last_90_days`, `last_365_days`), `platform` (slug défini dans Notation → Plateformes), `platform_limit` (1 à 10 plateformes) et `title` pour personnaliser l'entête.
 
 == Utilisation dans les widgets et blocs ==
 
@@ -75,7 +76,7 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 
 == Blocs Gutenberg ==
 
-Le plugin expose huit blocs dynamiques prêts à l'emploi :
+Le plugin expose neuf blocs dynamiques prêts à l'emploi :
 
 * **Bloc de notation** (`notation-jlg/rating-block`) — choisissez l'article ciblé ou laissez le champ vide pour utiliser le
   contenu courant, définissez la disposition (`texte` ou `cercle`), activez/désactivez les animations et sélectionnez le format du score (valeur absolue ou pourcentage).
@@ -89,6 +90,8 @@ Le plugin expose huit blocs dynamiques prêts à l'emploi :
 * **Bloc tout-en-un** (`notation-jlg/all-in-one`) — activez/désactivez chaque sous-bloc, modifiez le style, la couleur d'accent, les titres et le format du score (valeur absolue ou pourcentage).
 * **Game Explorer** (`notation-jlg/game-explorer`) — configurez le tri initial, les filtres proposés et les paramètres de
   préfiltrage (catégorie, plateforme, lettre).
+* **Score Insights** (`notation-jlg/score-insights`) — sélectionnez la période analysée, filtrez par plateforme et limitez le nombre de plateformes listées pour générer une synthèse accessible (moyenne, médiane, histogramme, top plateformes).
+ 
 
 Chaque bloc délègue le rendu à la logique PHP historique (shortcodes) tout en appelant `JLG_Frontend::mark_shortcode_rendered()`
 afin de charger automatiquement les scripts et feuilles de style requis dans l'éditeur.

--- a/plugin-notation-jeux_V4/assets/blocks/score-insights/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/score-insights/block.json
@@ -1,0 +1,33 @@
+{
+  "apiVersion": 2,
+  "name": "notation-jlg/score-insights",
+  "title": "Score Insights",
+  "category": "widgets",
+  "icon": "chart-area",
+  "description": "Affiche la moyenne, la médiane et les plateformes les plus performantes sur une période donnée.",
+  "textdomain": "notation-jlg",
+  "supports": {
+    "align": ["wide", "full"],
+    "html": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": ""
+    },
+    "timeRange": {
+      "type": "string",
+      "default": "all"
+    },
+    "platform": {
+      "type": "string",
+      "default": ""
+    },
+    "platformLimit": {
+      "type": "number",
+      "default": 5
+    }
+  },
+  "editorScript": "notation-jlg-score-insights-editor",
+  "editorStyle": "notation-jlg-block-editor"
+}

--- a/plugin-notation-jeux_V4/assets/js/blocks/score-insights.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/score-insights.js
@@ -1,0 +1,134 @@
+(function (wp, blocksHelpers) {
+    if (!wp || !blocksHelpers || !blocksHelpers.BlockPreview) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks && wp.blocks.registerBlockType ? wp.blocks.registerBlockType : null;
+    if (!registerBlockType) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor || wp.editor || {};
+    var InspectorControls = blockEditor.InspectorControls || function (props) {
+        return wp.element.createElement(wp.element.Fragment, null, props.children);
+    };
+    var useBlockPropsHook = blockEditor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var SelectControl = wp.components.SelectControl;
+    var TextControl = wp.components.TextControl;
+    var RangeControl = wp.components.RangeControl;
+    var createElement = wp.element.createElement;
+    var Fragment = wp.element.Fragment;
+    var BlockPreview = blocksHelpers.BlockPreview;
+
+    var useBlockProps = typeof useBlockPropsHook === 'function'
+        ? useBlockPropsHook
+        : function (extraProps) {
+              var props = extraProps || {};
+              if (!props.className) {
+                  props.className = 'notation-jlg-block';
+              }
+              return props;
+          };
+
+    var timeRangeOptions = [
+        { value: 'all', label: __('Toutes les périodes', 'notation-jlg') },
+        { value: 'last_30_days', label: __('30 derniers jours', 'notation-jlg') },
+        { value: 'last_90_days', label: __('90 derniers jours', 'notation-jlg') },
+        { value: 'last_365_days', label: __('12 derniers mois', 'notation-jlg') }
+    ];
+
+    registerBlockType('notation-jlg/score-insights', {
+        edit: function (props) {
+            var attributes = props.attributes || {};
+            var setAttributes = typeof props.setAttributes === 'function' ? props.setAttributes : function () {};
+            var blockProps = useBlockProps({ className: 'notation-jlg-score-insights-block' });
+
+            var safeLimit = typeof attributes.platformLimit === 'number' ? attributes.platformLimit : 5;
+            if (safeLimit < 1) {
+                safeLimit = 1;
+            }
+            if (safeLimit > 10) {
+                safeLimit = 10;
+            }
+
+            return createElement(
+                Fragment,
+                null,
+                createElement(
+                    InspectorControls,
+                    null,
+                    createElement(
+                        PanelBody,
+                        { title: __('Données affichées', 'notation-jlg'), initialOpen: true },
+                        createElement(SelectControl, {
+                            label: __('Période analysée', 'notation-jlg'),
+                            value: attributes.timeRange || 'all',
+                            options: timeRangeOptions,
+                            onChange: function (value) {
+                                setAttributes({ timeRange: value || 'all' });
+                            }
+                        }),
+                        createElement(TextControl, {
+                            label: __('Filtrer par plateforme (slug)', 'notation-jlg'),
+                            value: attributes.platform || '',
+                            onChange: function (value) {
+                                setAttributes({ platform: value || '' });
+                            },
+                            help: __('Laissez vide pour toutes les plateformes ou utilisez le slug enregistré dans Notation → Plateformes.', 'notation-jlg')
+                        }),
+                        createElement(RangeControl, {
+                            label: __('Nombre de plateformes affichées', 'notation-jlg'),
+                            value: safeLimit,
+                            min: 1,
+                            max: 10,
+                            onChange: function (value) {
+                                var parsed = parseInt(value, 10);
+                                if (isNaN(parsed)) {
+                                    parsed = 5;
+                                }
+                                if (parsed < 1) {
+                                    parsed = 1;
+                                }
+                                if (parsed > 10) {
+                                    parsed = 10;
+                                }
+                                setAttributes({ platformLimit: parsed });
+                            }
+                        })
+                    ),
+                    createElement(
+                        PanelBody,
+                        { title: __('Présentation', 'notation-jlg'), initialOpen: false },
+                        createElement(TextControl, {
+                            label: __('Titre personnalisé', 'notation-jlg'),
+                            value: attributes.title || '',
+                            onChange: function (value) {
+                                setAttributes({ title: value || '' });
+                            },
+                            placeholder: __('Score Insights', 'notation-jlg')
+                        })
+                    )
+                ),
+                createElement(
+                    'div',
+                    blockProps,
+                    createElement(BlockPreview, {
+                        block: 'notation-jlg/score-insights',
+                        attributes: {
+                            title: attributes.title || '',
+                            timeRange: attributes.timeRange || 'all',
+                            platform: attributes.platform || '',
+                            platformLimit: safeLimit
+                        },
+                        label: __('Score Insights', 'notation-jlg')
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    });
+})(window.wp, window.jlgBlocks || {});

--- a/plugin-notation-jeux_V4/docs/score-insights.md
+++ b/plugin-notation-jeux_V4/docs/score-insights.md
@@ -1,0 +1,29 @@
+# Shortcode & bloc « Score Insights »
+
+Ce module affiche une synthèse statistique des notes publiées : moyenne, médiane, histogramme par tranches et classement des plateformes les plus performantes. Il repose sur le helper `Helpers::get_posts_score_insights()`.
+
+## Shortcode `[jlg_score_insights]`
+
+Attributs disponibles :
+
+- `time_range` : période analysée. Valeurs prises en charge : `all`, `last_30_days`, `last_90_days`, `last_365_days`. Les intégrateurs peuvent ajouter leurs propres périodes via le filtre `jlg_score_insights_time_ranges`.
+- `platform` : slug d'une plateforme enregistrée dans **Notation → Plateformes** (utiliser `sans-plateforme` pour les tests sans plateforme). Laisser vide pour inclure tous les supports.
+- `platform_limit` : nombre maximum de plateformes affichées dans le classement (1 à 10, défaut : 5).
+- `title` : titre personnalisé affiché dans l'en-tête du composant.
+
+Le template `templates/shortcode-score-insights.php` expose une structure accessible : région ARIA avec résumé, `<progress>` pour les barres de l'histogramme et `<ol>` pour le classement. En l'absence de données, un message `role="status"` invite à ajuster les filtres.
+
+## Bloc `notation-jlg/score-insights`
+
+Dans Gutenberg, le bloc reprend ces attributs :
+
+- Panneau **Données affichées** : sélection de la période, filtre par plateforme (slug) et limite du classement.
+- Panneau **Présentation** : titre personnalisé visible sur le front.
+
+Le bloc réutilise le shortcode côté serveur, garantissant la parité front/éditeur. L'aperçu dynamique respecte également les attributs pour vérifier le rendu avant publication.
+
+## Bonnes pratiques
+
+- Préparez vos slugs de plateforme dans l'administration avant de configurer le bloc afin de disposer de libellés cohérents.
+- Pour analyser une période personnalisée, utilisez le filtre `jlg_score_insights_time_ranges` dans votre thème ou plugin compagnon et ajoutez une option dans le bloc via un script personnalisé si nécessaire.
+- Pensez à compléter `docs/responsive-testing.md` si vous introduisez de nouvelles variations visuelles autour de ce module.

--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -86,6 +86,12 @@ class Blocks {
             'script'    => 'notation-jlg-game-explorer-editor',
             'callback'  => 'render_game_explorer_block',
         ),
+        'score-insights'  => array(
+            'name'      => 'notation-jlg/score-insights',
+            'shortcode' => 'jlg_score_insights',
+            'script'    => 'notation-jlg-score-insights-editor',
+            'callback'  => 'render_score_insights_block',
+        ),
     );
 
     public function __construct() {
@@ -626,5 +632,33 @@ class Blocks {
         }
 
         return $output;
+    }
+
+    public function render_score_insights_block( $attributes ) {
+        $atts = array();
+
+        if ( ! empty( $attributes['title'] ) && is_string( $attributes['title'] ) ) {
+            $atts['title'] = sanitize_text_field( $attributes['title'] );
+        }
+
+        if ( ! empty( $attributes['timeRange'] ) && is_string( $attributes['timeRange'] ) ) {
+            $atts['time_range'] = sanitize_key( $attributes['timeRange'] );
+        }
+
+        if ( isset( $attributes['platform'] ) && is_string( $attributes['platform'] ) ) {
+            $platform = sanitize_title( $attributes['platform'] );
+            if ( $platform !== '' ) {
+                $atts['platform'] = $platform;
+            }
+        }
+
+        if ( isset( $attributes['platformLimit'] ) ) {
+            $limit = (int) $attributes['platformLimit'];
+            if ( $limit > 0 ) {
+                $atts['platform_limit'] = min( 10, $limit );
+            }
+        }
+
+        return $this->render_shortcode( 'jlg_score_insights', $atts );
     }
 }

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -11,6 +11,7 @@ use JLG\Notation\Shortcodes\GameExplorer;
 use JLG\Notation\Shortcodes\GameInfo;
 use JLG\Notation\Shortcodes\ProsCons;
 use JLG\Notation\Shortcodes\RatingBlock;
+use JLG\Notation\Shortcodes\ScoreInsights;
 use JLG\Notation\Shortcodes\SummaryDisplay;
 use JLG\Notation\Shortcodes\Tagline;
 use JLG\Notation\Shortcodes\UserRating;
@@ -109,6 +110,7 @@ class Frontend {
             UserRating::class,
             Tagline::class,
             SummaryDisplay::class,
+            ScoreInsights::class,
             AllInOne::class,
             GameExplorer::class,
         );
@@ -164,6 +166,7 @@ class Frontend {
             'jlg_bloc_complet',
             'bloc_notation_complet',
             'jlg_game_explorer',
+            'jlg_score_insights',
         );
     }
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/ScoreInsights.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/ScoreInsights.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * Shortcode "jlg_score_insights" – synthèse statistique des notes.
+ *
+ * @package JLG_Notation
+ * @version 5.1
+ */
+
+namespace JLG\Notation\Shortcodes;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use JLG\Notation\Frontend;
+use JLG\Notation\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ScoreInsights {
+
+    private const SHORTCODE              = 'jlg_score_insights';
+    private const DEFAULT_PLATFORM_LIMIT = 5;
+    private const UNKNOWN_PLATFORM_SLUG  = 'sans-plateforme';
+
+    public function __construct() {
+        add_shortcode( self::SHORTCODE, array( $this, 'render' ) );
+    }
+
+    public static function get_default_atts() {
+        return array(
+            'title'          => '',
+            'time_range'     => 'all',
+            'platform'       => '',
+            'platform_limit' => self::DEFAULT_PLATFORM_LIMIT,
+        );
+    }
+
+    public function render( $atts, $content = '', $shortcode_tag = '' ) {
+        unset( $content );
+
+        $shortcode = $shortcode_tag ?: self::SHORTCODE;
+        $atts      = shortcode_atts( self::get_default_atts(), $atts, $shortcode );
+
+        $time_range     = $this->sanitize_time_range( $atts['time_range'] ?? '' );
+        $platform_slug  = $this->sanitize_platform_slug( $atts['platform'] ?? '' );
+        $platform_limit = $this->sanitize_platform_limit( $atts['platform_limit'] ?? self::DEFAULT_PLATFORM_LIMIT );
+
+        $post_ids = $this->resolve_post_ids( $time_range, $platform_slug );
+        $insights = Helpers::get_posts_score_insights( $post_ids );
+
+        if ( isset( $insights['platform_rankings'] ) && is_array( $insights['platform_rankings'] ) ) {
+            $insights['platform_rankings'] = array_slice( $insights['platform_rankings'], 0, $platform_limit );
+        }
+
+        $time_ranges = $this->get_available_time_ranges();
+        $platforms   = Helpers::get_registered_platform_labels();
+
+        $platform_label = '';
+        if ( $platform_slug !== '' ) {
+            if ( isset( $platforms[ $platform_slug ] ) ) {
+                $platform_label = $platforms[ $platform_slug ];
+            } elseif ( $platform_slug === self::UNKNOWN_PLATFORM_SLUG ) {
+                $platform_label = _x( 'Sans plateforme', 'Fallback platform label', 'notation-jlg' );
+            } else {
+                $platform_label = $this->humanize_slug( $platform_slug );
+            }
+        }
+
+        $context = array(
+            'atts'                  => $atts,
+            'insights'              => $insights,
+            'time_range'            => $time_range,
+            'time_range_label'      => $time_ranges[ $time_range ]['label'] ?? '',
+            'available_time_ranges' => $time_ranges,
+            'platform_slug'         => $platform_slug,
+            'platform_label'        => $platform_label,
+            'platform_limit'        => $platform_limit,
+            'post_ids'              => $post_ids,
+        );
+
+        Frontend::mark_shortcode_rendered( $shortcode );
+
+        return Frontend::get_template_html( 'shortcode-score-insights', $context );
+    }
+
+    private function sanitize_time_range( $value ) {
+        $value      = is_string( $value ) ? $value : '';
+        $value      = trim( strtolower( $value ) );
+        $time_range = $value !== '' ? sanitize_key( $value ) : 'all';
+
+        $ranges = $this->get_available_time_ranges();
+        if ( ! isset( $ranges[ $time_range ] ) ) {
+            return 'all';
+        }
+
+        return $time_range;
+    }
+
+    private function sanitize_platform_slug( $value ) {
+        if ( is_string( $value ) ) {
+            $value = trim( $value );
+        } else {
+            $value = '';
+        }
+
+        if ( $value === '' ) {
+            return '';
+        }
+
+        $slug = sanitize_title( $value );
+        if ( $slug === '' || $slug === 'all' ) {
+            return '';
+        }
+
+        return $slug;
+    }
+
+    private function sanitize_platform_limit( $value ) {
+        if ( is_numeric( $value ) ) {
+            $value = (int) $value;
+        } else {
+            $value = self::DEFAULT_PLATFORM_LIMIT;
+        }
+
+        if ( $value < 1 ) {
+            $value = 1;
+        }
+
+        if ( $value > 10 ) {
+            $value = 10;
+        }
+
+        return $value;
+    }
+
+    private function get_available_time_ranges() {
+        $ranges = array(
+            'all'           => array(
+                'label' => _x( 'Depuis toujours', 'Score insights time range', 'notation-jlg' ),
+                'since' => null,
+            ),
+            'last_30_days'  => array(
+                'label' => _x( '30 derniers jours', 'Score insights time range', 'notation-jlg' ),
+                'since' => '-30 days',
+            ),
+            'last_90_days'  => array(
+                'label' => _x( '90 derniers jours', 'Score insights time range', 'notation-jlg' ),
+                'since' => '-90 days',
+            ),
+            'last_365_days' => array(
+                'label' => _x( '12 derniers mois', 'Score insights time range', 'notation-jlg' ),
+                'since' => '-365 days',
+            ),
+        );
+
+        /**
+         * Permet d'ajouter ou de modifier les plages temporelles proposées.
+         *
+         * @param array $ranges Liste des plages disponibles.
+         */
+        $ranges = apply_filters( 'jlg_score_insights_time_ranges', $ranges );
+
+        if ( ! is_array( $ranges ) ) {
+            return array(
+                'all' => array(
+                    'label' => _x( 'Depuis toujours', 'Score insights time range', 'notation-jlg' ),
+                    'since' => null,
+                ),
+            );
+        }
+
+        // Assurer un label et une clé valide pour chaque entrée.
+        foreach ( $ranges as $key => $range ) {
+            if ( ! is_array( $range ) ) {
+                unset( $ranges[ $key ] );
+                continue;
+            }
+
+            if ( empty( $range['label'] ) || ! is_string( $range['label'] ) ) {
+                $ranges[ $key ]['label'] = ucfirst( str_replace( '_', ' ', sanitize_key( $key ) ) );
+            }
+
+            if ( ! array_key_exists( 'since', $range ) ) {
+                $ranges[ $key ]['since'] = null;
+            }
+        }
+
+        return $ranges;
+    }
+
+    private function resolve_post_ids( $time_range, $platform_slug ) {
+        $post_ids = Helpers::get_rated_post_ids();
+
+        if ( empty( $post_ids ) || ! is_array( $post_ids ) ) {
+            return array();
+        }
+
+        $post_ids = array_values(
+            array_filter(
+                array_map( 'absint', $post_ids ),
+                static function ( $post_id ) {
+                    return $post_id > 0;
+                }
+            )
+        );
+
+        $ranges           = $this->get_available_time_ranges();
+        $range_definition = $ranges[ $time_range ] ?? array();
+        $since_clause     = isset( $range_definition['since'] ) ? $range_definition['since'] : null;
+        $threshold        = null;
+
+        if ( is_string( $since_clause ) && $since_clause !== '' ) {
+            $threshold = $this->get_threshold_timestamp( $since_clause );
+        }
+
+        $filtered = array();
+
+        foreach ( $post_ids as $post_id ) {
+            if ( $threshold !== null ) {
+                $post_timestamp = $this->get_post_timestamp( $post_id );
+                if ( $post_timestamp === null || $post_timestamp < $threshold ) {
+                    continue;
+                }
+            }
+
+            if ( $platform_slug !== '' && ! $this->post_matches_platform( $post_id, $platform_slug ) ) {
+                continue;
+            }
+
+            $filtered[] = $post_id;
+        }
+
+        return $filtered;
+    }
+
+    private function get_threshold_timestamp( $relative_time ) {
+        $relative_time = is_string( $relative_time ) ? trim( $relative_time ) : '';
+        if ( $relative_time === '' ) {
+            return null;
+        }
+
+        try {
+            $timezone = function_exists( 'wp_timezone' ) ? wp_timezone() : new DateTimeZone( 'UTC' );
+        } catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            $timezone = new DateTimeZone( 'UTC' );
+        }
+
+        $now    = new DateTimeImmutable( 'now', $timezone );
+        $target = strtotime( $relative_time, $now->getTimestamp() );
+
+        if ( $target === false ) {
+            return null;
+        }
+
+        return (int) $target;
+    }
+
+    private function get_post_timestamp( $post_id ) {
+        $post_date_gmt = get_post_field( 'post_date_gmt', $post_id );
+        if ( is_string( $post_date_gmt ) && $post_date_gmt !== '' && $post_date_gmt !== '0000-00-00 00:00:00' ) {
+            $timestamp = strtotime( $post_date_gmt . ' GMT' );
+            if ( $timestamp !== false ) {
+                return (int) $timestamp;
+            }
+        }
+
+        $post_date = get_post_field( 'post_date', $post_id );
+        if ( is_string( $post_date ) && $post_date !== '' && $post_date !== '0000-00-00 00:00:00' ) {
+            $timestamp = strtotime( $post_date );
+            if ( $timestamp !== false ) {
+                return (int) $timestamp;
+            }
+        }
+
+        return null;
+    }
+
+    private function post_matches_platform( $post_id, $platform_slug ) {
+        $slugs = $this->get_post_platform_slugs( $post_id );
+
+        if ( empty( $slugs ) ) {
+            return $platform_slug === self::UNKNOWN_PLATFORM_SLUG;
+        }
+
+        return in_array( $platform_slug, $slugs, true );
+    }
+
+    private function get_post_platform_slugs( $post_id ) {
+        $meta   = get_post_meta( $post_id, '_jlg_plateformes', true );
+        $labels = array();
+
+        if ( is_array( $meta ) ) {
+            foreach ( $meta as $value ) {
+                if ( ! is_string( $value ) ) {
+                    continue;
+                }
+
+                $label = sanitize_text_field( $value );
+                if ( $label === '' ) {
+                    continue;
+                }
+
+                $labels[] = $label;
+            }
+        } elseif ( is_string( $meta ) && $meta !== '' ) {
+            $pieces = array_map( 'trim', explode( ',', $meta ) );
+            foreach ( $pieces as $piece ) {
+                if ( $piece === '' ) {
+                    continue;
+                }
+
+                $labels[] = sanitize_text_field( $piece );
+            }
+        }
+
+        if ( empty( $labels ) ) {
+            return array();
+        }
+
+        $slugs = array();
+
+        foreach ( $labels as $label ) {
+            $slug = sanitize_title( $label );
+            if ( $slug === '' ) {
+                $slugs[] = self::UNKNOWN_PLATFORM_SLUG;
+                continue;
+            }
+
+            $slugs[] = $slug;
+        }
+
+        return array_values( array_unique( $slugs ) );
+    }
+
+    private function humanize_slug( $slug ) {
+        $slug = str_replace( array( '-', '_' ), ' ', (string) $slug );
+        $slug = trim( $slug );
+
+        if ( $slug === '' ) {
+            return '';
+        }
+
+        if ( function_exists( 'mb_convert_case' ) ) {
+            return mb_convert_case( $slug, MB_CASE_TITLE, 'UTF-8' );
+        }
+
+        return ucwords( $slug );
+    }
+}

--- a/plugin-notation-jeux_V4/templates/shortcode-score-insights.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-score-insights.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Template pour le shortcode jlg_score_insights.
+ *
+ * Variables disponibles :
+ * - $atts : Attributs du shortcode.
+ * - $insights : Données préparées par Helpers::get_posts_score_insights().
+ * - $time_range : Identifiant de la plage temporelle.
+ * - $time_range_label : Libellé de la plage temporelle.
+ * - $platform_slug : Slug de plateforme filtrée.
+ * - $platform_label : Libellé de la plateforme filtrée.
+ * - $platform_limit : Nombre maximum de plateformes listées.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$atts             = isset( $atts ) && is_array( $atts ) ? $atts : array();
+$insights         = isset( $insights ) && is_array( $insights ) ? $insights : array();
+$time_range_label = isset( $time_range_label ) ? (string) $time_range_label : '';
+$platform_label   = isset( $platform_label ) ? (string) $platform_label : '';
+$platform_slug    = isset( $platform_slug ) ? (string) $platform_slug : '';
+$platform_limit   = isset( $platform_limit ) ? intval( $platform_limit ) : 5;
+
+$total_reviews = isset( $insights['total'] ) ? intval( $insights['total'] ) : 0;
+$mean_value    = $insights['mean']['formatted'] ?? null;
+$median_value  = $insights['median']['formatted'] ?? null;
+$distribution  = isset( $insights['distribution'] ) && is_array( $insights['distribution'] ) ? $insights['distribution'] : array();
+$rankings      = isset( $insights['platform_rankings'] ) && is_array( $insights['platform_rankings'] ) ? $insights['platform_rankings'] : array();
+
+$title = '';
+if ( ! empty( $atts['title'] ) ) {
+    $title = sanitize_text_field( $atts['title'] );
+}
+
+$section_id   = 'jlg-score-insights-' . uniqid();
+$heading_id   = $section_id . '-title';
+$summary_id   = $section_id . '-summary';
+$histogram_id = $section_id . '-histogram';
+$platforms_id = $section_id . '-platforms';
+
+$time_summary_parts = array();
+if ( $time_range_label !== '' ) {
+    $time_summary_parts[] = $time_range_label;
+}
+if ( $platform_label !== '' ) {
+    $time_summary_parts[] = sprintf(
+        /* translators: %s: platform name */
+        __( 'Plateforme : %s', 'notation-jlg' ),
+        $platform_label
+    );
+} elseif ( $platform_slug === '' ) {
+    $time_summary_parts[] = __( 'Toutes les plateformes', 'notation-jlg' );
+}
+$time_summary_text = implode( ' · ', $time_summary_parts );
+?>
+
+<section
+    class="jlg-score-insights"
+    role="region"
+    aria-labelledby="<?php echo esc_attr( $heading_id ); ?>"
+    aria-describedby="<?php echo esc_attr( $summary_id ); ?>"
+    aria-live="polite"
+>
+    <header class="jlg-score-insights__header">
+        <h2 id="<?php echo esc_attr( $heading_id ); ?>" class="jlg-score-insights__title">
+            <?php echo esc_html( $title !== '' ? $title : __( 'Score Insights', 'notation-jlg' ) ); ?>
+        </h2>
+        <p id="<?php echo esc_attr( $summary_id ); ?>" class="jlg-score-insights__meta">
+            <?php
+            echo esc_html(
+                sprintf(
+                    /* translators: 1: summary (time range/platform), 2: total number of reviews. */
+                    __( '%1$s — %2$s tests analysés', 'notation-jlg' ),
+                    $time_summary_text !== '' ? $time_summary_text : __( 'Toutes les périodes', 'notation-jlg' ),
+                    number_format_i18n( $total_reviews )
+                )
+            );
+            ?>
+        </p>
+    </header>
+
+    <?php if ( $total_reviews === 0 ) : ?>
+        <p class="jlg-score-insights__empty" role="status">
+            <?php esc_html_e( 'Aucune note disponible pour ces critères. Ajustez la période ou la plateforme sélectionnée.', 'notation-jlg' ); ?>
+        </p>
+    <?php else : ?>
+        <div class="jlg-score-insights__grid">
+            <div class="jlg-score-insights__stats" aria-live="polite">
+                <h3 class="jlg-score-insights__subtitle">
+                    <?php esc_html_e( 'Tendance centrale', 'notation-jlg' ); ?>
+                </h3>
+                <dl class="jlg-score-insights__figures">
+                    <div class="jlg-score-insights__figure">
+                        <dt><?php esc_html_e( 'Moyenne', 'notation-jlg' ); ?></dt>
+                        <dd>
+                            <?php echo $mean_value !== null ? esc_html( $mean_value ) : '&mdash;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </dd>
+                    </div>
+                    <div class="jlg-score-insights__figure">
+                        <dt><?php esc_html_e( 'Médiane', 'notation-jlg' ); ?></dt>
+                        <dd>
+                            <?php echo $median_value !== null ? esc_html( $median_value ) : '&mdash;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+
+            <div class="jlg-score-insights__histogram" id="<?php echo esc_attr( $histogram_id ); ?>">
+                <h3 class="jlg-score-insights__subtitle">
+                    <?php esc_html_e( 'Répartition des notes', 'notation-jlg' ); ?>
+                </h3>
+                <ul class="jlg-score-insights__buckets" role="list">
+                    <?php foreach ( $distribution as $bucket ) { ?>
+                        <?php
+                        $bucket_label      = isset( $bucket['label'] ) ? (string) $bucket['label'] : '';
+                        $bucket_percentage = isset( $bucket['percentage'] ) ? (float) $bucket['percentage'] : 0.0;
+                        $bucket_count      = isset( $bucket['count'] ) ? intval( $bucket['count'] ) : 0;
+                        $summary_text      = sprintf(
+                            /* translators: 1: score range label, 2: number of reviews, 3: percentage */
+                            __( '%1$s : %2$s tests, %3$s%% des notes', 'notation-jlg' ),
+                            $bucket_label,
+                            number_format_i18n( $bucket_count ),
+                            number_format_i18n( $bucket_percentage, 1 )
+                        );
+                        ?>
+                        <li class="jlg-score-insights__bucket">
+                            <div class="jlg-score-insights__bucket-label"><?php echo esc_html( $bucket_label ); ?></div>
+                            <progress
+                                class="jlg-score-insights__bucket-progress"
+                                max="100"
+                                value="<?php echo esc_attr( $bucket_percentage ); ?>"
+                                aria-label="<?php echo esc_attr( $summary_text ); ?>"
+                            >
+                                <?php echo esc_html( $summary_text ); ?>
+                            </progress>
+                            <div class="jlg-score-insights__bucket-value">
+                                <?php echo esc_html( sprintf( _x( '%1$s%% · %2$s tests', 'Bucket percentage and count', 'notation-jlg' ), number_format_i18n( $bucket_percentage, 1 ), number_format_i18n( $bucket_count ) ) ); ?>
+                            </div>
+                        </li>
+                    <?php } ?>
+                </ul>
+            </div>
+
+            <div class="jlg-score-insights__platforms" id="<?php echo esc_attr( $platforms_id ); ?>">
+                <h3 class="jlg-score-insights__subtitle">
+                    <?php esc_html_e( 'Top plateformes', 'notation-jlg' ); ?>
+                </h3>
+                <?php if ( empty( $rankings ) ) : ?>
+                    <p class="jlg-score-insights__empty-platforms">
+                        <?php esc_html_e( 'Aucune plateforme ne se détache encore sur cette période.', 'notation-jlg' ); ?>
+                    </p>
+                <?php else : ?>
+                    <ol class="jlg-score-insights__platform-list" aria-live="polite">
+                        <?php foreach ( $rankings as $index => $platform ) { ?>
+                            <?php
+                            $label       = isset( $platform['label'] ) ? (string) $platform['label'] : '';
+                            $average     = isset( $platform['average_formatted'] ) ? (string) $platform['average_formatted'] : '';
+                            $count       = isset( $platform['count'] ) ? intval( $platform['count'] ) : 0;
+                            $position    = $index + 1;
+                            $platform_sr = sprintf(
+                                /* translators: 1: ranking position, 2: platform name, 3: average score, 4: number of reviews */
+                                __( '%1$s. %2$s — moyenne %3$s sur %4$s tests', 'notation-jlg' ),
+                                number_format_i18n( $position ),
+                                $label,
+                                $average !== '' ? $average : __( 'N/A', 'notation-jlg' ),
+                                number_format_i18n( $count )
+                            );
+                            ?>
+                            <li class="jlg-score-insights__platform-item">
+                                <span class="jlg-score-insights__platform-rank" aria-hidden="true">
+                                    <?php echo esc_html( number_format_i18n( $position ) ); ?>
+                                </span>
+                                <div class="jlg-score-insights__platform-content">
+                                    <span class="jlg-score-insights__platform-label"><?php echo esc_html( $label ); ?></span>
+                                    <span class="jlg-score-insights__platform-score">
+                                        <?php echo esc_html( $average !== '' ? $average : __( 'N/A', 'notation-jlg' ) ); ?>
+                                    </span>
+                                    <span class="jlg-score-insights__platform-count">
+                                        <?php echo esc_html( sprintf( _n( '%s test', '%s tests', $count, 'notation-jlg' ), number_format_i18n( $count ) ) ); ?>
+                                    </span>
+                                </div>
+                                <span class="screen-reader-text"><?php echo esc_html( $platform_sr ); ?></span>
+                            </li>
+                        <?php } ?>
+                    </ol>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</section>

--- a/plugin-notation-jeux_V4/tests/ShortcodeScoreInsightsTemplateTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeScoreInsightsTemplateTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ShortcodeScoreInsightsTemplateTest extends TestCase
+{
+    public function test_histogram_progress_elements_are_accessible()
+    {
+        $atts = array('title' => 'Score Insights');
+        $insights = array(
+            'total' => 5,
+            'mean' => array(
+                'formatted' => '8,2',
+            ),
+            'median' => array(
+                'formatted' => '8,0',
+            ),
+            'distribution' => array(
+                array(
+                    'label' => '0 – 2',
+                    'count' => 1,
+                    'percentage' => 20.0,
+                ),
+                array(
+                    'label' => '2 – 4',
+                    'count' => 2,
+                    'percentage' => 40.0,
+                ),
+            ),
+            'platform_rankings' => array(
+                array(
+                    'label' => 'PC',
+                    'average_formatted' => '8,5',
+                    'count' => 3,
+                ),
+            ),
+        );
+
+        $time_range = 'last_30_days';
+        $time_range_label = '30 derniers jours';
+        $platform_slug = '';
+        $platform_label = '';
+        $platform_limit = 5;
+
+        ob_start();
+        require dirname(__DIR__) . '/templates/shortcode-score-insights.php';
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('role="region"', $output);
+        $this->assertMatchesRegularExpression('/<progress[^>]*aria-label="[^"]+"/i', $output, 'Histogram buckets should expose accessible aria-labels.');
+        $this->assertMatchesRegularExpression('/<progress[^>]*value="40"/i', $output, 'Histogram buckets should expose numeric progress values.');
+        $this->assertMatchesRegularExpression('/<span class="screen-reader-text">[^<]+PC[^<]+tests/i', $output, 'Platform ranking should provide a screen reader summary.');
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated ScoreInsights shortcode that reuses Helpers::get_posts_score_insights with time range and platform filtering
- provide an accessible front-end template plus block metadata/JS so the new shortcode is available in Gutenberg
- document usage in the docs/README files and cover the template with a PHPUnit accessibility regression test

## Testing
- `composer install`
- `composer test` *(fails: existing suite errors such as undefined WP_Query::$args and GameInfo shortcode expectations)*
- `composer cs` *(fails: repository already contains numerous coding standards violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a95613d8832e9c0adfcbf7929c31