### PR TITLE
Extend review schema with multimedia metadata

### DIFF
--- a/plugin-notation-jeux_V4/tests/FrontendReviewSchemaTest.php
+++ b/plugin-notation-jeux_V4/tests/FrontendReviewSchemaTest.php
@@ -44,7 +44,21 @@ class FrontendReviewSchemaTest extends TestCase
             'display_name' => 'Schema Tester',
         ];
 
-        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_average_score'] = 8.4;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_average_score']          = 8.4;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_tagline_fr']             = 'Résumé officiel de la rédaction';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_tagline_en']             = 'Official editorial summary';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_editeur']                = 'Studio JLG';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_plateformes']            = array( 'PlayStation 5', 'PC' );
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_cover_image_url']        = array( 'https://example.com/covers/schema.jpg' );
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_review_video_url']       = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_review_video_provider']  = 'youtube';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_count']      = 7;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_avg']        = 4.2;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_user_rating_breakdown']  = array(
+            '5' => 3,
+            '4' => 2,
+            '3' => 2,
+        );
 
         $frontend = new \JLG\Notation\Frontend();
 
@@ -69,6 +83,19 @@ class FrontendReviewSchemaTest extends TestCase
         $this->assertSame(8.4, $data['review']['reviewRating']['ratingValue'] ?? null, 'Schema should expose the cached average score.');
         $this->assertSame('Schema Tester', $data['review']['author']['name'] ?? null, 'Schema should include the author display name.');
         $this->assertSame('2024-01-15T08:00:00+00:00', $data['review']['datePublished'] ?? null, 'Schema should include the publication date.');
+        $this->assertSame('fr-FR', $data['inLanguage'] ?? null, 'Schema should expose the active locale.');
+        $this->assertSame('Résumé officiel de la rédaction', $data['review']['reviewBody'] ?? null, 'Schema should expose the localized tagline as reviewBody.');
+        $this->assertSame('Studio JLG', $data['publisher']['name'] ?? null, 'Schema should expose the publisher.');
+        $this->assertContains('PlayStation 5', $data['availableOnDevice'] ?? [], 'Schema should include platform availability.');
+        $this->assertContains('PC', $data['availableOnDevice'] ?? [], 'Schema should include all platforms.');
+        $this->assertContains('https://example.com/covers/schema.jpg', (array) ($data['image'] ?? []), 'Schema should include review imagery.');
+        $this->assertIsArray($data['video'] ?? null, 'Schema should embed the review video object.');
+        $this->assertStringStartsWith('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ', $data['video']['embedUrl'] ?? '', 'Schema should expose the privacy-friendly embed URL.');
+        $this->assertSame('https://www.youtube.com/watch?v=dQw4w9WgXcQ', $data['video']['contentUrl'] ?? null, 'Schema should expose the original video URL.');
+        $this->assertIsArray($data['aggregateRating'] ?? null, 'Schema should expose multiple aggregate rating scales.');
+        $this->assertGreaterThanOrEqual(3, count($data['aggregateRating']), 'Schema should include editorial and user aggregates.');
+        $this->assertIsArray($data['interactionStatistic'] ?? null, 'Schema should expose interaction statistics.');
+        $this->assertNotEmpty($data['interactionStatistic'], 'Interaction statistics should describe user votes.');
     }
 
     public function test_schema_falls_back_to_weighted_average_when_cache_missing(): void
@@ -123,6 +150,65 @@ class FrontendReviewSchemaTest extends TestCase
 
         $this->assertIsArray($data, 'JSON-LD payload should decode to an array.');
         $this->assertSame(8.3, $data['review']['reviewRating']['ratingValue'] ?? null, 'Schema should expose the weighted average when cache is missing.');
+    }
+
+    public function test_schema_translates_review_body_for_active_locale(): void
+    {
+        $this->configurePluginOptions();
+
+        $post_type = 'jlg_review';
+        register_post_type($post_type);
+
+        add_filter('jlg_rated_post_types', static function ($post_types) use ($post_type) {
+            $post_types[] = $post_type;
+
+            return array_values(array_unique((array) $post_types));
+        });
+
+        $post_id = 321;
+        $this->registerPost($post_id, $post_type, [
+            'post_author' => 99,
+            'post_title'  => 'Translated Review',
+        ]);
+
+        $GLOBALS['jlg_test_users'][99] = [
+            'display_name' => 'Translator',
+        ];
+
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_average_score'] = 9.1;
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_tagline_fr']    = 'Critique française seulement';
+
+        $locale_callback = static function () {
+            return 'en_US';
+        };
+
+        add_filter('jlg_schema_locale', $locale_callback);
+
+        $translation_callback = static function ($translated, $text, $source, $target, $context) {
+            if ($context === 'tagline' && $target === 'en') {
+                return 'French review translated';
+            }
+
+            return $translated;
+        };
+
+        add_filter('jlg_auto_translate_text', $translation_callback, 10, 5);
+
+        $frontend = new \JLG\Notation\Frontend();
+
+        ob_start();
+        $frontend->inject_review_schema();
+        $output = ob_get_clean();
+
+        remove_filter('jlg_auto_translate_text', $translation_callback, 10);
+        remove_filter('jlg_schema_locale', $locale_callback);
+
+        $this->assertNotSame('', $output, 'Schema output should not be empty for translated locale.');
+        preg_match('/<script type="application\/ld\+json">(.+)<\/script>/', $output, $matches);
+        $data = json_decode($matches[1] ?? '', true);
+
+        $this->assertSame('en-US', $data['inLanguage'] ?? null, 'Schema should reflect the filtered locale.');
+        $this->assertSame('French review translated', $data['review']['reviewBody'] ?? null, 'Schema should expose the translated tagline.');
     }
 
     private function configurePluginOptions(array $overrides = []): void


### PR DESCRIPTION
## Summary
- enrich the injected review schema with locale-aware fields, multimedia assets, and detailed aggregate ratings/interaction statistics
- add helper routines to resolve localized review bodies, translate taglines, and collect platforms, images, and video payloads
- expand FrontendReviewSchemaTest to cover the new JSON-LD nodes and automated translation behaviour

## Testing
- `composer test`
- `composer cs` *(fails: repository contains pre-existing PHPCS alignment violations in legacy templates)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6de3688832ebf4c8508956984c1