### PR TITLE
Add advanced filters to Game Explorer block

### DIFF
--- a/plugin-notation-jeux_V4/assets/blocks/game-explorer/block.json
+++ b/plugin-notation-jeux_V4/assets/blocks/game-explorer/block.json
@@ -21,7 +21,16 @@
     },
     "filters": {
       "type": "array",
-      "default": ["letter", "category", "platform", "availability"],
+      "default": [
+        "letter",
+        "category",
+        "platform",
+        "developer",
+        "publisher",
+        "availability",
+        "year",
+        "search"
+      ],
       "items": {
         "type": "string"
       }
@@ -45,6 +54,22 @@
     "sort": {
       "type": "string",
       "default": "date|DESC"
+    },
+    "developer": {
+      "type": "string",
+      "default": ""
+    },
+    "publisher": {
+      "type": "string",
+      "default": ""
+    },
+    "year": {
+      "type": "string",
+      "default": ""
+    },
+    "search": {
+      "type": "string",
+      "default": ""
     }
   },
   "editorScript": "notation-jlg-game-explorer-editor",

--- a/plugin-notation-jeux_V4/assets/js/blocks/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/blocks/game-explorer.js
@@ -37,7 +37,11 @@
         { value: 'letter', label: __('Filtre lettre', 'notation-jlg') },
         { value: 'category', label: __('Filtre catégorie', 'notation-jlg') },
         { value: 'platform', label: __('Filtre plateforme', 'notation-jlg') },
+        { value: 'developer', label: __('Filtre développeur', 'notation-jlg') },
+        { value: 'publisher', label: __('Filtre éditeur', 'notation-jlg') },
         { value: 'availability', label: __('Disponibilité', 'notation-jlg') },
+        { value: 'year', label: __('Filtre année de sortie', 'notation-jlg') },
+        { value: 'search', label: __('Recherche', 'notation-jlg') },
     ];
 
     var sortOptions = [
@@ -176,6 +180,35 @@
                             onChange: function (value) {
                                 setAttributes({ letter: value || '' });
                             },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Développeur (nom exact)', 'notation-jlg'),
+                            value: attributes.developer || '',
+                            onChange: function (value) {
+                                setAttributes({ developer: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Éditeur (nom exact)', 'notation-jlg'),
+                            value: attributes.publisher || '',
+                            onChange: function (value) {
+                                setAttributes({ publisher: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Année de sortie', 'notation-jlg'),
+                            type: 'number',
+                            value: attributes.year || '',
+                            onChange: function (value) {
+                                setAttributes({ year: value || '' });
+                            },
+                        }),
+                        createElement(TextControl, {
+                            label: __('Recherche (mot-clé)', 'notation-jlg'),
+                            value: attributes.search || '',
+                            onChange: function (value) {
+                                setAttributes({ search: value || '' });
+                            },
                         })
                     )
                 ),
@@ -191,6 +224,10 @@
                             category: attributes.category || '',
                             platform: attributes.platform || '',
                             letter: attributes.letter || '',
+                            developer: attributes.developer || '',
+                            publisher: attributes.publisher || '',
+                            year: attributes.year || '',
+                            search: attributes.search || '',
                             scorePosition: attributes.scorePosition || 'bottom-right',
                             sort: attributes.sort || 'date|DESC',
                         },

--- a/plugin-notation-jeux_V4/assets/js/game-explorer.js
+++ b/plugin-notation-jeux_V4/assets/js/game-explorer.js
@@ -371,6 +371,10 @@
         parsed.atts.plateforme = parsed.atts.plateforme || '';
         parsed.atts.lettre = parsed.atts.lettre || '';
         parsed.atts.score_position = parsed.atts.score_position || 'bottom-right';
+        parsed.atts.developpeur = parsed.atts.developpeur || '';
+        parsed.atts.editeur = parsed.atts.editeur || '';
+        parsed.atts.annee = parsed.atts.annee || '';
+        parsed.atts.recherche = parsed.atts.recherche || '';
 
         parsed.meta = parsed.meta || {};
 
@@ -802,6 +806,10 @@
         payload.set('categorie', config.atts.categorie || '');
         payload.set('plateforme', config.atts.plateforme || '');
         payload.set('lettre', config.atts.lettre || '');
+        payload.set('developpeur', config.atts.developpeur || '');
+        payload.set('editeur', config.atts.editeur || '');
+        payload.set('annee', config.atts.annee || '');
+        payload.set('recherche', config.atts.recherche || '');
         payload.set(getRequestKey(config, 'orderby'), config.state.orderby);
         payload.set(getRequestKey(config, 'order'), config.state.order);
         payload.set(getRequestKey(config, 'letter'), config.state.letter);

--- a/plugin-notation-jeux_V4/includes/Blocks.php
+++ b/plugin-notation-jeux_V4/includes/Blocks.php
@@ -202,7 +202,7 @@ class Blocks {
         }
 
         $frontend_handle = Frontend::FRONTEND_STYLE_HANDLE;
-        if ( ! wp_style_is( $frontend_handle, 'registered' ) ) { 
+        if ( ! wp_style_is( $frontend_handle, 'registered' ) ) {
             wp_register_style(
                 $frontend_handle,
                 trailingslashit( JLG_NOTATION_PLUGIN_URL ) . 'assets/css/jlg-frontend.css',
@@ -241,7 +241,7 @@ class Blocks {
         }
 
         $game_explorer_handle = Frontend::GAME_EXPLORER_STYLE_HANDLE;
-        if ( ! wp_style_is( $game_explorer_handle, 'registered' ) ) { 
+        if ( ! wp_style_is( $game_explorer_handle, 'registered' ) ) {
             wp_register_style(
                 $game_explorer_handle,
                 trailingslashit( JLG_NOTATION_PLUGIN_URL ) . 'assets/css/game-explorer.css',
@@ -372,7 +372,7 @@ class Blocks {
         }
 
         if ( array_key_exists( 'showAnimations', $attributes ) ) {
-            $is_enabled          = (bool) $attributes['showAnimations'];
+            $is_enabled         = (bool) $attributes['showAnimations'];
             $atts['animations'] = $is_enabled ? 'oui' : 'non';
         }
 
@@ -597,6 +597,28 @@ class Blocks {
 
         if ( ! empty( $attributes['letter'] ) && is_string( $attributes['letter'] ) ) {
             $atts['lettre'] = sanitize_text_field( $attributes['letter'] );
+        }
+
+        if ( ! empty( $attributes['developer'] ) && is_string( $attributes['developer'] ) ) {
+            $atts['developpeur'] = sanitize_text_field( $attributes['developer'] );
+        }
+
+        if ( ! empty( $attributes['publisher'] ) && is_string( $attributes['publisher'] ) ) {
+            $atts['editeur'] = sanitize_text_field( $attributes['publisher'] );
+        }
+
+        if ( isset( $attributes['year'] ) && is_string( $attributes['year'] ) ) {
+            $year = sanitize_text_field( $attributes['year'] );
+            if ( $year !== '' ) {
+                $atts['annee'] = $year;
+            }
+        }
+
+        if ( isset( $attributes['search'] ) && is_string( $attributes['search'] ) ) {
+            $search = sanitize_text_field( $attributes['search'] );
+            if ( $search !== '' ) {
+                $atts['recherche'] = $search;
+            }
         }
 
         $sort_override = null;

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -17,7 +17,7 @@ use JLG\Notation\Shortcodes\Tagline;
 use JLG\Notation\Shortcodes\UserRating;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+    exit;
 }
 
 class Frontend {
@@ -1380,6 +1380,10 @@ class Frontend {
             'categorie'      => isset( $_POST['categorie'] ) ? sanitize_text_field( wp_unslash( $_POST['categorie'] ) ) : ( $default_atts['categorie'] ?? '' ),
             'plateforme'     => isset( $_POST['plateforme'] ) ? sanitize_text_field( wp_unslash( $_POST['plateforme'] ) ) : ( $default_atts['plateforme'] ?? '' ),
             'lettre'         => isset( $_POST['lettre'] ) ? sanitize_text_field( wp_unslash( $_POST['lettre'] ) ) : ( $default_atts['lettre'] ?? '' ),
+            'developpeur'    => isset( $_POST['developpeur'] ) ? sanitize_text_field( wp_unslash( $_POST['developpeur'] ) ) : ( $default_atts['developpeur'] ?? '' ),
+            'editeur'        => isset( $_POST['editeur'] ) ? sanitize_text_field( wp_unslash( $_POST['editeur'] ) ) : ( $default_atts['editeur'] ?? '' ),
+            'annee'          => isset( $_POST['annee'] ) ? sanitize_text_field( wp_unslash( $_POST['annee'] ) ) : ( $default_atts['annee'] ?? '' ),
+            'recherche'      => isset( $_POST['recherche'] ) ? sanitize_text_field( wp_unslash( $_POST['recherche'] ) ) : ( $default_atts['recherche'] ?? '' ),
         );
 
         if ( $atts['posts_per_page'] < 1 ) {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -11,7 +11,7 @@ use JLG\Notation\Helpers;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+    exit;
 }
 
 class GameExplorer {
@@ -246,6 +246,10 @@ class GameExplorer {
             'categorie'      => '',
             'plateforme'     => '',
             'lettre'         => '',
+            'developpeur'    => '',
+            'editeur'        => '',
+            'annee'          => '',
+            'recherche'      => '',
         );
     }
 
@@ -1016,6 +1020,28 @@ class GameExplorer {
             $letter_filter = $forced_letter;
         }
 
+        $forced_developer = isset( $atts['developpeur'] ) ? trim( sanitize_text_field( $atts['developpeur'] ) ) : '';
+        if ( $forced_developer !== '' ) {
+            $developer_filter     = $forced_developer;
+            $developer_filter_key = self::normalize_text_key( $developer_filter );
+        }
+
+        $forced_publisher = isset( $atts['editeur'] ) ? trim( sanitize_text_field( $atts['editeur'] ) ) : '';
+        if ( $forced_publisher !== '' ) {
+            $publisher_filter     = $forced_publisher;
+            $publisher_filter_key = self::normalize_text_key( $publisher_filter );
+        }
+
+        $forced_year = isset( $atts['annee'] ) ? sanitize_text_field( $atts['annee'] ) : '';
+        if ( $forced_year !== '' ) {
+            $year_filter_raw = $forced_year;
+        }
+
+        $forced_search = isset( $atts['recherche'] ) ? sanitize_text_field( $atts['recherche'] ) : '';
+        if ( $forced_search !== '' ) {
+            $search_filter = $forced_search;
+        }
+
         $developer_filter_key = $developer_filter !== '' ? self::normalize_text_key( $developer_filter ) : '';
         $publisher_filter_key = $publisher_filter !== '' ? self::normalize_text_key( $publisher_filter ) : '';
 
@@ -1252,6 +1278,10 @@ class GameExplorer {
                         'categorie'      => $atts['categorie'],
                         'plateforme'     => $atts['plateforme'],
                         'lettre'         => $atts['lettre'],
+                        'developpeur'    => $atts['developpeur'],
+                        'editeur'        => $atts['editeur'],
+                        'annee'          => $atts['annee'],
+                        'recherche'      => $atts['recherche'],
                     ),
                     'state'   => array(
                         'orderby'      => $orderby,
@@ -1467,6 +1497,10 @@ class GameExplorer {
                 'categorie'      => $atts['categorie'],
                 'plateforme'     => $atts['plateforme'],
                 'lettre'         => $atts['lettre'],
+                'developpeur'    => $atts['developpeur'],
+                'editeur'        => $atts['editeur'],
+                'annee'          => $atts['annee'],
+                'recherche'      => $atts['recherche'],
             ),
             'state'   => array(
                 'orderby'      => $orderby,

--- a/plugin-notation-jeux_V4/tests/BlocksRegistrationTest.php
+++ b/plugin-notation-jeux_V4/tests/BlocksRegistrationTest.php
@@ -174,4 +174,30 @@ class BlocksRegistrationTest extends TestCase
         $this->assertSame($expected_shortcode, $GLOBALS['jlg_test_last_shortcode']);
         $this->assertSame('[rendered]' . $expected_shortcode, $result);
     }
+
+    public function test_render_game_explorer_block_supports_extended_prefilters(): void
+    {
+        $blocks = new \JLG\Notation\Blocks();
+
+        $GLOBALS['jlg_test_last_shortcode'] = null;
+
+        $result = $blocks->render_game_explorer_block([
+            'postsPerPage' => 8,
+            'columns' => 2,
+            'scorePosition' => 'top-left',
+            'filters' => ['developer', 'publisher', 'year', 'search'],
+            'category' => 'action',
+            'platform' => 'pc',
+            'letter' => 'A',
+            'developer' => 'Studio Alpha',
+            'publisher' => 'Publisher Beta',
+            'year' => '2023',
+            'search' => 'Metroid',
+        ]);
+
+        $expected_shortcode = '[jlg_game_explorer posts_per_page="8" columns="2" score_position="top-left" filters="developer,publisher,year,search" categorie="action" plateforme="pc" lettre="A" developpeur="Studio Alpha" editeur="Publisher Beta" annee="2023" recherche="Metroid"]';
+
+        $this->assertSame($expected_shortcode, $GLOBALS['jlg_test_last_shortcode']);
+        $this->assertSame('[rendered]' . $expected_shortcode, $result);
+    }
 }

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerExtendedFiltersTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerExtendedFiltersTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512) {
+        return json_encode($data, $options, $depth);
+    }
+}
+
+require_once __DIR__ . '/../includes/Frontend.php';
+
+class ShortcodeGameExplorerExtendedFiltersTest extends TestCase
+{
+    public function test_developer_and_publisher_filters_render(): void
+    {
+        $output = \JLG\Notation\Frontend::get_template_html('shortcode-game-explorer', [
+            'atts' => [
+                'id' => 'explorer-filters',
+                'posts_per_page' => 9,
+                'columns' => 3,
+            ],
+            'filters_enabled' => [
+                'letter' => false,
+                'category' => false,
+                'platform' => false,
+                'developer' => true,
+                'publisher' => true,
+                'availability' => false,
+                'year' => false,
+                'search' => true,
+            ],
+            'current_filters' => [
+                'letter' => '',
+                'category' => '',
+                'platform' => '',
+                'developer' => 'studio-alpha',
+                'publisher' => 'publisher-beta',
+                'availability' => '',
+                'year' => '',
+                'search' => '',
+            ],
+            'developers_list' => [
+                ['value' => 'studio-alpha', 'label' => 'Studio Alpha'],
+                ['value' => 'studio-beta', 'label' => 'Studio Beta'],
+            ],
+            'publishers_list' => [
+                ['value' => 'publisher-beta', 'label' => 'Publisher Beta'],
+            ],
+            'games' => [],
+            'letters' => [],
+            'sort_options' => [],
+            'pagination' => [
+                'current' => 1,
+                'total' => 0,
+            ],
+            'total_items' => 0,
+            'config_payload' => [
+                'atts' => [
+                    'id' => 'explorer-filters',
+                    'posts_per_page' => 9,
+                    'columns' => 3,
+                    'filters' => 'developer,publisher,search',
+                    'categorie' => '',
+                    'plateforme' => '',
+                    'lettre' => '',
+                    'developpeur' => '',
+                    'editeur' => '',
+                    'annee' => '',
+                    'recherche' => '',
+                ],
+                'state' => [
+                    'orderby' => 'date',
+                    'order' => 'DESC',
+                    'letter' => '',
+                    'category' => '',
+                    'platform' => '',
+                    'developer' => 'studio-alpha',
+                    'publisher' => 'publisher-beta',
+                    'availability' => '',
+                    'year' => '',
+                    'search' => '',
+                    'paged' => 1,
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('data-role="filters-toggle"', $output, 'Filters toggle should be present.');
+
+        preg_match('/data-config="([^"]+)"/', $output, $configMatches);
+        $this->assertNotEmpty($configMatches, 'Configuration payload should be exposed.');
+
+        $config = json_decode(htmlspecialchars_decode($configMatches[1], ENT_QUOTES), true);
+        $this->assertIsArray($config, 'Configuration payload should decode to an array.');
+
+        $this->assertSame('studio-alpha', $config['state']['developer'] ?? null, 'Developer state should persist in config.');
+        $this->assertSame('publisher-beta', $config['state']['publisher'] ?? null, 'Publisher state should persist in config.');
+        $this->assertStringContainsString('developer', $config['atts']['filters'] ?? '', 'Developer filter should be exported.');
+        $this->assertStringContainsString('publisher', $config['atts']['filters'] ?? '', 'Publisher filter should be exported.');
+        $this->assertArrayHasKey('developpeur', $config['atts'], 'Developer pre-filter attribute should be present.');
+        $this->assertArrayHasKey('editeur', $config['atts'], 'Publisher pre-filter attribute should be present.');
+    }
+
+    public function test_year_filter_renders_with_hint_and_state(): void
+    {
+        $output = \JLG\Notation\Frontend::get_template_html('shortcode-game-explorer', [
+            'atts' => [
+                'id' => 'explorer-year',
+                'posts_per_page' => 6,
+                'columns' => 3,
+            ],
+            'filters_enabled' => [
+                'letter' => false,
+                'category' => false,
+                'platform' => false,
+                'developer' => false,
+                'publisher' => false,
+                'availability' => false,
+                'year' => true,
+                'search' => true,
+            ],
+            'current_filters' => [
+                'letter' => '',
+                'category' => '',
+                'platform' => '',
+                'developer' => '',
+                'publisher' => '',
+                'availability' => '',
+                'year' => '2023',
+                'search' => '',
+            ],
+            'years_list' => [
+                ['value' => '2022', 'label' => '2022'],
+                ['value' => '2023', 'label' => '2023'],
+            ],
+            'years_meta' => [
+                'min' => 2015,
+                'max' => 2024,
+            ],
+            'games' => [],
+            'letters' => [],
+            'sort_options' => [],
+            'pagination' => [
+                'current' => 1,
+                'total' => 0,
+            ],
+            'total_items' => 0,
+            'config_payload' => [
+                'atts' => [
+                    'id' => 'explorer-year',
+                    'posts_per_page' => 6,
+                    'columns' => 3,
+                    'filters' => 'year,search',
+                    'categorie' => '',
+                    'plateforme' => '',
+                    'lettre' => '',
+                    'developpeur' => '',
+                    'editeur' => '',
+                    'annee' => '2023',
+                    'recherche' => '',
+                ],
+                'state' => [
+                    'orderby' => 'date',
+                    'order' => 'DESC',
+                    'letter' => '',
+                    'category' => '',
+                    'platform' => '',
+                    'developer' => '',
+                    'publisher' => '',
+                    'availability' => '',
+                    'year' => '2023',
+                    'search' => '',
+                    'paged' => 1,
+                ],
+                'meta' => [
+                    'years' => [
+                        'min' => 2015,
+                        'max' => 2024,
+                        'buckets' => [2015 => 2, 2023 => 5],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('data-role="filters-toggle"', $output, 'Filters toggle should be rendered.');
+
+        preg_match('/data-config="([^"]+)"/', $output, $configMatches);
+        $this->assertNotEmpty($configMatches, 'Configuration payload should be available.');
+
+        $config = json_decode(htmlspecialchars_decode($configMatches[1], ENT_QUOTES), true);
+        $this->assertIsArray($config, 'Configuration payload should decode to an array.');
+
+        $this->assertSame('2023', $config['state']['year'] ?? null, 'Year state should be persisted.');
+        $this->assertSame('2023', $config['atts']['annee'] ?? null, 'Year pre-filter should be exported.');
+        $this->assertStringContainsString('year', $config['atts']['filters'] ?? '', 'Year filter should be part of exported filters.');
+        $this->assertArrayHasKey('meta', $config, 'Meta information should accompany the payload.');
+        $this->assertSame(2015, $config['meta']['years']['min'] ?? null, 'Year metadata should expose the minimum bucket.');
+        $this->assertSame(2024, $config['meta']['years']['max'] ?? null, 'Year metadata should expose the maximum bucket.');
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Game Explorer block metadata with developer, publisher, year and search defaults
- update the editor controls, preview and front-end script to expose and persist the new filters
- pass the new pre-filter attributes through the PHP renderer and cover them with PHPUnit tests

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e27f2ac054832e96ee34d783216b05