### PR TITLE
Add fallback autoloader for plugin bootstrap without Composer

### DIFF
--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -1229,7 +1229,9 @@ class Frontend {
             if ( is_object( $response ) && method_exists( $response, 'set_status' ) ) {
                 $response->set_status( $status );
             } elseif ( is_array( $response ) ) {
-                $response['status'] = $status;
+                if ( ! array_key_exists( 'status', $response ) ) {
+                    $response['status'] = $status;
+                }
             } else {
                 $response = array_merge( (array) $response, array( 'status' => $status ) );
             }

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -21,6 +21,45 @@ if ( file_exists( $autoload_path ) ) {
         require $autoload_path;
 }
 
+require_once __DIR__ . '/functions.php';
+
+if ( ! defined( 'JLG_NOTATION_FALLBACK_AUTOLOADER' ) ) {
+    define( 'JLG_NOTATION_FALLBACK_AUTOLOADER', true );
+
+    spl_autoload_register(
+        static function ( $class ) {
+            $prefixes = array(
+                'JLG\\Notation\\Admin\\'      => 'includes/Admin/',
+                'JLG\\Notation\\Utils\\'      => 'includes/Utils/',
+                'JLG\\Notation\\Shortcodes\\' => 'includes/Shortcodes/',
+                'JLG\\Notation\\'              => 'includes/',
+            );
+
+            foreach ( $prefixes as $prefix => $directory ) {
+                if ( strpos( $class, $prefix ) !== 0 ) {
+                    continue;
+                }
+
+                $relative_class = substr( $class, strlen( $prefix ) );
+                if ( $relative_class === false ) {
+                    return;
+                }
+
+                $relative_path = str_replace( '\\', '/', $relative_class );
+                $file          = __DIR__ . '/' . $directory . $relative_path . '.php';
+
+                if ( file_exists( $file ) ) {
+                    require_once $file;
+                }
+
+                return;
+            }
+        },
+        true,
+        true
+    );
+}
+
 // Constantes
 define( 'JLG_NOTATION_VERSION', '5.0' );
 define( 'JLG_NOTATION_PLUGIN_FILE', __FILE__ );

--- a/plugin-notation-jeux_V4/tests/PluginAutoloadFallbackTest.php
+++ b/plugin-notation-jeux_V4/tests/PluginAutoloadFallbackTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class PluginAutoloadFallbackTest extends TestCase
+{
+    public function test_plugin_registers_psr4_fallback_when_vendor_autoload_missing(): void
+    {
+        $this->assertFalse(class_exists('\\JLG\\Notation\\Assets', false));
+
+        @require_once __DIR__ . '/../plugin-notation-jeux.php';
+
+        $this->assertTrue(function_exists('jlg_display_thumbnail_score'));
+        $this->assertTrue(class_exists('\\JLG\\Notation\\Assets'));
+        $this->assertTrue(class_exists('\\JLG\\Notation\\Admin\\Core'));
+        $this->assertTrue(class_exists('\\JLG\\Notation\\Shortcodes\\GameExplorer'));
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -44,6 +44,18 @@ if (!function_exists('plugin_dir_url')) {
     }
 }
 
+if (!function_exists('trailingslashit')) {
+    function trailingslashit($value) {
+        $value = (string) $value;
+
+        if ($value === '') {
+            return '/';
+        }
+
+        return rtrim($value, '/\\') . '/';
+    }
+}
+
 if (!function_exists('wp_login_url')) {
     /**
      * Fournit une URL de connexion déterministe avec prise en charge du redirect.


### PR DESCRIPTION
## Summary
- register a PSR-4 fallback autoloader and load helper functions so the plugin boots without Composer's vendor directory
- preserve status data when REST responses are returned as arrays in the test environment
- add a regression test and bootstrap stub to cover the fallback autoloader scenario

## Testing
- composer install
- composer test
- composer cs *(fails: numerous pre-existing coding standard violations reported by phpcs)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce0572e0832eb52d404b0cd14f61