### PR TITLE
Add reader ratings to Game Explorer cards

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -63,7 +63,13 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - `[jlg_points_forts_faibles]` - Points positifs et négatifs
 - `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs avec histogramme dynamique (barres accessibles ARIA, mise à jour en temps réel après chaque vote)
 - `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les en-têtes permettent désormais de trier par titre, date, note moyenne ainsi que par métadonnées développeur/éditeur via les paramètres `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
-- `[jlg_game_explorer]` - Game Explorer interactif affichant vos tests sous forme de cartes. Attributs disponibles : `posts_per_page` (nombre d'entrées par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour préfiltrer le rendu. La navigation (lettres, filtres, tri et pagination) fonctionne désormais également sans JavaScript via des requêtes GET accessibles. Sur mobile, les filtres sont regroupés dans un panneau masquable pour laisser plus d'espace aux résultats tout en restant utilisables sans JavaScript.
+- `[jlg_game_explorer]` - Game Explorer interactif affichant vos tests sous forme de cartes. Attributs disponibles : `posts_per_page` (nombre d'entrées par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour préfiltrer le rendu. La navigation (lettres, filtres, tri et pagination) fonctionne désormais également sans JavaScript via des requêtes GET accessibles. Sur mobile, les filtres sont regroupés dans un panneau masquable pour laisser plus d'espace aux résultats tout en restant utilisables sans JavaScript. Les cartes affichent côte à côte la note de la rédaction et, lorsque le module **Notation utilisateurs** est actif, la moyenne et le volume de votes lecteurs avec un intitulé ARIA explicite.
+
+#### FAQ — Afficher la note des lecteurs dans le Game Explorer
+
+1. Activez l'option **Notation utilisateurs** depuis `Notation JLG > Réglages` (onglet *Modules*). Les votes déposés via le shortcode `[notation_utilisateurs_jlg]` mettent à jour automatiquement les métadonnées `_jlg_user_rating_avg` et `_jlg_user_rating_count`.
+2. Insérez `[jlg_game_explorer]` dans une page ou un modèle : le Game Explorer lit ces métadonnées et ajoute un badge « Lecteurs » avec la moyenne /5 et le nombre d'avis. En l'absence de votes, un état « Aucun vote » est annoncé.
+3. Les deux badges sont groupés avec `role="group"` et un libellé ARIA décrivant la comparaison des notes afin que lecteurs et lecteurs d'écran perçoivent simultanément la note rédactionnelle et la moyenne communautaire.
 
 ### Utilisation dans les widgets et blocs
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -60,7 +60,13 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * `[jlg_points_forts_faibles]` - Points positifs et négatifs
 * `[notation_utilisateurs_jlg]` - Système de vote pour les lecteurs avec histogramme dynamique (barres accessibles ARIA, mise à jour en temps réel après chaque vote)
 * `[jlg_tableau_recap]` - Tableau/grille récapitulatif. Les entêtes sont triables par titre, date, note moyenne et métadonnées développeur/éditeur via `orderby=title`, `orderby=average_score`, `orderby=meta__jlg_developpeur` ou `orderby=meta__jlg_editeur`.
-* `[jlg_game_explorer]` - Game Explorer interactif avec cartes et filtres dynamiques. Attributs : `posts_per_page` (nombre d'articles par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour forcer un filtrage initial. La navigation (lettres, filtres, tri et pagination) reste pleinement fonctionnelle sans JavaScript grâce à des requêtes GET accessibles. Sur mobile, les filtres se replient dans un panneau masquable pour libérer l'écran tout en conservant l'accessibilité sans JavaScript.
+* `[jlg_game_explorer]` - Game Explorer interactif avec cartes et filtres dynamiques. Attributs : `posts_per_page` (nombre d'articles par page), `columns` (2 à 4 colonnes), `filters` (liste séparée par des virgules parmi `letter`, `category`, `platform`, `developer`, `publisher`, `availability`), `categorie`, `plateforme` et `lettre` pour forcer un filtrage initial. La navigation (lettres, filtres, tri et pagination) reste pleinement fonctionnelle sans JavaScript grâce à des requêtes GET accessibles. Sur mobile, les filtres se replient dans un panneau masquable pour libérer l'écran tout en conservant l'accessibilité sans JavaScript. Les cartes juxtaposent désormais la note rédactionnelle et, si le module **Notation utilisateurs** est activé, la moyenne/5 ainsi que le volume de votes lecteurs avec un intitulé ARIA dédié.
+
+=== FAQ — Afficher la note des lecteurs dans le Game Explorer ===
+
+1. Activez l'option **Notation utilisateurs** dans `Notation JLG > Réglages` (onglet *Modules*). Les votes saisis via `[notation_utilisateurs_jlg]` alimentent les métadonnées `_jlg_user_rating_avg` et `_jlg_user_rating_count`.
+2. Ajoutez `[jlg_game_explorer]` sur une page ou un modèle. Le shortcode lit automatiquement ces valeurs pour afficher un badge « Lecteurs » /5 avec le nombre d'avis, ou « Aucun vote » tant qu'aucun retour n'est enregistré.
+3. Les badges « Rédaction » et « Lecteurs » sont regroupés avec `role="group"` et une description ARIA afin d'annoncer clairement la comparaison des notes aux technologies d'assistance.
 
 == Utilisation dans les widgets et blocs ==
 

--- a/plugin-notation-jeux_V4/assets/css/game-explorer.css
+++ b/plugin-notation-jeux_V4/assets/css/game-explorer.css
@@ -5,6 +5,7 @@
     --jlg-ge-text-muted: #9ca3af;
     --jlg-ge-accent: #60a5fa;
     --jlg-ge-accent-alt: #c084fc;
+    --jlg-ge-user-rating-color: #f59e0b;
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
@@ -344,75 +345,125 @@
     padding: 0.75rem;
 }
 
-.jlg-ge-card__score {
+.jlg-ge-card__ratings {
     position: absolute;
-    background: linear-gradient(135deg, var(--jlg-ge-accent), var(--jlg-ge-accent-alt));
-    color: #0f172a;
-    font-weight: 700;
-    padding: 0.45rem 0.75rem;
-    border-radius: 9999px;
-    font-size: 1rem;
-    box-shadow: 0 0 25px rgba(96, 165, 250, 0.3);
-    transform: none;
-    max-width: calc(100% - 1.5rem);
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    z-index: 2;
+    width: calc(100% - 1.5rem);
 }
 
-.jlg-ge-card__score--top-left,
-.jlg-ge-card__score--middle-left,
-.jlg-ge-card__score--bottom-left {
+.jlg-ge-card__ratings--top-left,
+.jlg-ge-card__ratings--middle-left,
+.jlg-ge-card__ratings--bottom-left {
     left: 0.75rem;
-    right: auto;
+    align-items: flex-start;
 }
 
-.jlg-ge-card__score--top-right,
-.jlg-ge-card__score--middle-right,
-.jlg-ge-card__score--bottom-right {
+.jlg-ge-card__ratings--top-right,
+.jlg-ge-card__ratings--middle-right,
+.jlg-ge-card__ratings--bottom-right {
     right: 0.75rem;
-    left: auto;
+    align-items: flex-end;
 }
 
-.jlg-ge-card__score--top-left,
-.jlg-ge-card__score--top-right {
+.jlg-ge-card__ratings--top-left,
+.jlg-ge-card__ratings--top-right {
     top: 0.75rem;
-    bottom: auto;
-    transform: none;
 }
 
-.jlg-ge-card__score--bottom-left,
-.jlg-ge-card__score--bottom-right {
+.jlg-ge-card__ratings--bottom-left,
+.jlg-ge-card__ratings--bottom-right {
     bottom: 0.75rem;
-    top: auto;
-    transform: none;
 }
 
-.jlg-ge-card__score--middle-left,
-.jlg-ge-card__score--middle-right {
+.jlg-ge-card__ratings--middle-left,
+.jlg-ge-card__ratings--middle-right {
     top: 50%;
-    bottom: auto;
     transform: translateY(-50%);
 }
 
-@media (max-width: 640px) {
-    .jlg-ge-card__score {
-        font-size: 0.9rem;
-        padding: 0.4rem 0.65rem;
-    }
+.jlg-ge-card__score {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    background: linear-gradient(135deg, var(--jlg-ge-score-color, var(--jlg-ge-accent)), var(--jlg-ge-accent-alt));
+    color: #0f172a;
+    font-weight: 700;
+    padding: 0.5rem 0.8rem;
+    border-radius: 1rem;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+    min-width: 7rem;
+}
+
+.jlg-ge-card__ratings--top-right .jlg-ge-card__score,
+.jlg-ge-card__ratings--middle-right .jlg-ge-card__score,
+.jlg-ge-card__ratings--bottom-right .jlg-ge-card__score {
+    align-items: flex-end;
+    text-align: right;
+}
+
+.jlg-ge-card__score--readers {
+    background: linear-gradient(135deg, var(--jlg-ge-score-color, var(--jlg-ge-user-rating-color)), rgba(96, 165, 250, 0.75));
+    box-shadow: 0 12px 30px rgba(192, 132, 252, 0.25);
 }
 
 .jlg-ge-card__score::before {
     content: '';
     position: absolute;
     inset: 0;
-    border-radius: 9999px;
+    border-radius: inherit;
     background: var(--jlg-ge-score-color, var(--jlg-ge-accent));
-    opacity: 0.25;
+    opacity: 0.18;
     z-index: -1;
 }
 
-.jlg-ge-card__score-outof {
+.jlg-ge-card__score-label {
     font-size: 0.7rem;
-    margin-left: 0.15rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    opacity: 0.85;
+}
+
+.jlg-ge-card__score-main {
+    display: flex;
+    align-items: baseline;
+    gap: 0.2rem;
+}
+
+.jlg-ge-card__score-value {
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.jlg-ge-card__score-outof {
+    font-size: 0.75rem;
+    opacity: 0.85;
+}
+
+.jlg-ge-card__score-extra {
+    font-size: 0.7rem;
+    font-weight: 500;
+    opacity: 0.9;
+}
+
+@media (max-width: 640px) {
+    .jlg-ge-card__ratings {
+        gap: 0.3rem;
+        width: calc(100% - 1rem);
+    }
+
+    .jlg-ge-card__score {
+        padding: 0.45rem 0.65rem;
+        min-width: 0;
+    }
+
+    .jlg-ge-card__score-value {
+        font-size: 1.1rem;
+    }
 }
 
 .jlg-ge-card__body {

--- a/plugin-notation-jeux_V4/docs/benchmark-2024-05-15.md
+++ b/plugin-notation-jeux_V4/docs/benchmark-2024-05-15.md
@@ -1,0 +1,14 @@
+# Benchmark Game Explorer — 2024-05-15
+
+## Références analysées
+- **IGN.com** – Les fiches jeux affichent la note de la rédaction et la moyenne des lecteurs dans deux encarts visuellement proches mais sans liaison explicite pour les lecteurs d'écran.
+- **OpenCritic.com** – Les pages synthèse mêlent score "Top Critic" et appréciation des joueurs via un histogramme, mais la densité d'information rend la hiérarchie peu lisible sur mobile.
+
+## Enseignements
+- Les deux plateformes placent les scores éditoriaux et communautaires dans la même zone visuelle, ce qui facilite la comparaison immédiate.
+- L'accessibilité reste perfectible : absence d'attributs ARIA contextualisant les deux notes, et contraste parfois insuffisant sur les badges secondaires.
+
+## Décisions pour WP Notation Jeux
+- Juxtaposer la note rédactionnelle et la moyenne des lecteurs au sein du Game Explorer, avec `role="group"` et libellés ARIA explicites pour annoncer la comparaison.
+- Afficher le volume d'avis afin d'éviter toute interprétation trompeuse d'une moyenne basée sur peu de votes.
+- Conserver une mise en page compacte et responsive pour éviter la surcharge visuelle observée sur OpenCritic, tout en réutilisant la palette du plugin.

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -11,7 +11,7 @@ use JLG\Notation\Helpers;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class GameExplorer {
@@ -231,7 +231,7 @@ class GameExplorer {
             Helpers::get_default_game_explorer_filters()
         );
 
-        $filters = implode( ',', $filters_list );
+        $filters        = implode( ',', $filters_list );
         $score_position = Helpers::normalize_game_explorer_score_position(
             $options['game_explorer_score_position'] ?? ''
         );
@@ -315,7 +315,7 @@ class GameExplorer {
     }
 
     protected static function normalize_filters( $filters_string ) {
-        $allowed        = Helpers::get_game_explorer_allowed_filters();
+        $allowed         = Helpers::get_game_explorer_allowed_filters();
         $default_filters = Helpers::get_default_game_explorer_filters();
         $list            = Helpers::normalize_game_explorer_filters( $filters_string, $default_filters );
 
@@ -604,12 +604,12 @@ class GameExplorer {
 
     protected static function build_filters_snapshot() {
         $snapshot = array(
-            'posts'           => array(),
-            'letters_map'     => array(),
-            'categories_map'  => array(),
-            'platforms_map'   => array(),
-            'developers_map'  => array(),
-            'publishers_map'  => array(),
+            'posts'          => array(),
+            'letters_map'    => array(),
+            'categories_map' => array(),
+            'platforms_map'  => array(),
+            'developers_map' => array(),
+            'publishers_map' => array(),
         );
 
         $rated_posts = Helpers::get_rated_post_ids();
@@ -954,7 +954,7 @@ class GameExplorer {
             }
         }
 
-        $developers_map  = isset( $snapshot['developers_map'] ) && is_array( $snapshot['developers_map'] ) ? $snapshot['developers_map'] : array();
+        $developers_map = isset( $snapshot['developers_map'] ) && is_array( $snapshot['developers_map'] ) ? $snapshot['developers_map'] : array();
         if ( $developer_filter_key !== '' && $developer_filter !== '' && ! isset( $developers_map[ $developer_filter_key ] ) ) {
             $developers_map[ $developer_filter_key ] = $developer_filter;
         }
@@ -970,7 +970,7 @@ class GameExplorer {
             }
         }
 
-        $publishers_map  = isset( $snapshot['publishers_map'] ) && is_array( $snapshot['publishers_map'] ) ? $snapshot['publishers_map'] : array();
+        $publishers_map = isset( $snapshot['publishers_map'] ) && is_array( $snapshot['publishers_map'] ) ? $snapshot['publishers_map'] : array();
         if ( $publisher_filter_key !== '' && $publisher_filter !== '' && ! isset( $publishers_map[ $publisher_filter_key ] ) ) {
             $publishers_map[ $publisher_filter_key ] = $publisher_filter;
         }
@@ -1166,17 +1166,17 @@ class GameExplorer {
 
             if ( $has_popularity_meta ) {
                 $query_args['meta_query'] = array(
-                    'relation'                        => 'OR',
-                    'popularity_clause'               => array(
+                    'relation'                  => 'OR',
+                    'popularity_clause'         => array(
                         'key'  => $popularity_meta_key,
                         'type' => 'NUMERIC',
                     ),
-                    'popularity_missing_clause'       => array(
+                    'popularity_missing_clause' => array(
                         'key'     => $popularity_meta_key,
                         'compare' => 'NOT EXISTS',
                     ),
                 );
-                $query_args['orderby'] = array(
+                $query_args['orderby']    = array(
                     'popularity_clause' => $order,
                     'date'              => 'DESC',
                 );
@@ -1209,6 +1209,34 @@ class GameExplorer {
                 $score_color   = $score_value !== null
                     ? Helpers::calculate_color_from_note( $score_value, $options )
                     : ( $options['color_mid'] ?? '#f97316' );
+
+                $user_rating_avg_meta = get_post_meta( $post_id, '_jlg_user_rating_avg', true );
+                $user_rating_avg      = is_numeric( $user_rating_avg_meta ) ? (float) $user_rating_avg_meta : null;
+                $user_rating_count    = (int) get_post_meta( $post_id, '_jlg_user_rating_count', true );
+
+                $user_rating_bounds = apply_filters(
+                    'jlg_user_rating_bounds',
+                    array(
+                        'min' => 1.0,
+                        'max' => 5.0,
+                    ),
+                    $post_id
+                );
+
+                $user_rating_min = isset( $user_rating_bounds['min'] )
+                    ? (float) $user_rating_bounds['min']
+                    : 1.0;
+                $user_rating_max = isset( $user_rating_bounds['max'] )
+                    ? (float) $user_rating_bounds['max']
+                    : 5.0;
+
+                $user_rating_color = '';
+                if ( isset( $options['user_rating_star_color'] ) && is_string( $options['user_rating_star_color'] ) ) {
+                    $user_rating_color = sanitize_hex_color( $options['user_rating_star_color'] );
+                }
+                if ( ! $user_rating_color ) {
+                    $user_rating_color = '#f59e0b';
+                }
 
                 $cover_meta = get_post_meta( $post_id, '_jlg_cover_image_url', true );
                 $cover_url  = '';
@@ -1271,6 +1299,11 @@ class GameExplorer {
                     'availability_label' => $availability_data['label'],
                     'timestamp'          => get_post_time( 'U', true, $post ),
                     'search_haystack'    => isset( $post_info['search_haystack'] ) ? $post_info['search_haystack'] : '',
+                    'user_rating_avg'    => $user_rating_avg,
+                    'user_rating_count'  => $user_rating_count,
+                    'user_rating_min'    => $user_rating_min,
+                    'user_rating_max'    => $user_rating_max,
+                    'user_rating_color'  => $user_rating_color,
                 );
             }
             wp_reset_postdata();

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameInfo.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameInfo.php
@@ -4,9 +4,10 @@ namespace JLG\Notation\Shortcodes;
 
 use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
+use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class GameInfo {
@@ -31,9 +32,9 @@ class GameInfo {
         $default_fields_order = implode( ',', array_keys( $all_possible_fields ) );
         $atts                 = shortcode_atts(
             array(
-				'titre'   => 'Fiche Technique',
-				'champs'  => $default_fields_order,
-				'post_id' => '',
+                'titre'   => 'Fiche Technique',
+                'champs'  => $default_fields_order,
+                'post_id' => '',
             ),
             $atts,
             'jlg_fiche_technique'
@@ -71,9 +72,9 @@ class GameInfo {
         return Frontend::get_template_html(
             'shortcode-game-info',
             array(
-				'titre'             => sanitize_text_field( $atts['titre'] ),
-				'champs_a_afficher' => $data_to_display,
-			)
+                'titre'             => sanitize_text_field( $atts['titre'] ),
+                'champs_a_afficher' => $data_to_display,
+            )
         );
     }
 

--- a/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
@@ -23,6 +23,7 @@ if (!function_exists('_n')) {
 if (!class_exists('WP_Query')) {
     class WP_Query
     {
+        public $args = [];
         public $posts = [];
         public $post_count = 0;
         public $found_posts = 0;
@@ -32,6 +33,7 @@ if (!class_exists('WP_Query')) {
 
         public function __construct($args = [])
         {
+            $this->args = is_array($args) ? $args : [];
             $post_ids = isset($args['post__in']) ? (array) $args['post__in'] : [];
             $per_page = isset($args['posts_per_page']) ? (int) $args['posts_per_page'] : count($post_ids);
             $all_posts = $GLOBALS['jlg_test_posts'] ?? [];

--- a/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendGameExplorerAjaxTest.php
@@ -260,6 +260,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Alpha',
                 '_jlg_editeur'         => 'Publisher A',
                 '_jlg_plateformes'     => ['PC', 'PlayStation 5'],
+                '_jlg_user_rating_avg'   => 4.4,
+                '_jlg_user_rating_count' => 58,
             ],
             202 => [
                 '_jlg_average_score'   => 7.4,
@@ -268,6 +270,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Beta',
                 '_jlg_editeur'         => 'Publisher B',
                 '_jlg_plateformes'     => ['PC'],
+                '_jlg_user_rating_avg'   => 3.7,
+                '_jlg_user_rating_count' => 24,
             ],
         ];
 
@@ -484,6 +488,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Alpha',
                 '_jlg_editeur'         => 'Publisher A',
                 '_jlg_plateformes'     => ['PC', 'PlayStation 5'],
+                '_jlg_user_rating_avg'   => 4.8,
+                '_jlg_user_rating_count' => 80,
             ],
             202 => [
                 '_jlg_average_score'   => 7.4,
@@ -492,6 +498,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Beta',
                 '_jlg_editeur'         => 'Publisher B',
                 '_jlg_plateformes'     => ['PC'],
+                '_jlg_user_rating_avg'   => 3.2,
+                '_jlg_user_rating_count' => 9,
             ],
         ];
 
@@ -532,6 +540,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Alpha',
                 '_jlg_editeur'         => 'Publisher A',
                 '_jlg_plateformes'     => ['PC', 'PlayStation 5'],
+                '_jlg_user_rating_avg'   => 4.3,
+                '_jlg_user_rating_count' => 61,
             ],
             202 => [
                 '_jlg_average_score'   => 7.2,
@@ -540,6 +550,8 @@ class FrontendGameExplorerAjaxTest extends TestCase
                 '_jlg_developpeur'     => 'Studio Beta',
                 '_jlg_editeur'         => 'Publisher B',
                 '_jlg_plateformes'     => ['PC'],
+                '_jlg_user_rating_avg'   => 3.9,
+                '_jlg_user_rating_count' => 18,
             ],
         ];
 
@@ -556,7 +568,7 @@ class FrontendGameExplorerAjaxTest extends TestCase
 
         $defaultResponse = $this->dispatchExplorerAjax($basePost);
         $this->assertArrayHasKey('html', $defaultResponse);
-        $this->assertStringContainsString('jlg-ge-card__score--bottom-right', $defaultResponse['html']);
+        $this->assertStringContainsString('jlg-ge-card__ratings--bottom-right', $defaultResponse['html']);
         $this->assertSame('bottom-right', $defaultResponse['config']['atts']['score_position'] ?? null);
 
         $GLOBALS['jlg_test_options']['notation_jlg_settings']['game_explorer_score_position'] = 'top-left';
@@ -564,7 +576,7 @@ class FrontendGameExplorerAjaxTest extends TestCase
 
         $topLeftResponse = $this->dispatchExplorerAjax($basePost);
         $this->assertArrayHasKey('html', $topLeftResponse);
-        $this->assertStringContainsString('jlg-ge-card__score--top-left', $topLeftResponse['html']);
+        $this->assertStringContainsString('jlg-ge-card__ratings--top-left', $topLeftResponse['html']);
         $this->assertSame('top-left', $topLeftResponse['config']['atts']['score_position'] ?? null);
 
         $overridePost = $basePost;
@@ -572,8 +584,60 @@ class FrontendGameExplorerAjaxTest extends TestCase
 
         $overrideResponse = $this->dispatchExplorerAjax($overridePost);
         $this->assertArrayHasKey('html', $overrideResponse);
-        $this->assertStringContainsString('jlg-ge-card__score--middle-right', $overrideResponse['html']);
+        $this->assertStringContainsString('jlg-ge-card__ratings--middle-right', $overrideResponse['html']);
         $this->assertSame('middle-right', $overrideResponse['config']['atts']['score_position'] ?? null);
+    }
+
+    public function test_render_context_exposes_user_rating_payload(): void
+    {
+        $this->configureOptions();
+        $this->primeSnapshot($this->buildSnapshotWithPosts());
+
+        $this->registerPost(101, 'Alpha Quest', 'Alpha content for user ratings.', '2023-01-01 10:00:00');
+        $this->registerPost(202, 'Beta Strike', 'Beta content for user ratings.', '2023-01-05 11:30:00');
+
+        $GLOBALS['jlg_test_meta'] = [
+            101 => [
+                '_jlg_game_title'        => 'Alpha Quest',
+                '_jlg_average_score'     => 8.4,
+                '_jlg_cover_image_url'   => 'https://example.com/alpha.jpg',
+                '_jlg_date_sortie'       => '2023-02-14',
+                '_jlg_developpeur'       => 'Studio Alpha',
+                '_jlg_editeur'           => 'Publisher A',
+                '_jlg_plateformes'       => ['PC', 'PlayStation 5'],
+                '_jlg_user_rating_avg'   => 4.6,
+                '_jlg_user_rating_count' => 42,
+            ],
+            202 => [
+                '_jlg_game_title'        => 'Beta Strike',
+                '_jlg_average_score'     => 7.1,
+                '_jlg_cover_image_url'   => '',
+                '_jlg_date_sortie'       => '2022-11-10',
+                '_jlg_developpeur'       => 'Studio Beta',
+                '_jlg_editeur'           => 'Publisher B',
+                '_jlg_plateformes'       => ['PC'],
+                '_jlg_user_rating_avg'   => 0,
+                '_jlg_user_rating_count' => 0,
+            ],
+        ];
+
+        $atts = \JLG\Notation\Shortcodes\GameExplorer::get_default_atts();
+        $request = [
+            'orderby' => 'date',
+            'order'   => 'DESC',
+        ];
+
+        $context = \JLG\Notation\Shortcodes\GameExplorer::get_render_context($atts, $request);
+
+        $this->assertNotEmpty($context['games'], 'At least one game should be present in the render context.');
+
+        $firstGame = $context['games'][0];
+        $this->assertArrayHasKey('user_rating_avg', $firstGame);
+        $this->assertArrayHasKey('user_rating_count', $firstGame);
+        $this->assertArrayHasKey('user_rating_max', $firstGame);
+        $this->assertSame(4.6, $firstGame['user_rating_avg']);
+        $this->assertSame(42, $firstGame['user_rating_count']);
+        $this->assertSame(5.0, $firstGame['user_rating_max']);
     }
 
     private function dispatchExplorerAjax(array $post): array

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerScoreDisplayTest.php
@@ -8,6 +8,13 @@ if (!function_exists('wp_json_encode')) {
     }
 }
 
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain = 'default')
+    {
+        return $number === 1 ? $single : $plural;
+    }
+}
+
 require_once __DIR__ . '/../includes/Frontend.php';
 
 class ShortcodeGameExplorerScoreDisplayTest extends TestCase
@@ -18,10 +25,12 @@ class ShortcodeGameExplorerScoreDisplayTest extends TestCase
             'score_display' => 'N/A',
             'score_value' => null,
             'has_score' => false,
+            'user_rating_count' => 0,
+            'user_rating_avg' => null,
         ]);
 
         $this->assertStringContainsString(
-            'jlg-ge-card__score',
+            'jlg-ge-card__ratings',
             $output,
             'The score container should still be rendered even without a numeric score.'
         );
@@ -39,15 +48,51 @@ class ShortcodeGameExplorerScoreDisplayTest extends TestCase
             'score_display' => '8.5',
             'score_value' => 8.5,
             'has_score' => true,
+            'user_rating_count' => 0,
         ]);
 
         $score_max_label = number_format_i18n( \JLG\Notation\Helpers::get_score_max() );
-        $pattern         = '/<span class="jlg-ge-card__score-outof">\s*\/' . preg_quote( $score_max_label, '/' ) . '<\/span>/';
 
-        $this->assertMatchesRegularExpression(
-            $pattern,
+        $this->assertStringContainsString(
+            '/' . $score_max_label,
             $output,
             'The score suffix should be rendered when a numeric score is available.'
+        );
+
+        $this->assertStringContainsString(
+            'Aucun vote',
+            $output,
+            'When no audience votes exist the template should surface the placeholder label.'
+        );
+    }
+
+    public function test_displays_reader_score_with_vote_count(): void
+    {
+        $output = $this->renderExplorerWithGame([
+            'user_rating_avg' => 4.2,
+            'user_rating_count' => 37,
+            'user_rating_max' => 5.0,
+        ]);
+
+        $this->assertStringContainsString(
+            'Lecteurs',
+            $output,
+            'Reader badge label should be rendered when ratings are available.'
+        );
+
+        $this->assertStringContainsString(
+            '/5',
+            $output,
+            'Reader badge should display the rating scale when votes are present.'
+        );
+
+        $this->assertStringContainsString(
+            sprintf(
+                _n('%s vote', '%s votes', 37, 'notation-jlg'),
+                number_format_i18n(37)
+            ),
+            $output,
+            'The vote counter should be announced next to the reader badge.'
         );
     }
 
@@ -71,6 +116,11 @@ class ShortcodeGameExplorerScoreDisplayTest extends TestCase
                 'availability_label' => '',
                 'availability' => '',
                 'excerpt' => '',
+                'user_rating_avg' => null,
+                'user_rating_count' => 0,
+                'user_rating_min' => 1.0,
+                'user_rating_max' => 5.0,
+                'user_rating_color' => '#f59e0b',
             ],
             $overrides
         );


### PR DESCRIPTION
## Summary
- load the `_jlg_user_rating_*` metadata in the Game Explorer shortcode payload and expose the values to the fragment template
- render paired editorial and reader score badges with updated ARIA labelling, palette adjustments, and documented guidance for enabling the option
- extend PHPUnit coverage for the shortcode context and template output while adding the latest benchmark notes

## Testing
- composer test
- composer cs -- includes/Shortcodes/GameExplorer.php includes/Shortcodes/GameInfo.php templates/game-explorer-fragment.php

------
https://chatgpt.com/codex/tasks/task_e_68e1a44f4074832e85b3ec4f460ad979