### PR TITLE
Fix Validator reflection imports

### DIFF
--- a/plugin-notation-jeux_V4/includes/Utils/Validator.php
+++ b/plugin-notation-jeux_V4/includes/Utils/Validator.php
@@ -4,8 +4,6 @@ namespace JLG\Notation\Utils;
 
 use DateTime;
 use JLG\Notation\Helpers;
-use ReflectionException;
-use ReflectionMethod;
 
 if ( ! defined( 'ABSPATH' ) ) {
 exit;
@@ -184,14 +182,14 @@ class Validator {
                 $default_definitions = \JLG\Notation\Helpers::get_default_platform_definitions();
             } else {
                 try {
-                    $reflection = new ReflectionMethod( \JLG\Notation\Helpers::class, 'get_default_platform_definitions' );
+                    $reflection = new \ReflectionMethod( \JLG\Notation\Helpers::class, 'get_default_platform_definitions' );
 
                     if ( ! $reflection->isPublic() ) {
                         $reflection->setAccessible( true );
                     }
 
                     $default_definitions = $reflection->invoke( null );
-                } catch ( ReflectionException $exception ) {
+                } catch ( \ReflectionException $exception ) {
                     $default_definitions = array();
                 }
             }


### PR DESCRIPTION
## Summary
- qualify the Reflection API usage in the validator helper to ensure it resolves in the plugin namespace

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e24e565bec832ebf83ca09e7c6bfbb