### PR TITLE
docs: benchmark with pro platforms and refresh feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un système complet de notation destiné aux sites de tests de jeux vidéo. Il fournit un rendu professionnel pour vos reviews avec des shortcodes prêts à l'emploi, un widget et des helpers PHP pour intégrer la note partout dans votre thème.
 
 ## Présentation rapide
-- **Fonctionnalités clés :** 6 catégories de notes personnalisables, bloc complet avec points forts/faibles, fiche technique, widget des derniers tests, tableau récapitulatif, prise en charge de la notation des lecteurs, badge « Coup de cœur » éditorial à seuil configurable, intégration de l'API RAWG et schema.org pour les rich snippets.
+- **Fonctionnalités clés :** 6 catégories de notes personnalisables avec badge « Coup de cœur » éditorial, notation lecteurs avec histogramme dynamique, remplissage RAWG, validation PEGI/date/nom du jeu, Game Explorer filtrable, Score Insights (moyenne, médiane, histogramme, top plateformes), tableau récapitulatif triable et widget des derniers tests.
 - **Prérequis techniques :** WordPress 5.0 minimum et PHP 7.4 ou supérieur, vérifiés automatiquement à l’activation du plugin.
 - **Architecture :** le cœur du plugin charge dynamiquement les composants admin et front-office, inclut un widget et expose des fonctions helper globales (`jlg_notation()`, `jlg_get_post_rating()`, `jlg_display_post_rating()`).
 
@@ -14,22 +14,27 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
 4. **Gérer les plateformes** dans l’onglet dédié afin d’ajouter, trier, supprimer ou réinitialiser la liste proposée dans les metaboxes.
 5. **Saisir la clé RAWG (facultatif)** dans la section *API* des réglages pour activer le remplissage automatique des données de jeu.
 
-## Utilisation au quotidien
 - **Shortcodes principaux** :
   - `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) pour afficher en une seule fois notation, points forts/faibles et tagline avec de nombreux attributs (`post_id`, `style`, `couleur_accent`, etc.).
-  - `[bloc_notation_jeu]`, `[jlg_fiche_technique]`, `[jlg_points_forts_faibles]`, `[tagline_notation_jlg]`, `[notation_utilisateurs_jlg]`, `[jlg_tableau_recap]` pour construire des mises en page modulaires ; le module de vote affiche désormais un histogramme dynamique accessible (barres ARIA, rafraîchies en direct). Lorsque le badge « Coup de cœur » est activé et que la note atteint le seuil défini dans les réglages, le bloc de notation met en avant la sélection de la rédaction et affiche la moyenne des lecteurs ainsi que l'écart avec la rédaction.
+  - `[bloc_notation_jeu]`, `[jlg_fiche_technique]`, `[jlg_points_forts_faibles]`, `[tagline_notation_jlg]`, `[notation_utilisateurs_jlg]`, `[jlg_tableau_recap]`, `[jlg_game_explorer]`, `[jlg_score_insights]` pour construire des mises en page modulaires ; le module de vote affiche désormais un histogramme dynamique accessible (barres ARIA, rafraîchies en direct). Lorsque le badge « Coup de cœur » est activé et que la note atteint le seuil défini dans les réglages, le bloc de notation met en avant la sélection de la rédaction et affiche la moyenne des lecteurs ainsi que l'écart avec la rédaction.
+- **Blocs Gutenberg** :
+  - `notation-jlg/rating-block` pour gérer format du score (texte/cercle), animations, thème clair/sombre et ciblage d’article.
+  - `notation-jlg/all-in-one` pour activer/désactiver chaque sous-composant et personnaliser style, titres et couleur d’accent.
+  - `notation-jlg/game-info`, `notation-jlg/pros-cons`, `notation-jlg/tagline`, `notation-jlg/user-rating` pour afficher automatiquement les métadonnées saisies.
+  - `notation-jlg/summary-display`, `notation-jlg/game-explorer`, `notation-jlg/score-insights` pour proposer tableau, explorateur filtrable et tableau de bord analytique directement depuis Gutenberg.
 - **Widget « Derniers tests »** : activé automatiquement, il peut être ajouté depuis *Apparence > Widgets* grâce au registre `JLG_Latest_Reviews_Widget`.
-- **Intégration vidéo enrichie** : les helpers détectent désormais automatiquement YouTube, Vimeo, Twitch et Dailymotion pour générer un lecteur embarqué respectant les paramètres recommandés.
+- **Game Explorer & Score Insights** : `[jlg_game_explorer]` propose une navigation filtrable accessible (GET), panneaux responsives et focus géré ; `[jlg_score_insights]` calcule moyenne/médiane, histogramme et podium plateformes sur une période configurée.
+- **Intégration vidéo enrichie** : les helpers détectent automatiquement YouTube, Vimeo, Twitch et Dailymotion pour générer un lecteur embarqué respectant les paramètres recommandés.
 - **Fonctions helper** :
-  - `jlg_get_post_rating()` retourne la moyenne /10 pour un article donné ; `jlg_display_post_rating()` affiche la note formatée ; `jlg_display_thumbnail_score()` injecte la note dans vos templates de vignettes.
+  - `jlg_get_post_rating()` retourne la moyenne /10 pour un article donné ; `jlg_display_post_rating()` affiche la note formatée ; `jlg_display_thumbnail_score()` injecte la note dans vos templates de vignettes ; `JLG_Frontend::mark_shortcode_rendered()` gère le chargement conditionnel des assets.
 - **Templates front** : surchargez les fichiers du dossier [`templates/`](plugin-notation-jeux_V4/templates) ou utilisez les gabarits d’admin disponibles dans [`admin/templates/`](plugin-notation-jeux_V4/admin/templates) pour personnaliser le rendu des blocs et onglets.
 
-## Personnalisation avancée
-- **Thèmes clair/sombre et palettes complètes** pour adapter l’apparence du bloc de notation, y compris les couleurs sémantiques des notes.
+- **Thèmes clair/sombre et palettes complètes** pour adapter l’apparence du bloc de notation, y compris les couleurs sémantiques des notes et les gradients sécurisés (filtrage anti-injection).
 - **Effets Glow / Neon** configurables pour les modes texte ou cercle (intensité, pulsation, couleur dynamique ou fixe).
-- **Modules optionnels** : activer/désactiver la notation utilisateurs, le badge « Coup de cœur », les taglines, les animations de barres ou le schema SEO JSON-LD directement depuis l’onglet Réglages.
-- **CSS personnalisé** et réglages précis pour le tableau récapitulatif ou les vignettes (espacements, bordures, alternance de lignes).
+- **Modules optionnels** : activer/désactiver la notation utilisateurs, le badge « Coup de cœur », les taglines, les animations de barres, le schema SEO JSON-LD, les sons d’interface ou le remplissage RAWG directement depuis l’onglet Réglages.
+- **CSS personnalisé** et réglages précis pour le tableau récapitulatif ou les vignettes (espacements, bordures, alternance de lignes) ainsi qu’un sélecteur couleur acceptant la valeur `transparent` lorsque pertinent.
 - **Notation des lecteurs** : personnalisez couleurs et textes du module dédié et profitez d'un histogramme accessible mis à jour en direct, avec verrouillage automatique des interactions pendant le traitement AJAX pour éviter les doubles clics. Les votes peuvent, au besoin, être réservés aux membres connectés via l'option *Connexion obligatoire avant le vote* dans les réglages.
+- **Gestion dynamique des plateformes** : ajoutez, triez, supprimez ou réinitialisez les plateformes proposées dans les metaboxes pour conserver des fiches homogènes.
 
 ## Ressources développeur
 - **Composer** : `composer.json` définit PHP >=7.4 et fournit les scripts `composer test`, `composer cs`, `composer cs-fix` pour lancer PHPUnit et PHPCS (WPCS).
@@ -39,6 +44,7 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
   - [`assets/`](plugin-notation-jeux_V4/assets) regroupe styles, scripts et images front/back.
   - [`includes/`](plugin-notation-jeux_V4/includes) contient le cœur PHP (helpers, frontend, admin, utils).
   - [`admin/templates/`](plugin-notation-jeux_V4/admin/templates) centralise les vues des onglets d’administration.
+- **Tests et documentation** : suite PHPUnit couvrant les helpers principaux, scénarios de benchmark dans [`docs/`](plugin-notation-jeux_V4/docs) (Game Explorer, histogramme, responsive, Score Insights) et checklist manuelle responsive maintenue.
 
 ## Intégration continue
 Un workflow GitHub Actions (`CI`) s’exécute sur chaque `push` et `pull_request`. Il installe les dépendances Composer du dossier [`plugin-notation-jeux_V4`](plugin-notation-jeux_V4), puis enchaîne deux commandes clés pour garantir la qualité :

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -18,21 +18,21 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 
 = Fonctionnalités principales =
 
-* **Système de notation flexible** : 6 catégories personnalisables avec un barème ajustable (par défaut sur 10)
-* **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
-* **Notation utilisateurs** : Permettez à vos lecteurs de voter, visualisez la répartition des notes dans un histogramme accessible mis à jour en direct et laissez le script AJAX empêcher les doubles soumissions. L'option *Connexion obligatoire avant le vote* autorise au besoin la restriction aux membres connectés.
-* **Badge coup de cœur** : Activez un badge éditorial lorsque la note dépasse un seuil configurable et affichez en parallèle la moyenne des lecteurs ainsi que l'écart avec la rédaction
-* **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage
-* **Nom de jeu personnalisé** : Remplacez le titre WordPress dans les tableaux, widgets et données structurées
-* **Widget** : Affichez vos derniers tests notés
-* **Intégration vidéo enrichie** : Les helpers détectent désormais automatiquement YouTube, Vimeo, Twitch et Dailymotion pour générer un lecteur embarqué respectant les paramètres recommandés
-* **API RAWG** : Remplissage automatique des informations de jeu
-* **SEO optimisé** : Support schema.org pour les rich snippets Google
-* **Thèmes visuels** : Mode clair et sombre avec personnalisation complète
-* **Sélecteur de couleurs enrichi** : Profitez du color picker WordPress avec saisie libre (y compris `transparent` lorsque pris en charge)
-* **Accessibilité renforcée** : Les animations respectent la préférence système "réduire les mouvements" et la navigation du Game Explorer annonce désormais la page active (aria-current) tout en proposant des repères de focus visibles, y compris sur mobile. Sur smartphone, un bouton « Filtres » accessible (aria-expanded/aria-controls) ouvre un panneau coulissant qui se referme automatiquement après application et replace le focus sur la liste de résultats.
-* **Gestion dynamique des plateformes** : Ajoutez, triez et réinitialisez vos plateformes depuis l'onglet Plateformes
-* **Responsive** : Parfaitement adapté mobile et tablette
+* **Système de notation flexible** : 6 catégories personnalisables avec barème ajustable (par défaut sur 10) et badge « Coup de cœur » éditorial déclenché par seuil.
+* **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues, Game Explorer, Score Insights et tableau récapitulatif.
+* **Blocs Gutenberg** : neuf blocs dynamiques (notation, tout-en-un, fiche technique, points forts/faibles, tagline, notation lecteurs, tableau récapitulatif, Game Explorer, Score Insights) garantissant la parité éditeur/front.
+* **Notation utilisateurs** : votes AJAX, histogramme accessible rafraîchi en direct, verrouillage anti double clic et option *Connexion obligatoire avant le vote*.
+* **Tableau récapitulatif & Game Explorer** : vues triables/filtrables avec navigation accessible sans JavaScript et panneaux responsives.
+* **Score Insights** : tableau de bord statistique (moyenne, médiane, histogramme, plateformes dominantes) filtrable par période et plateforme.
+* **Nom de jeu personnalisé** : remplace le titre WordPress dans tableaux, widgets et données structurées.
+* **Widget « Derniers tests »** : met en avant vos dernières reviews notées.
+* **Intégration vidéo enrichie** : détection automatique YouTube, Vimeo, Twitch, Dailymotion pour un embed conforme.
+* **API RAWG** : remplissage automatique des informations de jeu avec validation (dates, PEGI, nom normalisé).
+* **SEO optimisé** : schema.org (JSON-LD) activable et métadonnées cohérentes.
+* **Thèmes visuels & effets** : mode clair/sombre, palettes complètes, effets Glow/Neon et sélecteur couleur acceptant `transparent`.
+* **Accessibilité renforcée** : respect de `prefers-reduced-motion`, focus visibles, aria-current sur la navigation et boutons de filtres annotés.
+* **Gestion dynamique des plateformes** : ajoutez, triez, supprimez ou réinitialisez depuis l'onglet Plateformes.
+* **Responsive** : design adapté mobile/tablette et chargement conditionnel des assets via `JLG_Frontend::mark_shortcode_rendered()`.
 
 = Histogramme des votes lecteurs =
 

--- a/plugin-notation-jeux_V4/docs/benchmark-2025-10-05.md
+++ b/plugin-notation-jeux_V4/docs/benchmark-2025-10-05.md
@@ -1,0 +1,39 @@
+# Benchmark produit – 2025-10-05
+
+## Contexte
+- **Produit analysé :** Notation JLG v5.0 (shortcodes, blocs Gutenberg, modules Game Explorer & Score Insights, remplissage RAWG, histogramme lecteurs, badge « Coup de cœur », thèmes clair/sombre, validation PEGI/date, template overrides).
+- **Objectif :** comparer l’expérience offerte avec trois références du marché (IGN, GameSpot, OpenCritic) afin d’identifier les écarts et priorités d’évolution.
+
+## Synthèse des écarts majeurs
+| Axe | Notation JLG | IGN | GameSpot | OpenCritic | Opportunités |
+| --- | --- | --- | --- | --- | --- |
+| **Structure de review** | Bloc tout-en-un, shortcodes modulaires, badge éditorial, tagline bilingue, histogramme lecteurs | Présentation hiérarchisée (score en tête, « Verdict », encarts « + / - », vidéo review synchronisée) | Mise en avant de sections thématiques (Gameplay, Graphismes, Conclusion), modules « Review in Progress » et timelines | Agrégation multi-critiques avec indicateurs « Top Critic Average », « Critics Recommend », résumé automatique | Ajouter un template « Verdict » enrichi (résumé + CTA), prise en charge d’un mode « Review en cours » et mise en page multi-sections paramétrable. |
+| **Couverture multi-plateforme** | Métadonnées plateforme + Game Explorer filtrable | Comparatifs par plateforme (performance, visuels, mode 60 FPS) | Encadrés « Platform Differences » et recommandations matérielles | Regroupement par plateforme + lien vers versions spécifiques | Ajouter un composant de comparatif plateformes (tableau performances, patches, recommandations). |
+| **Engagement & communautés** | Votes lecteurs, histogramme en temps réel, Score Insights (moyenne, médiane, top plateformes) | Systèmes de commentaires, intégration réseaux sociaux, suggestions d’articles liés | Highlights communautaires, carrousel de guides/astuces, statistiques de temps de jeu | Suivi d’activité critique (Trending, Hype Meter) | Enrichir Score Insights avec segmentation (lecteurs vs rédaction), ajouter modules « Guides associés » et badges sociaux partageables. |
+| **Monétisation & conversion** | Pas de module dédié | Encarts affiliés (Amazon, partenaires), bannières deals dynamiques | Boutons « Buy Now » multi-boutiques, alertes prix | Agrégateur de prix & disponibilité, wishlist | Créer un widget « Deals & disponibilités » intégrable dans bloc complet (affiliation, stocks). |
+| **Automation & data** | Remplissage RAWG, validation PEGI/date, Score Insights | Lien API interne (IGN Playlist), systèmes de recommandations personnalisés | Réutilisation back-office (planning éditorial, notes partagées), intégrations CMS custom | API publique, export CSV, webhooks pour notifs | Étendre API REST du plugin (exposition des moyennes, insights, votes) et prévoir exports CSV automatiques. |
+
+## Recommandations priorisées
+1. **Template Verdict & mode « Review en cours » (P0)**
+   - Ajouter un sous-bloc optionnel dans `[jlg_bloc_complet]`/bloc tout-en-un pour afficher résumé, verdict, date de mise à jour, statut (En cours / Final / Mise à jour patch). 
+   - Permettre la planification d’un rappel (cron) pour transformer automatiquement le statut « En cours » en « Final » après publication d’une mise à jour.
+
+2. **Comparateur multi-plateformes (P0)**
+   - Nouveau shortcode/bloc `jlg_platform_breakdown` utilisant les métadonnées existantes pour afficher performances (fps, résolution, mode) + champs personnalisés.
+   - Intégrer des microdonnées supplémentaires (`isBasedOn`, `gamePlatform`) pour aligner sur les fiches IGN/GameSpot.
+
+3. **Widget Deals & disponibilités (P1)**
+   - Module optionnel alimenté par des champs d’affiliation (lien, prix, vendeur) et compatible avec l’API RAWG pour récupérer la disponibilité régionale.
+   - Prise en charge de liens trackés (Amazon, FNAC, PS Store) et possibilité de trier par meilleur prix.
+
+4. **Segmentation Insights & recommandations croisées (P1)**
+   - Étendre `[jlg_score_insights]` avec comparaison rédaction/lecteurs, évolution temporelle (sparkline) et surfaces de points forts/faibles les plus cités.
+   - Ajouter un panneau « Guides associés / articles connexes » alimenté par taxonomies (catégories, plateformes) pour rivaliser avec les carrousels GameSpot.
+
+5. **API & exports avancés (P2)**
+   - Exposer via REST `/jlg/v1/ratings` les moyennes par jeu, la distribution des votes et les notes par plateforme.
+   - Ajouter une commande WP-CLI `jlg export:ratings` pour générer un CSV consolidé (notes, plateformes, badge coup de cœur, moyenne lecteurs) facilitant les usages marketing.
+
+## Suivi
+- Documenter toute implémentation future dans `docs/` (sous dossier `product-roadmap/` à créer si nécessaire).
+- Prévoir une nouvelle passe benchmark dans 6 mois pour mesurer l’écart après implémentation des priorités P0/P1.


### PR DESCRIPTION
## Summary
- document a market comparison against IGN, GameSpot and OpenCritic with prioritized follow-up actions
- refresh both READMEs to list every current shortcode, Gutenberg block and advanced feature now available

## Testing
- composer test
- composer cs *(fails: existing PHPCS alignment issues in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3028bedc4832ea3741bdc5a14966f