### PR TITLE
Add editor placeholder skeleton for rating block

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/blocks-editor.css
+++ b/plugin-notation-jeux_V4/assets/css/blocks-editor.css
@@ -66,3 +66,52 @@
     font-style: italic;
     text-align: center;
 }
+
+.editor-styles-wrapper .jlg-rating-block-placeholder {
+    margin: 0;
+}
+
+.editor-styles-wrapper .jlg-rating-placeholder-notice {
+    margin: 0 0 16px;
+    font-size: 13px;
+    font-style: italic;
+    color: #6b7280;
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder {
+    --jlg-bg-color: rgba(248, 250, 252, 0.85);
+    --jlg-border-color: rgba(148, 163, 184, 0.65);
+    --jlg-main-text-color: #52525b;
+    --jlg-secondary-text-color: #94a3b8;
+    --jlg-bar-bg-color: rgba(226, 232, 240, 0.7);
+    --jlg-score-gradient-1: #d4d4d8;
+    --jlg-score-gradient-2: #a1a1aa;
+    border-style: dashed;
+    box-shadow: none;
+    pointer-events: none;
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder .score-value {
+    background: none;
+    -webkit-text-fill-color: currentColor;
+    color: var(--jlg-main-text-color);
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder .rating-bar {
+    background-color: rgba(156, 163, 175, 0.65);
+    transition: none;
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder .rating-badge {
+    background: rgba(226, 232, 240, 0.6);
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    color: var(--jlg-main-text-color);
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder .user-rating-summary {
+    color: var(--jlg-main-text-color);
+}
+
+.editor-styles-wrapper .review-box-jlg.is-placeholder hr {
+    background-color: rgba(203, 213, 225, 0.8);
+}

--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -11,6 +11,55 @@
     box-shadow: 0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -2px rgba(0,0,0,.05);
 }
 
+.jlg-rating-block-placeholder {
+    margin: 0;
+}
+
+.jlg-rating-placeholder-notice {
+    margin: 0 0 16px;
+    font-size: 0.875rem;
+    font-style: italic;
+    color: #64748b;
+}
+
+.review-box-jlg.is-placeholder {
+    --jlg-bg-color: rgba(248, 250, 252, 0.85);
+    --jlg-border-color: rgba(148, 163, 184, 0.65);
+    --jlg-main-text-color: #52525b;
+    --jlg-secondary-text-color: #94a3b8;
+    --jlg-bar-bg-color: rgba(226, 232, 240, 0.7);
+    --jlg-score-gradient-1: #d4d4d8;
+    --jlg-score-gradient-2: #a1a1aa;
+    border-style: dashed;
+    box-shadow: none;
+    pointer-events: none;
+}
+
+.review-box-jlg.is-placeholder .score-value {
+    background: none;
+    -webkit-text-fill-color: currentColor;
+    color: var(--jlg-main-text-color);
+}
+
+.review-box-jlg.is-placeholder .rating-bar {
+    background-color: rgba(156, 163, 175, 0.65);
+    transition: none;
+}
+
+.review-box-jlg.is-placeholder .rating-badge {
+    background: rgba(226, 232, 240, 0.6);
+    border: 1px dashed rgba(148, 163, 184, 0.6);
+    color: var(--jlg-main-text-color);
+}
+
+.review-box-jlg.is-placeholder .user-rating-summary {
+    color: var(--jlg-main-text-color);
+}
+
+.review-box-jlg.is-placeholder hr {
+    background-color: rgba(203, 213, 225, 0.8);
+}
+
 .wp-block-notation-jlg-rating-block.alignwide .review-box-jlg,
 .wp-block-notation-jlg-rating-block.alignfull .review-box-jlg {
     max-width: none;

--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-09-23T11:27:06+00:00\n"
+"POT-Creation-Date: 2025-10-19T00:00:00+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: notation-jlg\n"
@@ -743,11 +743,32 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:51
-#: templates/shortcode-all-in-one.php:55
-#: templates/shortcode-rating-block.php:22
-#: templates/shortcode-rating-block.php:27
+#: templates/shortcode-all-in-one.php:51 templates/shortcode-all-in-one.php:55
+#: templates/shortcode-rating-block.php:22 templates/shortcode-rating-block.php:27
+#: templates/shortcode-rating-block-empty.php:140
+#: templates/shortcode-rating-block-empty.php:145
 msgid "Note Globale"
+msgstr ""
+
+#: templates/shortcode-rating-block.php:142
+#: templates/shortcode-rating-block-empty.php:150
+msgid "Sélection de la rédaction"
+msgstr ""
+
+#: templates/shortcode-rating-block.php:148
+#: templates/shortcode-rating-block-empty.php:153
+msgid "Note des lecteurs"
+msgstr ""
+
+#. translators: %s: difference between reader and editorial scores.
+#: templates/shortcode-rating-block.php:170
+#: templates/shortcode-rating-block-empty.php:170
+#, php-format
+msgid "Δ vs rédaction : %s"
+msgstr ""
+
+#: templates/shortcode-rating-block-empty.php:134
+msgid "Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes."
 msgstr ""
 
 #. translators: Section title for the list of advantages in the pros and cons block.
@@ -762,6 +783,8 @@ msgstr ""
 
 #. translators: 1: Rating value for a specific category. 2: Maximum possible rating.
 #: templates/shortcode-rating-block.php:46
+#: templates/shortcode-rating-block-empty.php:159
+#: templates/shortcode-rating-block-empty.php:205
 #, php-format
 msgid "%1$s / %2$s"
 msgstr ""
@@ -838,6 +861,7 @@ msgstr ""
 
 #: templates/shortcode-all-in-one.php:36
 #: templates/shortcode-rating-block.php:63
+#: templates/shortcode-rating-block-empty.php:124
 msgctxt "global percentage score"
 msgid "%s %%"
 msgstr ""

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
@@ -8,14 +8,212 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-?>
-<div class="jlg-rating-block-empty notice notice-info">
-    <p>
-        <?php
-        echo esc_html__(
-            'Aucune note n’est disponible pour le moment. Utilisez la metabox « Notation JLG » pour saisir les notes du test.',
-            'notation-jlg'
+
+$options = isset( $options ) && is_array( $options ) ? $options : \JLG\Notation\Helpers::get_plugin_options();
+
+$raw_score_max = null;
+if ( isset( $score_max ) && is_numeric( $score_max ) ) {
+    $raw_score_max = (float) $score_max;
+}
+
+$resolved_score_max = $raw_score_max !== null && $raw_score_max > 0
+    ? $raw_score_max
+    : (float) \JLG\Notation\Helpers::get_score_max( $options );
+
+if ( $resolved_score_max <= 0 ) {
+    $resolved_score_max = 10.0;
+}
+
+$placeholder_average = isset( $average_score ) && is_numeric( $average_score )
+    ? (float) $average_score
+    : round( $resolved_score_max / 2, 1 );
+
+$average_percentage_value = isset( $average_score_percentage ) && is_numeric( $average_score_percentage )
+    ? max( 0, min( 100, (float) $average_score_percentage ) )
+    : max( 0, min( 100, ( $placeholder_average / $resolved_score_max ) * 100 ) );
+
+$resolved_layout = isset( $score_layout ) && in_array( (string) $score_layout, array( 'text', 'circle' ), true )
+    ? (string) $score_layout
+    : 'text';
+
+$resolved_display_mode = isset( $display_mode ) && in_array( (string) $display_mode, array( 'absolute', 'percent' ), true )
+    ? (string) $display_mode
+    : 'absolute';
+
+$percentages_map = array();
+if ( isset( $category_percentages ) && is_array( $category_percentages ) ) {
+    foreach ( $category_percentages as $key => $percentage ) {
+        if ( ! is_string( $key ) ) {
+            continue;
+        }
+
+        if ( is_numeric( $percentage ) ) {
+            $percentages_map[ (string) $key ] = max( 0, min( 100, (float) $percentage ) );
+        }
+    }
+}
+
+$categories_for_display = array();
+
+if ( isset( $category_scores ) && is_array( $category_scores ) ) {
+    foreach ( $category_scores as $category ) {
+        if ( ! is_array( $category ) ) {
+            continue;
+        }
+
+        $label = isset( $category['label'] ) ? (string) $category['label'] : '';
+        if ( $label === '' ) {
+            continue;
+        }
+
+        $category_id = isset( $category['id'] ) ? (string) $category['id'] : '';
+        $score_value = isset( $category['score'] ) && is_numeric( $category['score'] )
+            ? (float) $category['score']
+            : $placeholder_average;
+
+        $percentage_value = isset( $percentages_map[ $category_id ] )
+            ? $percentages_map[ $category_id ]
+            : $average_percentage_value;
+
+        $categories_for_display[] = array(
+            'label'    => $label,
+            'score'    => $score_value,
+            'percent'  => $percentage_value,
         );
-        ?>
-    </p>
+    }
+}
+
+if ( empty( $categories_for_display ) ) {
+    foreach ( \JLG\Notation\Helpers::get_rating_category_definitions() as $definition ) {
+        $label = isset( $definition['label'] ) ? (string) $definition['label'] : '';
+
+        if ( $label === '' ) {
+            continue;
+        }
+
+        $categories_for_display[] = array(
+            'label'   => $label,
+            'score'   => $placeholder_average,
+            'percent' => $average_percentage_value,
+        );
+    }
+}
+
+$score_max_label      = esc_html( number_format_i18n( $resolved_score_max ) );
+$average_score_label  = esc_html( number_format_i18n( $placeholder_average, 1 ) );
+$percentage_label     = esc_html( number_format_i18n( $average_percentage_value, 1 ) );
+$user_rating_value    = isset( $user_rating_average ) && is_numeric( $user_rating_average )
+    ? (float) $user_rating_average
+    : $placeholder_average;
+$user_rating_delta     = isset( $user_rating_delta ) && is_numeric( $user_rating_delta )
+    ? (float) $user_rating_delta
+    : 0.0;
+$user_rating_has_delta = abs( $user_rating_delta ) > 0.01;
+
+if ( $user_rating_delta > 0 ) {
+    $user_rating_delta_formatted = '+' . number_format_i18n( $user_rating_delta, 1 );
+} elseif ( $user_rating_delta < 0 ) {
+    $user_rating_delta_formatted = number_format_i18n( $user_rating_delta, 1 );
+} else {
+    $user_rating_delta_formatted = number_format_i18n( 0, 1 );
+}
+
+if ( $resolved_display_mode === 'percent' && $percentage_label !== '' ) {
+    $global_visible_value = sprintf(
+        /* translators: %s: Global score percentage. */
+        esc_html_x( '%s %%', 'global percentage score', 'notation-jlg' ),
+        $percentage_label
+    );
+} else {
+    $global_visible_value = $average_score_label;
+}
+
+$placeholder_notice = esc_html__( 'Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes.', 'notation-jlg' );
+?>
+<div class="jlg-rating-block-placeholder jlg-rating-block-empty">
+    <p class="jlg-rating-placeholder-notice"><?php echo $placeholder_notice; ?></p>
+    <div class="review-box-jlg is-placeholder" aria-hidden="true">
+        <div class="global-score-wrapper">
+            <?php if ( $resolved_layout === 'circle' ) : ?>
+                <div class="score-circle">
+                    <div class="score-value"><?php echo esc_html( $global_visible_value ); ?></div>
+                    <div class="score-label"><?php esc_html_e( 'Note Globale', 'notation-jlg' ); ?></div>
+                </div>
+            <?php else : ?>
+                <div class="global-score-text">
+                    <div class="score-value"><?php echo esc_html( $global_visible_value ); ?></div>
+                    <div class="score-label"><?php esc_html_e( 'Note Globale', 'notation-jlg' ); ?></div>
+                </div>
+            <?php endif; ?>
+
+            <div class="rating-badge rating-badge--placeholder" role="presentation">
+                <span class="rating-badge__label"><?php esc_html_e( 'Sélection de la rédaction', 'notation-jlg' ); ?></span>
+            </div>
+
+            <div class="user-rating-summary user-rating-summary--placeholder">
+                <span class="user-rating-summary__label"><?php esc_html_e( 'Note des lecteurs', 'notation-jlg' ); ?></span>
+                <span class="user-rating-summary__value">
+                    <?php
+                    printf(
+                        /* translators: 1: reader score. 2: maximum possible score. */
+                        esc_html__( '%1$s / %2$s', 'notation-jlg' ),
+                        esc_html( number_format_i18n( $user_rating_value, 1 ) ),
+                        $score_max_label
+                    );
+                    ?>
+                </span>
+                <?php if ( $user_rating_has_delta ) : ?>
+                    <span class="user-rating-summary__delta">
+                        <?php
+                        printf(
+                            /* translators: %s: difference between reader and editorial scores. */
+                            esc_html__( 'Δ vs rédaction : %s', 'notation-jlg' ),
+                            esc_html( $user_rating_delta_formatted )
+                        );
+                        ?>
+                    </span>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <hr>
+
+        <div class="rating-breakdown">
+            <?php foreach ( $categories_for_display as $category ) : ?>
+                <?php
+                $category_label = isset( $category['label'] ) ? (string) $category['label'] : '';
+
+                if ( $category_label === '' ) {
+                    continue;
+                }
+
+                $category_score_value = isset( $category['score'] ) && is_numeric( $category['score'] )
+                    ? (float) $category['score']
+                    : $placeholder_average;
+                $category_percent_value = isset( $category['percent'] ) && is_numeric( $category['percent'] )
+                    ? max( 0, min( 100, (float) $category['percent'] ) )
+                    : $average_percentage_value;
+                $percent_attr = number_format( $category_percent_value, 2, '.', '' );
+                ?>
+                <div class="rating-item">
+                    <div class="rating-label">
+                        <span><?php echo esc_html( $category_label ); ?></span>
+                        <span>
+                            <?php
+                            printf(
+                                /* translators: 1: category score. 2: maximum score. */
+                                esc_html__( '%1$s / %2$s', 'notation-jlg' ),
+                                esc_html( number_format_i18n( $category_score_value, 1 ) ),
+                                $score_max_label
+                            );
+                            ?>
+                        </span>
+                    </div>
+                    <div class="rating-bar-container">
+                        <div class="rating-bar" style="--rating-percent:<?php echo esc_attr( $percent_attr ); ?>%;"></div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- inject simulated rating data in the rating block shortcode when rendering editor previews without stored scores
- replace the empty rating block template with a full placeholder skeleton and add dedicated greyed placeholder styles in editor and front CSS
- refresh localisation entries to cover the new placeholder notice and template references

## Testing
- composer test
- composer cs *(fails: existing coding standards violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2687623a8832ead55cfac2bb092d4