### PR TITLE
Ajoute benchmark 2024-06-02 et durcit la couverture Score Insights

### DIFF
--- a/plugin-notation-jeux_V4/docs/benchmark-2024-06-02.md
+++ b/plugin-notation-jeux_V4/docs/benchmark-2024-06-02.md
@@ -1,0 +1,39 @@
+# Benchmark – 2024-06-02
+
+## Références étudiées
+- **IGN** : hub de tests avec filtres multiplateformes, segmentation par genre et indicateurs d'évolution des notes.
+- **GameSpot** : fiches détaillées mêlant critique, notation lecteur et recommandations croisées (« Best Of », jeux similaires) avec mise à jour continue.
+
+## Synthèse des écarts majeurs
+| Axe | État du plugin | Référence pro | Risque produit |
+| --- | --- | --- | --- |
+| Insights de notation | Agrégats statiques (moyenne, médiane, histogramme) sans tendance ni comparaison temporelle dans `Helpers::get_posts_score_insights()` et le rendu `ScoreInsights`. 【F:includes/Helpers.php†L2133-L2236】【F:includes/Shortcodes/ScoreInsights.php†L20-L83】 | IGN suit l'évolution des notes par plateforme et sur 30/90 jours ; GameSpot met en avant les variations entre rédactions et lecteurs. | Décisions éditoriales prises avec une vision partielle ; difficile de repérer les baisses de qualité.
+| Découverte / Game Explorer | Filtres unitaires (lettre, catégorie, plateforme, etc.) et tri limité aux combinaisons pré-définies dans `GameExplorer`. 【F:includes/Shortcodes/GameExplorer.php†L16-L120】【F:includes/Shortcodes/GameExplorer.php†L212-L311】 | IGN propose filtres combinables, favoris et tags personnalisés ; GameSpot enregistre des vues (Most Popular, Upcoming) et recommandations croisées. | Les rédactions peinent à reproduire des parcours éditoriaux avancés et à segmenter l'audience.
+| Modération des votes | API REST se limite à bannir/autoriser un jeton sans workflow (raisons, historique, seuils) dans `Frontend::register_user_rating_rest_routes()` et `rest_handle_user_rating_token_status()`. 【F:includes/Frontend.php†L1056-L1178】 | IGN/GameSpot intègrent modération multi-rôle, alertes automatiques et règles anti-abus (scores suspects, IP). | Gestion communautaire manuelle et lente, risque de dérive des votes.
+
+## Fonctions à renforcer en priorité
+### 1. `Helpers::get_posts_score_insights()`
+- Ajouter des séries temporelles (rolling 7/30 jours) et une comparaison rédactions vs lecteurs pour refléter les tableaux dynamiques des concurrents. 【F:includes/Helpers.php†L2133-L2236】
+- Étendre `build_score_distribution()` pour générer 10 segments (ou un mode 0-100) et prendre en charge les percentiles utilisés par IGN. 【F:includes/Helpers.php†L2238-L2299】
+
+### 2. `Shortcodes\ScoreInsights::render()`
+- Préparer le contexte avec plusieurs périodes (N-1, N-2) et exposer des deltas prêts à être consommés par le template ou Gutenberg. 【F:includes/Shortcodes/ScoreInsights.php†L24-L83】
+- Prévoir un mode API/headless (JSON) afin d'alimenter des dashboards internes comme ceux de GameSpot.
+
+### 3. `Shortcodes\GameExplorer` (contexte + filtres)
+- Permettre la sélection multiple (plates-formes, genres) et la sauvegarde de presets éditoriaux dans `get_default_atts()` / `normalize_filters()`. 【F:includes/Shortcodes/GameExplorer.php†L212-L284】
+- Exposer des hooks pour injecter des jeux similaires (« More Like This ») et des vues dynamiques (upcoming, top series) à la manière d'IGN/GameSpot. 【F:includes/Shortcodes/GameExplorer.php†L272-L311】
+
+### 4. `Frontend::register_user_rating_rest_routes()`
+- Ajouter des statuts intermédiaires (sous surveillance, en litige) et un historique d'actions afin de refléter un vrai back-office de modération. 【F:includes/Frontend.php†L1056-L1178】
+- Intégrer des heuristiques (seuil d'alertes, ratio bannissements) et logs pour audit.
+
+## Plan de débogage et de tests
+### Tests automatisés
+- **Nouveau** `HelpersScoreInsightsAggregationTest` : vérifie l'agrégation par plateforme, la mise en forme i18n et les valeurs de distribution pour préparer l'évolution analytics. 【F:tests/HelpersScoreInsightsAggregationTest.php†L1-L104】
+- Étendre ensuite les tests `ShortcodeScoreInsightsTemplateTest` pour couvrir l'affichage de deltas temporels lorsque les données seront disponibles. 【F:tests/ShortcodeScoreInsightsTemplateTest.php†L1-L44】
+
+### Tests manuels suggérés
+1. Vérifier dans Game Explorer la combinaison de plusieurs filtres (lettre + plateforme + développeur) et mesurer le temps de réponse vs IGN.
+2. Simuler un pic de votes lecteurs (50+ en 5 minutes) et observer si l'API REST actuelle permet une modération efficace.
+3. Comparer la mise en avant des jeux similaires avec GameSpot pour identifier les données manquantes (tags, séries, trending).

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -1229,15 +1229,28 @@ class Frontend {
             if ( is_object( $response ) && method_exists( $response, 'set_status' ) ) {
                 $response->set_status( $status );
             } elseif ( is_array( $response ) ) {
-                $response['status'] = $status;
+                if ( array_key_exists( 'status', $response ) && $response['status'] !== null && $response['status'] !== '' ) {
+                    $response['_http_status'] = $status;
+                } else {
+                    $response['status'] = $status;
+                }
             } else {
-                $response = array_merge( (array) $response, array( 'status' => $status ) );
+                $response = array_merge(
+                    (array) $response,
+                    array(
+                        'status' => $status,
+                    )
+                );
             }
 
             return $response;
         }
 
-        $data['status'] = $status;
+        if ( array_key_exists( 'status', $data ) && $data['status'] !== null && $data['status'] !== '' ) {
+            $data['_http_status'] = $status;
+        } else {
+            $data['status'] = $status;
+        }
 
         return $data;
     }

--- a/plugin-notation-jeux_V4/tests/HelpersScoreInsightsAggregationTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersScoreInsightsAggregationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersScoreInsightsAggregationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_meta'] = [];
+        $GLOBALS['jlg_test_options'] = [];
+
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+
+        unset($GLOBALS['jlg_test_meta'], $GLOBALS['jlg_test_options']);
+
+        parent::tearDown();
+    }
+
+    public function test_platform_rankings_are_sorted_and_labelled(): void
+    {
+        $post_ids = [101, 202, 303];
+
+        $GLOBALS['jlg_test_meta'][101] = [
+            '_jlg_average_score' => '9.2',
+            '_jlg_plateformes'   => ['PlayStation 5', 'PC'],
+        ];
+
+        $GLOBALS['jlg_test_meta'][202] = [
+            '_jlg_average_score' => '8.4',
+            '_jlg_plateformes'   => 'PlayStation 5, Xbox Series X',
+        ];
+
+        $GLOBALS['jlg_test_meta'][303] = [
+            '_jlg_average_score' => '7.5',
+        ];
+
+        $insights = \JLG\Notation\Helpers::get_posts_score_insights($post_ids);
+
+        $this->assertSame(3, $insights['total']);
+        $this->assertSame(8.4, $insights['mean']['value']);
+        $this->assertSame('8.4', $insights['mean']['formatted']);
+        $this->assertSame(8.4, $insights['median']['value']);
+
+        $distribution_total = array_sum(array_map(static function ($bucket) {
+            return $bucket['count'];
+        }, $insights['distribution']));
+        $this->assertSame(3, $distribution_total, 'Distribution buckets should cover every scored post.');
+
+        $this->assertCount(4, $insights['platform_rankings']);
+
+        $top_platform = $insights['platform_rankings'][0];
+        $this->assertSame('pc', $top_platform['slug']);
+        $this->assertSame('PC', $top_platform['label']);
+        $this->assertSame(1, $top_platform['count']);
+        $this->assertSame(9.2, $top_platform['average']);
+        $this->assertSame('9.2', $top_platform['average_formatted']);
+
+        $playstation = $insights['platform_rankings'][1];
+        $this->assertSame('playstation-5', $playstation['slug']);
+        $this->assertSame(2, $playstation['count']);
+        $this->assertSame(8.8, $playstation['average']);
+        $this->assertSame('8.8', $playstation['average_formatted']);
+
+        $xbox = $insights['platform_rankings'][2];
+        $this->assertSame('xbox-series-x', $xbox['slug']);
+        $this->assertSame('Xbox Series S/X', $xbox['label']);
+        $this->assertSame(1, $xbox['count']);
+        $this->assertSame(8.4, $xbox['average']);
+
+        $unknown = $insights['platform_rankings'][3];
+        $this->assertSame('sans-plateforme', $unknown['slug']);
+        $this->assertSame('Sans plateforme', $unknown['label']);
+        $this->assertSame(1, $unknown['count']);
+        $this->assertSame(7.5, $unknown['average']);
+        $this->assertSame('7.5', $unknown['average_formatted']);
+    }
+
+    public function test_returns_empty_summary_when_no_scores(): void
+    {
+        $insights = \JLG\Notation\Helpers::get_posts_score_insights([999]);
+
+        $this->assertSame(0, $insights['total']);
+        $this->assertNull($insights['mean']['value']);
+        $this->assertNull($insights['median']['value']);
+        $this->assertSame([], $insights['platform_rankings']);
+
+        $distribution_total = array_sum(array_map(static function ($bucket) {
+            return $bucket['count'];
+        }, $insights['distribution']));
+        $this->assertSame(0, $distribution_total, 'Distribution should be empty when no scores are present.');
+    }
+}


### PR DESCRIPTION
## Summary
- documente un benchmark IGN/GameSpot et les axes d’amélioration prioritaires dans `docs/benchmark-2024-06-02.md`
- ajoute des tests unitaires ciblant l’agrégation `Helpers::get_posts_score_insights()` pour préparer les évolutions analytics
- fiabilise `Frontend::prepare_rest_response()` afin de préserver le statut fonctionnel des réponses REST tout en exposant le code HTTP

## Testing
- composer install
- composer test
- composer cs *(échoue : violations existantes dans les templates fournis)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cb708bd4832e9d1e54915a24f276