### PR TITLE
Refactor Game Explorer query handling and extend tests

### DIFF
--- a/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
+++ b/plugin-notation-jeux_V4/tests/AdminPostsListInsightsTest.php
@@ -20,57 +20,6 @@ if (!function_exists('_n')) {
     }
 }
 
-if (!class_exists('WP_Query')) {
-    class WP_Query
-    {
-        public $args = [];
-        public $posts = [];
-        public $post_count = 0;
-        public $found_posts = 0;
-        public $max_num_pages = 1;
-
-        private $current_index = 0;
-
-        public function __construct($args = [])
-        {
-            $this->args = is_array($args) ? $args : [];
-            $post_ids = isset($args['post__in']) ? (array) $args['post__in'] : [];
-            $per_page = isset($args['posts_per_page']) ? (int) $args['posts_per_page'] : count($post_ids);
-            $all_posts = $GLOBALS['jlg_test_posts'] ?? [];
-
-            foreach ($post_ids as $post_id) {
-                if (isset($all_posts[$post_id])) {
-                    $this->posts[] = $all_posts[$post_id];
-                }
-            }
-
-            if ($per_page > 0) {
-                $this->posts = array_slice($this->posts, 0, $per_page);
-            }
-
-            $this->post_count = count($this->posts);
-            $this->found_posts = $this->post_count;
-        }
-
-        public function have_posts()
-        {
-            return $this->current_index < $this->post_count;
-        }
-
-        public function the_post()
-        {
-            $post = $this->posts[$this->current_index] ?? null;
-
-            if ($post instanceof WP_Post) {
-                $GLOBALS['post'] = $post;
-                $GLOBALS['jlg_test_current_post_id'] = $post->ID;
-            }
-
-            $this->current_index++;
-        }
-    }
-}
-
 if (!function_exists('paginate_links')) {
     function paginate_links($args = [])
     {

--- a/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerSearchFilterTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeGameExplorerSearchFilterTest.php
@@ -75,4 +75,74 @@ class ShortcodeGameExplorerSearchFilterTest extends TestCase
         $this->assertIsArray($config, 'The configuration payload should be valid JSON.');
         $this->assertSame($search_value, $config['state']['search'] ?? null, 'Search state should be exported in the configuration payload.');
     }
+
+    public function test_search_config_exports_suggestions_and_sorts(): void
+    {
+        $output = \JLG\Notation\Frontend::get_template_html('shortcode-game-explorer', [
+            'atts' => [
+                'id' => 'explorer-test',
+                'posts_per_page' => 6,
+            ],
+            'filters_enabled' => [
+                'search' => true,
+            ],
+            'current_filters' => [
+                'search' => 'épopée légende',
+            ],
+            'config_payload' => [
+                'atts' => [
+                    'id' => 'explorer-test',
+                    'posts_per_page' => 6,
+                    'columns' => 3,
+                    'score_position' => 'bottom-right',
+                    'filters' => 'search,category',
+                    'categorie' => '',
+                    'plateforme' => '',
+                    'lettre' => '',
+                ],
+                'state' => [
+                    'orderby' => 'popularity',
+                    'order' => 'DESC',
+                    'letter' => '',
+                    'category' => '',
+                    'platform' => '',
+                    'search' => 'épopée légende',
+                    'paged' => 1,
+                    'total_items' => 2,
+                    'total_pages' => 1,
+                ],
+                'suggestions' => [
+                    'search' => ['epopee', 'legende'],
+                    'developers' => ['Studio Élan'],
+                    'publishers' => ['Éditions Futur'],
+                    'platforms' => ['PC'],
+                ],
+                'sorts' => [
+                    'options' => [
+                        ['value' => 'date|DESC', 'label' => 'Plus récents'],
+                        ['value' => 'popularity|DESC', 'label' => 'Popularité (plus de votes)'],
+                    ],
+                    'active' => [
+                        'orderby' => 'popularity',
+                        'order' => 'DESC',
+                    ],
+                ],
+            ],
+            'games' => [],
+            'pagination' => [
+                'current' => 1,
+                'total' => 1,
+            ],
+            'total_items' => 0,
+        ]);
+
+        preg_match('/data-config="([^"]+)"/', $output, $matches);
+        $this->assertNotEmpty($matches, 'Configuration payload should be printed as data attribute.');
+
+        $config = json_decode(htmlspecialchars_decode($matches[1], ENT_QUOTES), true);
+        $this->assertIsArray($config, 'JSON configuration should decode into an array.');
+        $this->assertSame('popularity', $config['state']['orderby'] ?? null, 'Active orderby should be exported.');
+        $this->assertContains('epopee', $config['suggestions']['search'] ?? [], 'Accentless search suggestion should be exposed.');
+        $this->assertSame('DESC', $config['sorts']['active']['order'] ?? null, 'Active sort order should be exported.');
+    }
 }

--- a/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeSummarySortingTest.php
@@ -2,29 +2,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-if (!class_exists('WP_Query')) {
-    class WP_Query
-    {
-        public $args;
-        public $max_num_pages = 1;
-
-        public function __construct($args = [])
-        {
-            $this->args = $args;
-        }
-
-        public function have_posts()
-        {
-            return false;
-        }
-
-        public function the_post()
-        {
-            // No-op in tests.
-        }
-    }
-}
-
 if (!function_exists('get_posts')) {
     function get_posts($args)
     {


### PR DESCRIPTION
## Summary
- delegate Game Explorer filtering to WP_Query with normalized search tokens, index meta synchronisation and popularity metadata exposure
- enrich the AJAX payload with search suggestions, active sort metadata and normalized totals for the front-end configuration
- update PHPUnit suite with reusable WP_Query stub, new search/popularity scenarios, and configuration assertions for suggestions and sorts

## Testing
- `composer test`
- `composer cs` *(fails: existing style violations in Settings.php and other legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6dd4b24832e9d9dcab34986a82f