### PR TITLE
Fix coding standards violations blocking composer cs

### DIFF
--- a/plugin-notation-jeux_V4/docs/benchmark-2025-10-06.md
+++ b/plugin-notation-jeux_V4/docs/benchmark-2025-10-06.md
@@ -1,0 +1,55 @@
+# Benchmark produit – 6 octobre 2025
+
+## Périmètre et sources
+- **Plugin étudié :** Notation JLG v5.0 (fonctionnalités décrites dans la documentation actuelle).
+- **Références pro :** IGN (template Review 2024), GameSpot (Review hub 2024), OpenCritic (aggregator dashboards 2024).
+- **Focus demandé :** options de configuration, UX/UI, navigation mobile, accessibilité, parité front ↔ éditeur WordPress.
+
+## Synthèse rapide
+| Thème | Niveau actuel du plugin | Référence pro | Gap constaté | Opportunités prioritaires |
+| --- | --- | --- | --- | --- |
+| Options de mise en page | Styles préconfigurés (moderne/classique/compact), réglages couleurs, seuil coup de cœur, bascule animations, grille Game Explorer personnalisable. | IGN/ GameSpot proposent des layouts modulaires avec sections réarrangeables, options spoiler/collapse, CTA affiliées, widgets cross-media. | Manque de contrôle section par section (ordre, visibilité), absence d’intégration achat/CTA, pas de prise en charge des avertissements spoiler. | Introduire un concepteur de layout par drag-and-drop, modules CTA affiliés, options d’avertissement spoiler et encadrés contextuels. |
+| UX/UI desktop | Bloc tout-en-un et shortcodes offrent synthèse note + pros/cons + tagline, histogramme lecteurs, Game Explorer accessible. | IGN affiche un *review verdict* sticky, résumés chiffrés, carrousels médias, timeline post-launch. GameSpot ajoute badges (Must Play), modules « Where to Buy ». | Scoreboard manque de résumé persistant, absence de carrousel média et timeline, pas de badges événementiels. | Ajouter carte verdict épinglée, carrousel média responsive avec annotation, badges dynamiques (mise à jour live service). |
+| Navigation mobile | Filtres Game Explorer repliables, histogramme responsive, tableaux convertibles en cartes. | IGN et GameSpot utilisent sommaires ancrés, en-têtes sticky, carrousels horizontaux, boutons d’action flottants. | Manque de sommaire in-page mobile, navigation sticky, CTA flottants. | Ajouter table des matières mobile, headers collants pour sections clés, boutons flottants (vote, partage, achat). |
+| Accessibilité | Respect `prefers-reduced-motion`, focus visibles, ARIA pour histogramme et navigation Game Explorer, support clavier complet. | OpenCritic fournit bascule contraste élevé, résumés textuels alternatifs pour graphiques, navigation skip links. | Pas de mode contraste renforcé, graphiques limités aux barres, absence de skip links et de légendes textuelles. | Ajouter toggle contraste, descriptifs textuels de données, skip links, contrôle granularité ARIA (ex : `aria-live` sur votes). |
+| Apparence éditeur WordPress | Blocs Gutenberg mirror du rendu front (thème clair/sombre, animations on/off), chargement auto des assets lors du rendu. | Pro tools internes affichent variations live (multi-device preview), checklists de contenu, placeholders médias. | Pas d’aperçu multi-device, pas de guides inline, prévisualisation limitée aux thèmes clair/sombre. | Ajouter panneau de prévisualisation responsive (desktop/tablette/mobile), onboarding inline (tips), placeholders média/CTA dans l’éditeur visuel. |
+
+## Détails & recommandations
+
+### 1. Options de configuration
+- **Concepteur de layout** : proposer un module permettant de réordonner les sections (note, verdict, pros/cons, fiche technique, médias, CTA) via un système de glisser-déposer avec sauvegarde par défaut et overrides par article. Les styles actuels (« moderne/classique/compact ») pourraient devenir des presets.
+- **Modules CTA & monétisation** : ajouter un sous-panneau pour configurer des boutons « Où acheter » (libellé, URL, suivi affilié, icônes store). Possibilité d’injecter automatiquement les CTA dans le bloc tout-en-un et le Game Explorer.
+- **Cartouche spoiler / avertissements** : offrir un bloc « Spoiler alert » repliable avec message personnalisé et icône, inspiré des collapsibles utilisés par IGN.
+- **Personnalisation médias** : permettre la sélection d’une galerie/capture clé et d’une vidéo héro, avec option d’autoplay sur desktop uniquement et fallback image accessible.
+- **Timeline post-lancement** : introduire un champ structuré pour documenter les mises à jour majeures (patches, DLC), aligné sur ce que GameSpot/IGN affichent pour les jeux service.
+
+### 2. UX/UI
+- **Carte verdict sticky** : afficher un panneau flottant résumant note globale, badge, CTA et liens vers sections clés. Le plugin gère déjà le badge « Coup de cœur », ce panneau pourrait l’exploiter et ajouter un comparatif note rédaction/lecteurs.【F:plugin-notation-jeux_V4/README.md†L24-L76】
+- **Carrousel média** : intégrer un composant slider accessible (contrôles clavier, pagination ARIA) alimenté par la médiathèque ou les URL vidéos détectées par les helpers actuels.【F:plugin-notation-jeux_V4/README.md†L33-L44】
+- **Badges dynamiques** : étendre le système de badge pour couvrir plusieurs statuts (ex : « Must Play », « Editor’s Choice », « En attente de patch »), gérables depuis les réglages.
+- **Mise en avant des insights** : enrichir `[jlg_score_insights]` avec graphiques additionnels (courbe d’évolution des notes, nuage de plateformes) et exports image/CSV pour partage.【F:plugin-notation-jeux_V4/README.md†L107-L135】
+
+### 3. Navigation mobile
+- **Sommaire ancré** : générer automatiquement une liste des sections principales (Résumé, Note, Pros/Cons, Verdict, CTA, Timeline) avec ancrage smooth compatible `prefers-reduced-motion`.
+- **En-têtes sticky** : fixer la note globale et les actions clé en haut de l’écran lors du scroll.
+- **Navigation gestuelle** : offrir un carrousel horizontal pour passer d’une section à l’autre (ex : « Résumé », « Détails », « Avis lecteurs »), avec pagination et support clavier.
+- **Actions flottantes** : bouton flottant pour voter (lorsque `[notation_utilisateurs_jlg]` est actif) ou partager, aligné sur les patterns mobile d’IGN/GameSpot.
+
+### 4. Accessibilité
+- **Mode contraste élevé** : ajouter un toggle global qui ajuste la palette (fond, texte, bordures) et force un ratio AA/AAA. Les couleurs personnalisables actuelles pourraient inclure un duo « couleurs standard / contraste ».
+- **Descriptions alternatives** : générer des résumés textuels automatiques pour les histogrammes de votes et futures visualisations, inspirés des bonnes pratiques d’OpenCritic.
+- **Skip links & ordre de tabulation** : injecter des liens « Aller au verdict », « Aller aux avis lecteurs », etc. au début du bloc tout-en-un.
+- **Feedback ARIA enrichi** : lors du vote lecteurs, annoncer le changement de moyenne via `aria-live="polite"` et fournir un message personnalisé en cas d’erreur d’envoi.【F:plugin-notation-jeux_V4/README.md†L29-L44】
+
+### 5. Apparence sur WordPress (éditeur visuel)
+- **Prévisualisation responsive** : ajouter un panneau latéral dans chaque bloc Gutenberg permettant de switcher entre vues Desktop/Tablette/Mobile (simples wrappers CSS) pour refléter ce que proposent les éditeurs pro.
+- **Guides inline & checklists** : afficher des hints contextuels (ex : « Pensez à ajouter 3 captures », « Remplissez la timeline post-lancement ») directement dans le panneau Inspector.
+- **Placeholders dynamiques** : lorsque certaines métadonnées sont manquantes, montrer des placeholders stylés (logo, gradient) plutôt qu’un simple vide, afin d’approcher la qualité visuelle d’IGN en mode brouillon.
+- **Simulation multi-thèmes** : étendre les options actuelles `preview_theme` pour inclure des presets « High Contrast », « Dark Neon », etc., facilitant les tests avant publication.【F:plugin-notation-jeux_V4/README.md†L80-L105】
+
+## Prochaines étapes recommandées
+1. **Atelier UX** avec rédaction/testeurs pour prioriser les modules (CTA, verdict sticky, sommaire mobile).
+2. **Spécifications techniques** pour le designer de layout et la bascule contraste élevé (impact CSS/JS, stockage réglages).
+3. **Prototype éditeur** (Storybook ou Storybook-like dans Gutenberg) pour valider les previews multi-device.
+4. **Itération accessibilité** : audit supplémentaire (Lighthouse + axe DevTools) après implémentation des nouveaux contrôles.
+5. **Documentation** : mettre à jour README et guides utilisateurs lors de chaque livraison pour refléter les nouvelles options.

--- a/plugin-notation-jeux_V4/includes/Admin/Ajax.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Ajax.php
@@ -6,7 +6,7 @@ use JLG\Notation\Helpers;
 use JLG\Notation\Utils\Validator;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Ajax {
@@ -230,7 +230,7 @@ class Ajax {
             $pegi = $raw_game['esrb_rating']['name'];
         }
 
-        $cover_image = '';
+        $cover_image      = '';
         $cover_candidates = array();
 
         if ( ! empty( $raw_game['background_image'] ) ) {
@@ -312,9 +312,9 @@ class Ajax {
 
         if ( $game['cover_image'] !== '' ) {
             if ( is_scalar( $game['cover_image'] ) ) {
-                $cover_value      = trim( (string) $game['cover_image'] );
-                $sanitized_cover  = esc_url_raw( $cover_value );
-                $is_valid_sanitize = is_string( $sanitized_cover ) && $sanitized_cover !== '' && filter_var( $sanitized_cover, FILTER_VALIDATE_URL );
+                $cover_value         = trim( (string) $game['cover_image'] );
+                $sanitized_cover     = esc_url_raw( $cover_value );
+                $is_valid_sanitize   = is_string( $sanitized_cover ) && $sanitized_cover !== '' && filter_var( $sanitized_cover, FILTER_VALIDATE_URL );
                 $game['cover_image'] = $is_valid_sanitize ? $sanitized_cover : '';
             } else {
                 $game['cover_image'] = '';

--- a/plugin-notation-jeux_V4/includes/Admin/Core.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Core.php
@@ -9,7 +9,7 @@ use JLG\Notation\Admin\Platforms;
 use JLG\Notation\Admin\Settings;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Core {

--- a/plugin-notation-jeux_V4/includes/Admin/Menu.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Menu.php
@@ -13,7 +13,7 @@ use JLG\Notation\Utils\TemplateLoader;
 use WP_Query;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Menu {
@@ -115,10 +115,10 @@ class Menu {
             return TemplateLoader::get_admin_template(
                 'tabs/posts-list',
                 array(
-                                        'has_rated_posts' => false,
-                                        'empty_state'     => $empty_state,
-                                        'insights'        => Helpers::get_posts_score_insights( array() ),
-                                )
+					'has_rated_posts' => false,
+					'empty_state'     => $empty_state,
+					'insights'        => Helpers::get_posts_score_insights( array() ),
+				)
             );
         }
 
@@ -215,20 +215,20 @@ class Menu {
         return TemplateLoader::get_admin_template(
             'tabs/posts-list',
             array(
-                                'has_rated_posts'    => true,
-                                'empty_state'        => $empty_state,
-                                'stats'              => array(
-                                        'total_items'   => $total_items,
-                                        'current_page'  => $current_page,
-                                        'total_pages'   => $total_pages,
-                                        'display_count' => count( $posts ),
-                                ),
-                                'insights'           => Helpers::get_posts_score_insights( $rated_posts ),
-                                'columns'            => $this->get_sortable_columns( $orderby, $order ),
-                                'posts'              => $posts,
-                                'pagination'         => $pagination,
-                                'print_button_label' => __( '🖨️ Imprimer cette liste', 'notation-jlg' ),
-                        )
+				'has_rated_posts'    => true,
+				'empty_state'        => $empty_state,
+				'stats'              => array(
+					'total_items'   => $total_items,
+					'current_page'  => $current_page,
+					'total_pages'   => $total_pages,
+					'display_count' => count( $posts ),
+				),
+				'insights'           => Helpers::get_posts_score_insights( $rated_posts ),
+				'columns'            => $this->get_sortable_columns( $orderby, $order ),
+				'posts'              => $posts,
+				'pagination'         => $pagination,
+				'print_button_label' => __( '🖨️ Imprimer cette liste', 'notation-jlg' ),
+			)
         );
     }
 

--- a/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
@@ -7,7 +7,7 @@ use JLG\Notation\Helpers;
 use JLG\Notation\Utils\Validator;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Metaboxes {
@@ -286,8 +286,8 @@ class Metaboxes {
         echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'YouTube et Vimeo sont pris en charge. Le mode sans cookie sera appliqué automatiquement quand possible.', 'notation-jlg' ) . '</p>';
         echo '</div>';
 
-        $provider_value = isset( $meta['review_video_provider'] ) ? (string) $meta['review_video_provider'] : '';
-        $provider_value = Validator::sanitize_video_provider( $provider_value );
+        $provider_value   = isset( $meta['review_video_provider'] ) ? (string) $meta['review_video_provider'] : '';
+        $provider_value   = Validator::sanitize_video_provider( $provider_value );
         $provider_options = Validator::get_allowed_video_providers();
 
         echo '<div>';

--- a/plugin-notation-jeux_V4/includes/Admin/Platforms.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Platforms.php
@@ -11,7 +11,7 @@ namespace JLG\Notation\Admin;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Platforms {
@@ -885,11 +885,17 @@ class Platforms {
                                     <?php endif; ?>
                                     <?php if ( ! empty( $linked_tag_terms ) ) : ?>
                                         <ul class="jlg-platform-tags" style="margin: 8px 0 0; padding: 0; list-style: none; display: flex; flex-wrap: wrap; gap: 6px;">
-                                            <?php foreach ( $linked_tag_terms as $term ) : if ( $term instanceof WP_Term ) : ?>
+                                            <?php
+                                            foreach ( $linked_tag_terms as $term ) :
+												if ( $term instanceof WP_Term ) :
+													?>
                                                 <li style="background: #f0f6fc; border: 1px solid #d0e3f3; color: #1d4f73; padding: 2px 8px; border-radius: 999px; font-size: 11px;">
                                                     <?php echo esc_html( $term->name ); ?>
                                                 </li>
-                                            <?php endif; endforeach; ?>
+													<?php
+                                            endif;
+endforeach;
+											?>
                                         </ul>
                                     <?php endif; ?>
                                 </td>
@@ -907,7 +913,7 @@ class Platforms {
                                     <input type="hidden" name="platform_order[]" value="<?php echo esc_attr( $key ); ?>">
                                 </td>
                             </tr>
-                            <?php
+								<?php
                                 ++$position;
                             endforeach;
                             ?>

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -12,7 +12,7 @@ use JLG\Notation\Helpers;
 use JLG\Notation\Utils\FormRenderer;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Settings {
@@ -535,12 +535,12 @@ class Settings {
         // Section 3: Présentation de la Note Globale
         add_settings_section( 'jlg_layout', '3. 🎨 Présentation de la Note Globale', null, 'notation_jlg_page' );
         $score_max_field_args = array(
-            'id'    => 'score_max',
-            'type'  => 'number',
-            'min'   => 5,
-            'max'   => 100,
-            'step'  => 1,
-            'desc'  => __( 'Définissez la note maximale utilisée pour vos tests (par exemple 10, 20 ou 100).', 'notation-jlg' ),
+            'id'   => 'score_max',
+            'type' => 'number',
+            'min'  => 5,
+            'max'  => 100,
+            'step' => 1,
+            'desc' => __( 'Définissez la note maximale utilisée pour vos tests (par exemple 10, 20 ou 100).', 'notation-jlg' ),
         );
         add_settings_field(
             'score_max',
@@ -879,11 +879,11 @@ class Settings {
         // Section 7: Modules
         add_settings_section( 'jlg_modules', '7. 🧩 Modules', null, 'notation_jlg_page' );
         $module_fields = array(
-            'user_rating_enabled'   => 'Notation utilisateurs',
-            'rating_badge_enabled'  => 'Badge « Coup de cœur »',
-            'tagline_enabled'       => 'Taglines bilingues',
-            'seo_schema_enabled'    => 'Schéma SEO (étoiles Google)',
-            'enable_animations'     => 'Animations des barres',
+            'user_rating_enabled'  => 'Notation utilisateurs',
+            'rating_badge_enabled' => 'Badge « Coup de cœur »',
+            'tagline_enabled'      => 'Taglines bilingues',
+            'seo_schema_enabled'   => 'Schéma SEO (étoiles Google)',
+            'enable_animations'    => 'Animations des barres',
         );
         foreach ( $module_fields as $id => $title ) {
             add_settings_field(
@@ -893,20 +893,20 @@ class Settings {
                 'notation_jlg_page',
                 'jlg_modules',
                 array(
-                                        'id'   => $id,
-                                        'type' => 'checkbox',
-                                )
+					'id'   => $id,
+					'type' => 'checkbox',
+				)
             );
         }
 
         $rating_badge_threshold_args = array(
-                        'id'   => 'rating_badge_threshold',
-                        'type' => 'number',
-                        'min'  => 0,
-                        'max'  => Helpers::get_score_max(),
-                        'step' => 0.1,
-                        'desc' => __( 'Le badge apparaît lorsque la note globale atteint ce seuil. Utilisez le même barème que vos tests (ex. 8 pour un barème sur 10).', 'notation-jlg' ),
-                );
+			'id'   => 'rating_badge_threshold',
+			'type' => 'number',
+			'min'  => 0,
+			'max'  => Helpers::get_score_max(),
+			'step' => 0.1,
+			'desc' => __( 'Le badge apparaît lorsque la note globale atteint ce seuil. Utilisez le même barème que vos tests (ex. 8 pour un barème sur 10).', 'notation-jlg' ),
+		);
         add_settings_field(
             'rating_badge_threshold',
             __( 'Seuil du badge', 'notation-jlg' ),
@@ -988,9 +988,9 @@ class Settings {
             'notation_jlg_page',
             'jlg_user_rating_section',
             array(
-                                'id'   => 'user_rating_star_color',
-                                'type' => 'color',
-                        )
+				'id'   => 'user_rating_star_color',
+				'type' => 'color',
+			)
         );
         add_settings_field(
             'user_rating_requires_login',
@@ -999,10 +999,10 @@ class Settings {
             'notation_jlg_page',
             'jlg_user_rating_section',
             array(
-                                'id'   => 'user_rating_requires_login',
-                                'type' => 'checkbox',
-                                'desc' => __( 'Empêche les visiteurs non connectés de voter et leur affiche un lien de connexion.', 'notation-jlg' ),
-                        )
+				'id'   => 'user_rating_requires_login',
+				'type' => 'checkbox',
+				'desc' => __( 'Empêche les visiteurs non connectés de voter et leur affiche un lien de connexion.', 'notation-jlg' ),
+			)
         );
 
         // Section 10: Tableau Récapitulatif
@@ -1289,12 +1289,12 @@ class Settings {
         );
 
         $score_position_options = array(
-            'top-left'      => __( 'En haut à gauche', 'notation-jlg' ),
-            'top-right'     => __( 'En haut à droite', 'notation-jlg' ),
-            'middle-left'   => __( 'Au centre à gauche', 'notation-jlg' ),
-            'middle-right'  => __( 'Au centre à droite', 'notation-jlg' ),
-            'bottom-left'   => __( 'En bas à gauche', 'notation-jlg' ),
-            'bottom-right'  => __( 'En bas à droite', 'notation-jlg' ),
+            'top-left'     => __( 'En haut à gauche', 'notation-jlg' ),
+            'top-right'    => __( 'En haut à droite', 'notation-jlg' ),
+            'middle-left'  => __( 'Au centre à gauche', 'notation-jlg' ),
+            'middle-right' => __( 'Au centre à droite', 'notation-jlg' ),
+            'bottom-left'  => __( 'En bas à gauche', 'notation-jlg' ),
+            'bottom-right' => __( 'En bas à droite', 'notation-jlg' ),
         );
 
         add_settings_field(
@@ -1495,11 +1495,11 @@ class Settings {
                 $data_attributes   = array();
 
                 if ( $allow_transparent ) {
-                    $classes[] = 'jlg-color-picker--allow-transparent';
+                    $classes[]                                 = 'jlg-color-picker--allow-transparent';
                     $data_attributes['data-allow-transparent'] = 'true';
                 }
 
-                $default_attr_value                  = is_string( $default_value ) ? $default_value : '';
+                $default_attr_value                    = is_string( $default_value ) ? $default_value : '';
                 $data_attributes['data-default-color'] = $default_attr_value;
 
                 $attributes = '';
@@ -1537,14 +1537,14 @@ class Settings {
     private function render_rating_categories_field( $args, $options ) {
         unset( $options );
 
-        $field_id      = $args['id'] ?? 'rating_categories';
-        $option_name   = $this->option_name;
-        $definitions   = Helpers::get_rating_category_definitions();
-        $wrapper_id    = $field_id . '_manager';
-        $next_index    = count( $definitions );
-        $move_up_text  = esc_html__( 'Monter', 'notation-jlg' );
+        $field_id       = $args['id'] ?? 'rating_categories';
+        $option_name    = $this->option_name;
+        $definitions    = Helpers::get_rating_category_definitions();
+        $wrapper_id     = $field_id . '_manager';
+        $next_index     = count( $definitions );
+        $move_up_text   = esc_html__( 'Monter', 'notation-jlg' );
         $move_down_text = esc_html__( 'Descendre', 'notation-jlg' );
-        $move_up_aria  = esc_attr__( 'Monter la catégorie', 'notation-jlg' );
+        $move_up_aria   = esc_attr__( 'Monter la catégorie', 'notation-jlg' );
         $move_down_aria = esc_attr__( 'Descendre la catégorie', 'notation-jlg' );
 
         static $styles_printed = false;
@@ -1566,15 +1566,15 @@ class Settings {
         echo '<div class="jlg-rating-categories__list">';
 
         foreach ( $definitions as $index => $definition ) {
-            $label       = isset( $definition['label'] ) ? $definition['label'] : '';
-            $id          = isset( $definition['id'] ) ? $definition['id'] : '';
-            $position    = isset( $definition['position'] ) ? (int) $definition['position'] : ( $index + 1 );
-            $legacy_ids  = isset( $definition['legacy_ids'] ) && is_array( $definition['legacy_ids'] ) ? $definition['legacy_ids'] : array();
-            $weight      = isset( $definition['weight'] )
+            $label          = isset( $definition['label'] ) ? $definition['label'] : '';
+            $id             = isset( $definition['id'] ) ? $definition['id'] : '';
+            $position       = isset( $definition['position'] ) ? (int) $definition['position'] : ( $index + 1 );
+            $legacy_ids     = isset( $definition['legacy_ids'] ) && is_array( $definition['legacy_ids'] ) ? $definition['legacy_ids'] : array();
+            $weight         = isset( $definition['weight'] )
                 ? Helpers::normalize_category_weight( $definition['weight'], 1.0 )
                 : 1.0;
-            $label_field = sprintf( '%s[%s][%d][label]', $option_name, $field_id, $index );
-            $id_field    = sprintf( '%s[%s][%d][id]', $option_name, $field_id, $index );
+            $label_field    = sprintf( '%s[%s][%d][label]', $option_name, $field_id, $index );
+            $id_field       = sprintf( '%s[%s][%d][id]', $option_name, $field_id, $index );
             $position_field = sprintf( '%s[%s][%d][position]', $option_name, $field_id, $index );
             $weight_field   = sprintf( '%s[%s][%d][weight]', $option_name, $field_id, $index );
             $weight_value   = number_format( $weight, 1, '.', '' );
@@ -1623,8 +1623,8 @@ class Settings {
 
         echo '</div>';
 
-        $template_label = esc_attr__( 'Libellé', 'notation-jlg' );
-        $template_id    = esc_attr__( 'Identifiant', 'notation-jlg' );
+        $template_label  = esc_attr__( 'Libellé', 'notation-jlg' );
+        $template_id     = esc_attr__( 'Identifiant', 'notation-jlg' );
         $template_remove = esc_attr__( 'Supprimer', 'notation-jlg' );
         $template_desc   = esc_html__( 'Utilisé pour la clé méta (_note_identifiant). Lettres minuscules, chiffres, tirets et soulignés uniquement.', 'notation-jlg' );
 
@@ -1694,5 +1694,4 @@ class Settings {
             echo '</details>';
         }
     }
-
 }

--- a/plugin-notation-jeux_V4/includes/Assets.php
+++ b/plugin-notation-jeux_V4/includes/Assets.php
@@ -3,7 +3,7 @@
 namespace JLG\Notation;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Assets {
@@ -149,13 +149,13 @@ class Assets {
             'jlgUserRatingL10n',
             function () {
                 return array(
-                                        'successMessage'      => __( 'Merci pour votre vote !', 'notation-jlg' ),
-                                        'genericErrorMessage' => __( 'Erreur. Veuillez réessayer.', 'notation-jlg' ),
-                                        'alreadyVotedMessage' => __( 'Vous avez déjà voté !', 'notation-jlg' ),
-                                        'loginRequiredMessage' => __( 'Connectez-vous pour voter.', 'notation-jlg' ),
-                                        'loginLinkLabel'       => __( 'Se connecter', 'notation-jlg' ),
-                                );
-                        }
+					'successMessage'       => __( 'Merci pour votre vote !', 'notation-jlg' ),
+					'genericErrorMessage'  => __( 'Erreur. Veuillez réessayer.', 'notation-jlg' ),
+					'alreadyVotedMessage'  => __( 'Vous avez déjà voté !', 'notation-jlg' ),
+					'loginRequiredMessage' => __( 'Connectez-vous pour voter.', 'notation-jlg' ),
+					'loginLinkLabel'       => __( 'Se connecter', 'notation-jlg' ),
+				);
+			}
         );
 
         $this->register_localization(

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -25,14 +25,14 @@ class Frontend {
     public const FRONTEND_STYLE_HANDLE      = 'jlg-frontend';
     public const GAME_EXPLORER_STYLE_HANDLE = 'jlg-game-explorer';
 
-    private const USER_RATING_MAX_STORED_VOTES       = 250;
-    private const USER_RATING_RETENTION_DAYS         = 180;
-    private const USER_RATING_THROTTLE_WINDOW        = 120;
-    private const USER_RATING_THROTTLE_TTL           = 900;
-    private const USER_RATING_ACTIVITY_OPTION        = 'jlg_user_rating_activity_log';
-    private const USER_RATING_ACTIVITY_MAX_ENTRIES   = 200;
-    private const USER_RATING_REPUTATION_OPTION      = 'jlg_user_rating_reputation';
-    private const USER_RATING_BANNED_TOKENS_OPTION   = 'jlg_user_rating_banned_tokens';
+    private const USER_RATING_MAX_STORED_VOTES     = 250;
+    private const USER_RATING_RETENTION_DAYS       = 180;
+    private const USER_RATING_THROTTLE_WINDOW      = 120;
+    private const USER_RATING_THROTTLE_TTL         = 900;
+    private const USER_RATING_ACTIVITY_OPTION      = 'jlg_user_rating_activity_log';
+    private const USER_RATING_ACTIVITY_MAX_ENTRIES = 200;
+    private const USER_RATING_REPUTATION_OPTION    = 'jlg_user_rating_reputation';
+    private const USER_RATING_BANNED_TOKENS_OPTION = 'jlg_user_rating_banned_tokens';
 
     /**
      * Contiendra les erreurs de chargement des shortcodes pour affichage.
@@ -926,11 +926,11 @@ class Frontend {
         $count      = isset( $previous_entry['count'] ) ? max( 0, (int) $previous_entry['count'] ) : 0;
         $timestamp  = current_time( 'timestamp' );
         $new_record = array(
-            'count'       => $count + 1,
-            'last_post'   => (int) $post_id,
-            'last_user_id'=> (int) $user_id,
-            'last_weight' => (float) $weight,
-            'updated_at'  => $timestamp,
+            'count'        => $count + 1,
+            'last_post'    => (int) $post_id,
+            'last_user_id' => (int) $user_id,
+            'last_weight'  => (float) $weight,
+            'updated_at'   => $timestamp,
         );
 
         $store[ $token_hash ] = $new_record;
@@ -961,7 +961,9 @@ class Frontend {
             }
         );
 
-        while ( count( $store ) > $max_entries ) {
+        $store_count = count( $store );
+
+        while ( $store_count > $max_entries ) {
             $first_key = key( $store );
 
             if ( $first_key === null ) {
@@ -971,6 +973,7 @@ class Frontend {
             unset( $store[ $first_key ] );
 
             reset( $store );
+            $store_count = count( $store );
         }
     }
 
@@ -1281,7 +1284,7 @@ class Frontend {
         if ( empty( $options['user_rating_enabled'] ) ) {
             wp_send_json_error(
                 array(
-                                        'message' => esc_html__( 'La notation des lecteurs est désactivée.', 'notation-jlg' ),
+					'message' => esc_html__( 'La notation des lecteurs est désactivée.', 'notation-jlg' ),
                 ),
                 403
             );
@@ -1627,7 +1630,7 @@ class Frontend {
                 continue;
             }
 
-            $count++;
+            ++$count;
 
             $weight = isset( $meta['weights'][ $hash ] ) && is_numeric( $meta['weights'][ $hash ] ) ? (float) $meta['weights'][ $hash ] : 1.0;
             $weight = max( 0.0, $weight );
@@ -1636,12 +1639,12 @@ class Frontend {
             $weight_total += $weight;
         }
 
-        $existing     = isset( $meta['aggregates'] ) && is_array( $meta['aggregates'] ) ? $meta['aggregates'] : array();
-        $current_sum  = isset( $existing['weighted_sum'] ) ? (float) $existing['weighted_sum'] : null;
-        $current_total = isset( $existing['weight_total'] ) ? (float) $existing['weight_total'] : null;
-        $current_count = isset( $existing['count'] ) ? (int) $existing['count'] : null;
+        $existing        = isset( $meta['aggregates'] ) && is_array( $meta['aggregates'] ) ? $meta['aggregates'] : array();
+        $current_sum     = isset( $existing['weighted_sum'] ) ? (float) $existing['weighted_sum'] : null;
+        $current_total   = isset( $existing['weight_total'] ) ? (float) $existing['weight_total'] : null;
+        $current_count   = isset( $existing['count'] ) ? (int) $existing['count'] : null;
         $current_average = isset( $existing['average'] ) ? (float) $existing['average'] : null;
-        $computed_at  = isset( $existing['computed_at'] ) ? (int) $existing['computed_at'] : current_time( 'timestamp' );
+        $computed_at     = isset( $existing['computed_at'] ) ? (int) $existing['computed_at'] : current_time( 'timestamp' );
 
         $average = 0.0;
 
@@ -1875,7 +1878,7 @@ class Frontend {
                 continue;
             }
 
-            $count++;
+            ++$count;
 
             $weight = isset( $weights[ $hash ] ) && is_numeric( $weights[ $hash ] ) ? (float) $weights[ $hash ] : 1.0;
             $weight = max( 0.0, $weight );
@@ -2224,8 +2227,8 @@ class Frontend {
         if ( ! empty( $context['error'] ) && ! empty( $context['message'] ) ) {
             wp_send_json_success(
                 array(
-                    'html'  => $context['message'],
-                    'state' => $state,
+                    'html'   => $context['message'],
+                    'state'  => $state,
                     'config' => $context['config_payload'] ?? array(),
                 )
             );
@@ -2403,11 +2406,11 @@ class Frontend {
         $review_body   = $this->resolve_review_body_for_schema( $post_id, $schema_locale );
 
         $schema = array(
-            '@context'    => 'https://schema.org',
-            '@type'       => 'Game',
-            'name'        => $game_title,
-            'inLanguage'  => $schema_locale !== '' ? $schema_locale : null,
-            'review'      => array(
+            '@context'   => 'https://schema.org',
+            '@type'      => 'Game',
+            'name'       => $game_title,
+            'inLanguage' => $schema_locale !== '' ? $schema_locale : null,
+            'review'     => array(
                 '@type'         => 'Review',
                 'reviewRating'  => array(
                     '@type'       => 'Rating',
@@ -2447,19 +2450,19 @@ class Frontend {
 
         $platforms = $this->collect_platforms_for_schema( $post_id, $schema_locale );
         if ( ! empty( $platforms ) ) {
-            $schema['availableOnDevice'] = $platforms;
+            $schema['availableOnDevice']   = $platforms;
             $item_reviewed['gamePlatform'] = $platforms;
         }
 
         $images = $this->collect_images_for_schema( $post_id );
         if ( ! empty( $images ) ) {
-            $schema['image'] = count( $images ) === 1 ? $images[0] : $images;
+            $schema['image']        = count( $images ) === 1 ? $images[0] : $images;
             $item_reviewed['image'] = $schema['image'];
         }
 
         $video_object = $this->build_video_object_for_schema( $post_id, $game_title, $schema_locale, $review_body );
         if ( ! empty( $video_object ) ) {
-            $schema['video'] = $video_object;
+            $schema['video']          = $video_object;
             $item_reviewed['trailer'] = $video_object;
         }
 
@@ -2550,7 +2553,7 @@ class Frontend {
                 );
             }
 
-            $breakdown = self::get_user_rating_breakdown_for_post( $post_id );
+            $breakdown               = self::get_user_rating_breakdown_for_post( $post_id );
             $distribution_properties = array();
 
             if ( is_array( $breakdown ) ) {
@@ -2559,7 +2562,7 @@ class Frontend {
                         continue;
                     }
 
-                    $bucket_label = is_numeric( $bucket ) ? (string) $bucket : (string) $bucket;
+                    $bucket_label              = is_numeric( $bucket ) ? (string) $bucket : (string) $bucket;
                     $distribution_properties[] = array(
                         '@type' => 'PropertyValue',
                         'name'  => sprintf( __( 'Rating %s', 'notation-jlg' ), $bucket_label ),
@@ -2569,9 +2572,9 @@ class Frontend {
             }
 
             $distribution_statistic = array(
-                '@type'               => 'InteractionCounter',
-                'interactionType'     => 'https://schema.org/UserInteraction',
-                'name'                => __( 'User rating distribution', 'notation-jlg' ),
+                '@type'                => 'InteractionCounter',
+                'interactionType'      => 'https://schema.org/UserInteraction',
+                'name'                 => __( 'User rating distribution', 'notation-jlg' ),
                 'userInteractionCount' => $user_rating_count,
             );
 
@@ -2592,9 +2595,9 @@ class Frontend {
                 }
 
                 $interaction_statistics[] = array(
-                    '@type'           => 'InteractionCounter',
-                    'interactionType' => 'https://schema.org/UserInteraction',
-                    'name'            => __( 'User rating trend', 'notation-jlg' ),
+                    '@type'              => 'InteractionCounter',
+                    'interactionType'    => 'https://schema.org/UserInteraction',
+                    'name'               => __( 'User rating trend', 'notation-jlg' ),
                     'additionalProperty' => array(
                         array(
                             '@type' => 'PropertyValue',
@@ -2700,14 +2703,16 @@ class Frontend {
             return '';
         }
 
-        $language = strtolower( preg_replace( '/[^a-z]/i', '', $parts[0] ) );
+        $language   = strtolower( preg_replace( '/[^a-z]/i', '', $parts[0] ) );
         $normalized = $language;
 
         if ( isset( $parts[1] ) ) {
             $normalized .= '-' . strtoupper( preg_replace( '/[^a-z]/i', '', $parts[1] ) );
         }
 
-        for ( $index = 2; $index < count( $parts ); $index++ ) {
+        $parts_count = count( $parts );
+
+        for ( $index = 2; $index < $parts_count; $index++ ) {
             $normalized .= '-' . $parts[ $index ];
         }
 
@@ -2908,8 +2913,8 @@ class Frontend {
             return '';
         }
 
-        $locale = str_replace( '_', '-', $locale );
-        $parts  = explode( '-', $locale );
+        $locale   = str_replace( '_', '-', $locale );
+        $parts    = explode( '-', $locale );
         $language = isset( $parts[0] ) ? strtolower( preg_replace( '/[^a-z]/i', '', $parts[0] ) ) : '';
 
         return $language;
@@ -3155,74 +3160,74 @@ class Frontend {
         if ( file_exists( $template_path ) ) {
             // Valeurs par défaut pour les variables utilisées par les templates existants.
             $template_defaults = array(
-                'options'              => array(),
-                'requires_login'       => false,
-                'login_required'       => false,
-                'login_url'            => '',
-                'is_logged_in'         => false,
-                'average_score'        => null,
-                'scores'               => array(),
-                'categories'           => array(),
-                'category_scores'      => array(),
-                'category_definitions' => array(),
-                'pros_list'            => array(),
-                'cons_list'            => array(),
-                'titre'                => '',
-                'champs_a_afficher'    => array(),
-                'tagline_fr'           => '',
-                'tagline_en'           => '',
-                'review_video'         => array(),
-                'query'                => null,
-                'atts'                 => array(),
-                'block_classes'        => '',
-                'css_variables'        => '',
-                'extra_classes'        => '',
-                'score_layout'         => 'text',
-                'animations_enabled'   => false,
+                'options'                  => array(),
+                'requires_login'           => false,
+                'login_required'           => false,
+                'login_url'                => '',
+                'is_logged_in'             => false,
+                'average_score'            => null,
+                'scores'                   => array(),
+                'categories'               => array(),
+                'category_scores'          => array(),
+                'category_definitions'     => array(),
+                'pros_list'                => array(),
+                'cons_list'                => array(),
+                'titre'                    => '',
+                'champs_a_afficher'        => array(),
+                'tagline_fr'               => '',
+                'tagline_en'               => '',
+                'review_video'             => array(),
+                'query'                    => null,
+                'atts'                     => array(),
+                'block_classes'            => '',
+                'css_variables'            => '',
+                'extra_classes'            => '',
+                'score_layout'             => 'text',
+                'animations_enabled'       => false,
                 'should_show_rating_badge' => false,
-                'user_rating_average'  => null,
-                'user_rating_delta'    => null,
+                'user_rating_average'      => null,
+                'user_rating_delta'        => null,
                 'average_score_percentage' => null,
-                'paged'                => 1,
-                'orderby'              => '',
-                'order'                => '',
-                'score_max'            => Helpers::get_score_max(),
-                'colonnes'             => array(),
-                'colonnes_disponibles' => array(),
-                'error_message'        => '',
-                'cat_filter'           => 0,
-                'table_id'             => '',
-                'widget_args'          => array(),
-                'title'                => '',
-                'latest_reviews'       => null,
-                'post_id'              => null,
-                'avg_rating'           => null,
-                'count'                => 0,
-                'rating_breakdown'     => array(),
-                'has_voted'            => false,
-                'user_vote'            => 0,
-                'games'                => array(),
-                'letters'              => array(),
-                'filters'              => array(),
-                'current_filters'      => array(),
-                'pagination'           => array(
+                'paged'                    => 1,
+                'orderby'                  => '',
+                'order'                    => '',
+                'score_max'                => Helpers::get_score_max(),
+                'colonnes'                 => array(),
+                'colonnes_disponibles'     => array(),
+                'error_message'            => '',
+                'cat_filter'               => 0,
+                'table_id'                 => '',
+                'widget_args'              => array(),
+                'title'                    => '',
+                'latest_reviews'           => null,
+                'post_id'                  => null,
+                'avg_rating'               => null,
+                'count'                    => 0,
+                'rating_breakdown'         => array(),
+                'has_voted'                => false,
+                'user_vote'                => 0,
+                'games'                    => array(),
+                'letters'                  => array(),
+                'filters'                  => array(),
+                'current_filters'          => array(),
+                'pagination'               => array(
 					'current' => 1,
 					'total'   => 0,
 				),
-                'sort_options'         => array(),
-                'sort_key'             => 'date',
-                'sort_order'           => 'DESC',
-                'filters_enabled'      => array(),
-                'categories_list'      => array(),
-                'platforms_list'       => array(),
-                'availability_options' => array(),
-                'base_url'             => '',
-                'request_prefix'       => '',
-                'request_keys'         => array(),
-                'total_items'          => 0,
-                'config_payload'       => array(),
-                'message'              => '',
-                'score_position'       => Helpers::normalize_game_explorer_score_position( '' ),
+                'sort_options'             => array(),
+                'sort_key'                 => 'date',
+                'sort_order'               => 'DESC',
+                'filters_enabled'          => array(),
+                'categories_list'          => array(),
+                'platforms_list'           => array(),
+                'availability_options'     => array(),
+                'base_url'                 => '',
+                'request_prefix'           => '',
+                'request_keys'             => array(),
+                'total_items'              => 0,
+                'config_payload'           => array(),
+                'message'                  => '',
+                'score_position'           => Helpers::normalize_game_explorer_score_position( '' ),
             );
 
             // Fusionner les arguments fournis avec les valeurs par défaut.

--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -9,7 +9,7 @@ namespace JLG\Notation;
 use JLG\Notation\Utils\Validator;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Helpers {
@@ -24,11 +24,11 @@ class Helpers {
     private const PLATFORM_TAG_OPTION                  = 'jlg_platform_tag_map';
     private const LEGACY_CATEGORY_SUFFIXES             = array( 'cat1', 'cat2', 'cat3', 'cat4', 'cat5', 'cat6' );
 
-    private static $option_name                = 'notation_jlg_settings';
-    private static $options_cache              = null;
-    private static $default_settings_cache     = null;
-    private static $category_definition_cache  = null;
-    private static $rating_meta_keys_cache     = null;
+    private static $option_name                   = 'notation_jlg_settings';
+    private static $options_cache                 = null;
+    private static $default_settings_cache        = null;
+    private static $category_definition_cache     = null;
+    private static $rating_meta_keys_cache        = null;
     private static $game_explorer_score_positions = array(
         'top-left',
         'top-right',
@@ -155,17 +155,17 @@ class Helpers {
         );
 
         return array(
-            'has_embed'               => true,
-            'provider'                => $provider,
-            'provider_label'          => $provider_label,
-            'iframe_src'              => esc_url( $iframe_src ),
-            'iframe_title'            => $title,
-            'iframe_allow'            => 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
-            'iframe_allowfullscreen'  => true,
-            'iframe_loading'          => 'lazy',
-            'iframe_referrerpolicy'   => 'strict-origin-when-cross-origin',
-            'fallback_message'        => '',
-            'original_url'            => esc_url( $sanitized_url ),
+            'has_embed'              => true,
+            'provider'               => $provider,
+            'provider_label'         => $provider_label,
+            'iframe_src'             => esc_url( $iframe_src ),
+            'iframe_title'           => $title,
+            'iframe_allow'           => 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
+            'iframe_allowfullscreen' => true,
+            'iframe_loading'         => 'lazy',
+            'iframe_referrerpolicy'  => 'strict-origin-when-cross-origin',
+            'fallback_message'       => '',
+            'original_url'           => esc_url( $sanitized_url ),
         );
     }
 
@@ -214,7 +214,7 @@ class Helpers {
         }
 
         if ( $candidate === '' && isset( $parts['path'] ) ) {
-            $path = trim( $parts['path'], '/' );
+            $path     = trim( $parts['path'], '/' );
             $segments = explode( '/', $path );
 
             if ( isset( $segments[0] ) ) {
@@ -495,9 +495,9 @@ class Helpers {
     private static function get_default_platform_definitions() {
         return array(
             'pc'              => array(
-                                'name'  => 'PC',
-                                'order' => 1,
-                        ),
+				'name'  => 'PC',
+				'order' => 1,
+			),
             'playstation-5'   => array(
 				'name'  => 'PlayStation 5',
 				'order' => 2,
@@ -519,9 +519,9 @@ class Helpers {
 				'order' => 6,
 			),
             'steam-deck'      => array(
-                                'name'  => 'Steam Deck',
-                                'order' => 7,
-                        ),
+				'name'  => 'Steam Deck',
+				'order' => 7,
+			),
         );
     }
 
@@ -890,98 +890,98 @@ class Helpers {
 
         self::$default_settings_cache = array(
             // Options générales
-            'visual_theme'                 => 'dark',
-            'score_layout'                 => 'text',
-            'score_max'                    => 10,
-            'enable_animations'            => 1,
-            'allowed_post_types'           => array( 'post' ),
-            'tagline_font_size'            => 16,
-            'rating_badge_enabled'         => 0,
-            'rating_badge_threshold'       => 8,
+            'visual_theme'                       => 'dark',
+            'score_layout'                       => 'text',
+            'score_max'                          => 10,
+            'enable_animations'                  => 1,
+            'allowed_post_types'                 => array( 'post' ),
+            'tagline_font_size'                  => 16,
+            'rating_badge_enabled'               => 0,
+            'rating_badge_threshold'             => 8,
 
             // Couleurs de Thème Sombre personnalisables
-            'dark_bg_color'                => $dark_defaults['bg_color'],
-            'dark_bg_color_secondary'      => $dark_defaults['bg_color_secondary'],
-            'dark_border_color'            => $dark_defaults['border_color'],
-            'dark_text_color'              => $dark_defaults['text_color'],
-            'dark_text_color_secondary'    => $dark_defaults['text_color_secondary'],
-            'tagline_bg_color'             => $dark_defaults['tagline_bg_color'],
-            'tagline_text_color'           => $dark_defaults['tagline_text_color'],
+            'dark_bg_color'                      => $dark_defaults['bg_color'],
+            'dark_bg_color_secondary'            => $dark_defaults['bg_color_secondary'],
+            'dark_border_color'                  => $dark_defaults['border_color'],
+            'dark_text_color'                    => $dark_defaults['text_color'],
+            'dark_text_color_secondary'          => $dark_defaults['text_color_secondary'],
+            'tagline_bg_color'                   => $dark_defaults['tagline_bg_color'],
+            'tagline_text_color'                 => $dark_defaults['tagline_text_color'],
 
             // Couleurs de Thème Clair personnalisables
-            'light_bg_color'               => $light_defaults['bg_color'],
-            'light_bg_color_secondary'     => $light_defaults['bg_color_secondary'],
-            'light_border_color'           => $light_defaults['border_color'],
-            'light_text_color'             => $light_defaults['text_color'],
-            'light_text_color_secondary'   => $light_defaults['text_color_secondary'],
+            'light_bg_color'                     => $light_defaults['bg_color'],
+            'light_bg_color_secondary'           => $light_defaults['bg_color_secondary'],
+            'light_border_color'                 => $light_defaults['border_color'],
+            'light_text_color'                   => $light_defaults['text_color'],
+            'light_text_color_secondary'         => $light_defaults['text_color_secondary'],
 
             // Couleurs sémantiques et de marque
-            'score_gradient_1'             => '#60a5fa',
-            'score_gradient_2'             => '#c084fc',
-            'color_low'                    => '#ef4444',
-            'color_mid'                    => '#f97316',
-            'color_high'                   => '#22c55e',
-            'user_rating_star_color'       => '#f59e0b',
-            'user_rating_text_color'       => '#a1a1aa',
-            'user_rating_title_color'      => '#fafafa',
+            'score_gradient_1'                   => '#60a5fa',
+            'score_gradient_2'                   => '#c084fc',
+            'color_low'                          => '#ef4444',
+            'color_mid'                          => '#f97316',
+            'color_high'                         => '#22c55e',
+            'user_rating_star_color'             => '#f59e0b',
+            'user_rating_text_color'             => '#a1a1aa',
+            'user_rating_title_color'            => '#fafafa',
 
             // Options cercle
-            'circle_dynamic_bg_enabled'    => 0,
-            'circle_border_enabled'        => 1,
-            'circle_border_width'          => 5,
-            'circle_border_color'          => '#60a5fa',
+            'circle_dynamic_bg_enabled'          => 0,
+            'circle_border_enabled'              => 1,
+            'circle_border_width'                => 5,
+            'circle_border_color'                => '#60a5fa',
 
             // Options glow pour mode texte
-            'text_glow_enabled'            => 0,
-            'text_glow_color_mode'         => 'dynamic',
-            'text_glow_custom_color'       => '#ffffff',
-            'text_glow_intensity'          => 15,
-            'text_glow_pulse'              => 0,
-            'text_glow_speed'              => 2.5,
+            'text_glow_enabled'                  => 0,
+            'text_glow_color_mode'               => 'dynamic',
+            'text_glow_custom_color'             => '#ffffff',
+            'text_glow_intensity'                => 15,
+            'text_glow_pulse'                    => 0,
+            'text_glow_speed'                    => 2.5,
 
             // Options glow pour mode cercle
-            'circle_glow_enabled'          => 0,
-            'circle_glow_color_mode'       => 'dynamic',
-            'circle_glow_custom_color'     => '#ffffff',
-            'circle_glow_intensity'        => 15,
-            'circle_glow_pulse'            => 0,
-            'circle_glow_speed'            => 2.5,
+            'circle_glow_enabled'                => 0,
+            'circle_glow_color_mode'             => 'dynamic',
+            'circle_glow_custom_color'           => '#ffffff',
+            'circle_glow_intensity'              => 15,
+            'circle_glow_pulse'                  => 0,
+            'circle_glow_speed'                  => 2.5,
 
             // Options des modules
-            'tagline_enabled'              => 1,
-            'user_rating_enabled'          => 1,
-            'user_rating_requires_login'   => 0,
-            'user_rating_weighting_enabled' => 0,
-            'user_rating_guest_weight_start' => 0.5,
+            'tagline_enabled'                    => 1,
+            'user_rating_enabled'                => 1,
+            'user_rating_requires_login'         => 0,
+            'user_rating_weighting_enabled'      => 0,
+            'user_rating_guest_weight_start'     => 0.5,
             'user_rating_guest_weight_increment' => 0.1,
-            'user_rating_guest_weight_max' => 1.0,
-            'table_zebra_striping'         => 0,
-            'table_border_style'           => 'horizontal',
-            'table_border_width'           => 1,
-            'table_header_bg_color'        => '#3f3f46',
-            'table_header_text_color'      => '#ffffff',
-            'table_row_bg_color'           => 'transparent', // Must remain literal "transparent" so CSS vars keep default transparency
-            'table_row_text_color'         => '#a1a1aa',
-            'table_zebra_bg_color'         => '#27272a',
-            'thumb_text_color'             => '#ffffff',
-            'thumb_font_size'              => 14,
-            'thumb_padding'                => 8,
-            'thumb_border_radius'          => 4,
+            'user_rating_guest_weight_max'       => 1.0,
+            'table_zebra_striping'               => 0,
+            'table_border_style'                 => 'horizontal',
+            'table_border_width'                 => 1,
+            'table_header_bg_color'              => '#3f3f46',
+            'table_header_text_color'            => '#ffffff',
+            'table_row_bg_color'                 => 'transparent', // Must remain literal "transparent" so CSS vars keep default transparency
+            'table_row_text_color'               => '#a1a1aa',
+            'table_zebra_bg_color'               => '#27272a',
+            'thumb_text_color'                   => '#ffffff',
+            'thumb_font_size'                    => 14,
+            'thumb_padding'                      => 8,
+            'thumb_border_radius'                => 4,
 
             // Options Game Explorer
-            'game_explorer_columns'        => 3,
-            'game_explorer_posts_per_page' => 12,
-            'game_explorer_filters'        => self::GAME_EXPLORER_DEFAULT_FILTERS,
-            'game_explorer_score_position' => self::GAME_EXPLORER_DEFAULT_SCORE_POSITION,
+            'game_explorer_columns'              => 3,
+            'game_explorer_posts_per_page'       => 12,
+            'game_explorer_filters'              => self::GAME_EXPLORER_DEFAULT_FILTERS,
+            'game_explorer_score_position'       => self::GAME_EXPLORER_DEFAULT_SCORE_POSITION,
 
             // Libellés & catégories de notation
-            'rating_categories'            => self::get_default_category_definitions(),
+            'rating_categories'                  => self::get_default_category_definitions(),
 
             // Options techniques et diverses
-            'custom_css'                   => '',
-            'seo_schema_enabled'           => 1,
-            'debug_mode_enabled'           => 0,
-            'rawg_api_key'                 => '',
+            'custom_css'                         => '',
+            'seo_schema_enabled'                 => 1,
+            'debug_mode_enabled'                 => 0,
+            'rawg_api_key'                       => '',
         );
 
         return self::$default_settings_cache;
@@ -1011,7 +1011,7 @@ class Helpers {
 
         self::$options_cache['game_explorer_score_position'] = self::normalize_game_explorer_score_position( $score_position );
 
-        $score_max = isset( self::$options_cache['score_max'] ) ? self::$options_cache['score_max'] : null;
+        $score_max                        = isset( self::$options_cache['score_max'] ) ? self::$options_cache['score_max'] : null;
         self::$options_cache['score_max'] = self::normalize_score_max( $score_max, self::$default_settings_cache['score_max'] ?? 10 );
 
         return self::$options_cache;
@@ -1221,7 +1221,7 @@ class Helpers {
         }
 
         $options['rating_categories'] = self::prepare_category_definitions( $category_definitions );
-        $category_definitions        = $options['rating_categories'];
+        $category_definitions         = $options['rating_categories'];
 
         foreach ( self::LEGACY_CATEGORY_SUFFIXES as $legacy_suffix ) {
             unset( $options[ 'label_' . $legacy_suffix ] );
@@ -1248,15 +1248,14 @@ class Helpers {
                     continue;
                 }
 
-                // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Table names are sourced from $wpdb.
                 $rows = $wpdb->get_results(
                     $wpdb->prepare(
+                        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name sourced from $wpdb.
                         "SELECT post_id, meta_value FROM {$postmeta_table} WHERE meta_key = %s",
                         $legacy_meta_key
                     ),
                     ARRAY_A
                 );
-                // phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
                 if ( empty( $rows ) ) {
                     continue;
@@ -1817,7 +1816,7 @@ class Helpers {
     public static function adjust_hex_brightness( $hex, $steps ) {
         $hex = str_replace( '#', '', $hex );
 
-        if ( strlen( $hex ) == 3 ) {
+        if ( strlen( $hex ) === 3 ) {
             $hex = str_repeat( substr( $hex, 0, 1 ), 2 ) .
                     str_repeat( substr( $hex, 1, 1 ), 2 ) .
                     str_repeat( substr( $hex, 2, 1 ), 2 );
@@ -2205,7 +2204,7 @@ class Helpers {
                 $slug = sanitize_title( $label );
 
                 if ( $slug === '' ) {
-                    $slug = $unknown_slug;
+                    $slug  = $unknown_slug;
                     $label = $unknown_label;
                 }
 
@@ -2247,14 +2246,14 @@ class Helpers {
 
         sort( $scores );
 
-        $mean_value = array_sum( $scores ) / $total_scores;
+        $mean_value   = array_sum( $scores ) / $total_scores;
         $median_value = self::calculate_median_from_sorted_scores( $scores );
 
         $distribution = self::build_score_distribution( $scores, $score_max );
 
         $platform_rankings = array();
         foreach ( $platforms as $data ) {
-            $average = $data['count'] > 0 ? $data['sum'] / $data['count'] : null;
+            $average             = $data['count'] > 0 ? $data['sum'] / $data['count'] : null;
             $platform_rankings[] = array(
                 'slug'              => $data['slug'],
                 'label'             => $data['label'],
@@ -2367,7 +2366,7 @@ class Helpers {
 
         foreach ( $buckets as $i => $bucket ) {
             if ( $bucket['count'] > 0 ) {
-                $percentage = ( $bucket['count'] / $total_scores ) * 100;
+                $percentage                  = ( $bucket['count'] / $total_scores ) * 100;
                 $buckets[ $i ]['percentage'] = round( $percentage, 1 );
             }
         }

--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -8,7 +8,7 @@ use WP_Query;
 use WP_Widget;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class LatestReviewsWidget extends WP_Widget {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -15,7 +15,7 @@ use JLG\Notation\Utils\Validator;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class AllInOne {
@@ -92,20 +92,20 @@ class AllInOne {
         // Attributs du shortcode
         $atts = shortcode_atts(
             array(
-                                'post_id'              => get_the_ID(),
-                                'afficher_notation'    => 'oui',
-                                'afficher_points'      => 'oui',
-                                'afficher_tagline'     => 'oui',
-                                'afficher_video'       => 'oui',
-                                'titre_points_forts'   => 'Points Forts',
-                                'titre_points_faibles' => 'Points Faibles',
-                                'style'                => 'moderne', // moderne, classique, compact
-                                'couleur_accent'       => '', // Permet de surcharger la couleur d'accent
-                                'cta_label'            => '',
-                                'cta_url'              => '',
-                                'cta_role'             => 'button',
-                                'cta_rel'              => 'nofollow sponsored',
-                                'display_mode'         => '',
+				'post_id'              => get_the_ID(),
+				'afficher_notation'    => 'oui',
+				'afficher_points'      => 'oui',
+				'afficher_tagline'     => 'oui',
+				'afficher_video'       => 'oui',
+				'titre_points_forts'   => 'Points Forts',
+				'titre_points_faibles' => 'Points Faibles',
+				'style'                => 'moderne', // moderne, classique, compact
+				'couleur_accent'       => '', // Permet de surcharger la couleur d'accent
+				'cta_label'            => '',
+				'cta_url'              => '',
+				'cta_role'             => 'button',
+				'cta_rel'              => 'nofollow sponsored',
+				'display_mode'         => '',
             ),
             $atts,
             'jlg_bloc_complet'
@@ -160,14 +160,14 @@ class AllInOne {
         }
 
         // Vérifier qu'il y a des données à afficher
-        $average_score = Helpers::get_average_score_for_post( $post_id );
-        $tagline_fr    = get_post_meta( $post_id, '_jlg_tagline_fr', true );
-        $tagline_en    = get_post_meta( $post_id, '_jlg_tagline_en', true );
-        $pros          = get_post_meta( $post_id, '_jlg_points_forts', true );
-        $cons          = get_post_meta( $post_id, '_jlg_points_faibles', true );
-        $cta_label     = get_post_meta( $post_id, '_jlg_cta_label', true );
-        $cta_url       = get_post_meta( $post_id, '_jlg_cta_url', true );
-        $video_url     = get_post_meta( $post_id, '_jlg_review_video_url', true );
+        $average_score  = Helpers::get_average_score_for_post( $post_id );
+        $tagline_fr     = get_post_meta( $post_id, '_jlg_tagline_fr', true );
+        $tagline_en     = get_post_meta( $post_id, '_jlg_tagline_en', true );
+        $pros           = get_post_meta( $post_id, '_jlg_points_forts', true );
+        $cons           = get_post_meta( $post_id, '_jlg_points_faibles', true );
+        $cta_label      = get_post_meta( $post_id, '_jlg_cta_label', true );
+        $cta_url        = get_post_meta( $post_id, '_jlg_cta_url', true );
+        $video_url      = get_post_meta( $post_id, '_jlg_review_video_url', true );
         $video_provider = get_post_meta( $post_id, '_jlg_review_video_provider', true );
 
         $cta_label = is_string( $cta_label ) ? sanitize_text_field( $cta_label ) : '';
@@ -197,10 +197,10 @@ class AllInOne {
         }
 
         // Récupération des options et configuration
-        $options               = Helpers::get_plugin_options();
-        $palette               = Helpers::get_color_palette();
-        $category_definitions  = Helpers::get_rating_category_definitions();
-        $defaults              = Helpers::get_default_settings();
+        $options              = Helpers::get_plugin_options();
+        $palette              = Helpers::get_color_palette();
+        $category_definitions = Helpers::get_rating_category_definitions();
+        $defaults             = Helpers::get_default_settings();
 
         // Couleur d'accent (utilise la couleur définie ou celle des options)
         $accent_color = $atts['couleur_accent'] ?: ( $options['score_gradient_1'] ?? '' );
@@ -237,7 +237,7 @@ class AllInOne {
 
             foreach ( $category_scores as $category_score ) {
                 if ( isset( $category_score['id'], $category_score['score'] ) ) {
-                    $category_id = (string) $category_score['id'];
+                    $category_id            = (string) $category_score['id'];
                     $scores[ $category_id ] = array(
                         'score'  => (float) $category_score['score'],
                         'weight' => isset( $category_score['weight'] )
@@ -425,30 +425,30 @@ class AllInOne {
         return Frontend::get_template_html(
             'shortcode-all-in-one',
             array(
-                                'options'            => $options,
-                                'average_score'      => $average_score,
-                                'average_score_percentage' => $average_percentage,
-                                'scores'             => $scores,
-                                'category_scores'    => $category_scores,
-                                'category_percentages' => $category_percentages,
-                                'category_definitions' => $category_definitions,
-                                'pros_list'          => $pros_list,
-                                'cons_list'          => $cons_list,
-                                'tagline_fr'         => $tagline_fr,
-                                'tagline_en'         => $tagline_en,
-                                'cta_label'          => $cta_label,
-                                'cta_url'            => $cta_url,
-                                'cta_role'           => $atts['cta_role'],
-                                'cta_rel'            => $atts['cta_rel'],
-                                'review_video'       => $review_video_data,
-                                'atts'               => $atts,
-                                'block_classes'      => $block_classes,
-                                'css_variables'      => $css_variables_string,
-                                'score_layout'       => $score_layout,
-                                'animations_enabled' => ! empty( $options['enable_animations'] ),
-                                'score_max'          => $score_max_value,
-                                'display_mode'       => $display_mode,
-                        )
+				'options'                  => $options,
+				'average_score'            => $average_score,
+				'average_score_percentage' => $average_percentage,
+				'scores'                   => $scores,
+				'category_scores'          => $category_scores,
+				'category_percentages'     => $category_percentages,
+				'category_definitions'     => $category_definitions,
+				'pros_list'                => $pros_list,
+				'cons_list'                => $cons_list,
+				'tagline_fr'               => $tagline_fr,
+				'tagline_en'               => $tagline_en,
+				'cta_label'                => $cta_label,
+				'cta_url'                  => $cta_url,
+				'cta_role'                 => $atts['cta_role'],
+				'cta_rel'                  => $atts['cta_rel'],
+				'review_video'             => $review_video_data,
+				'atts'                     => $atts,
+				'block_classes'            => $block_classes,
+				'css_variables'            => $css_variables_string,
+				'score_layout'             => $score_layout,
+				'animations_enabled'       => ! empty( $options['enable_animations'] ),
+				'score_max'                => $score_max_value,
+				'display_mode'             => $display_mode,
+			)
         );
     }
 

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -40,17 +40,17 @@ class GameExplorer {
     );
 
     private const INDEX_META_KEYS = array(
-        'letter'        => '_jlg_ge_letter',
-        'developer'     => '_jlg_ge_developer_key',
-        'publisher'     => '_jlg_ge_publisher_key',
-        'availability'  => '_jlg_ge_availability',
-        'release_year'  => '_jlg_ge_release_year',
-        'search_index'  => '_jlg_ge_search_index',
+        'letter'         => '_jlg_ge_letter',
+        'developer'      => '_jlg_ge_developer_key',
+        'publisher'      => '_jlg_ge_publisher_key',
+        'availability'   => '_jlg_ge_availability',
+        'release_year'   => '_jlg_ge_release_year',
+        'search_index'   => '_jlg_ge_search_index',
         'platform_index' => '_jlg_ge_platform_index',
     );
 
-    private const QUERY_CACHE_KEY_PREFIX      = 'jlg_ge_query_';
-    private const QUERY_CACHE_VERSION_OPTION  = 'jlg_ge_query_cache_version';
+    private const QUERY_CACHE_KEY_PREFIX     = 'jlg_ge_query_';
+    private const QUERY_CACHE_VERSION_OPTION = 'jlg_ge_query_cache_version';
 
     /** @var array<string, mixed>|null */
     private static $filters_snapshot = null;
@@ -248,7 +248,7 @@ class GameExplorer {
             Helpers::get_default_game_explorer_filters()
         );
 
-        $filters = implode( ',', $filters_list );
+        $filters        = implode( ',', $filters_list );
         $score_position = Helpers::normalize_game_explorer_score_position(
             $options['game_explorer_score_position'] ?? ''
         );
@@ -336,7 +336,7 @@ class GameExplorer {
     }
 
     protected static function normalize_filters( $filters_string ) {
-        $allowed        = Helpers::get_game_explorer_allowed_filters();
+        $allowed         = Helpers::get_game_explorer_allowed_filters();
         $default_filters = Helpers::get_default_game_explorer_filters();
         $list            = Helpers::normalize_game_explorer_filters( $filters_string, $default_filters );
 
@@ -808,8 +808,8 @@ class GameExplorer {
     }
 
     private static function bump_query_cache_version() {
-        $next_version                = self::get_query_cache_version() + 1;
-        self::$query_cache_version   = $next_version;
+        $next_version              = self::get_query_cache_version() + 1;
+        self::$query_cache_version = $next_version;
         update_option( self::QUERY_CACHE_VERSION_OPTION, $next_version, false );
     }
 
@@ -907,14 +907,14 @@ class GameExplorer {
 
     protected static function build_filters_snapshot() {
         $snapshot = array(
-            'posts'           => array(),
-            'letters_map'     => array(),
-            'categories_map'  => array(),
-            'platforms_map'   => array(),
-            'developers_map'  => array(),
-            'publishers_map'  => array(),
-            'search_tokens'   => array(),
-            'years'           => array(
+            'posts'          => array(),
+            'letters_map'    => array(),
+            'categories_map' => array(),
+            'platforms_map'  => array(),
+            'developers_map' => array(),
+            'publishers_map' => array(),
+            'search_tokens'  => array(),
+            'years'          => array(
                 'min'     => null,
                 'max'     => null,
                 'buckets' => array(),
@@ -991,7 +991,7 @@ class GameExplorer {
                         $snapshot['years']['buckets'][ $year_value ] = 0;
                     }
 
-                    $snapshot['years']['buckets'][ $year_value ]++;
+                    ++$snapshot['years']['buckets'][ $year_value ];
 
                     if ( ! is_int( $snapshot['years']['min'] ) || $year_value < $snapshot['years']['min'] ) {
                         $snapshot['years']['min'] = $year_value;
@@ -1090,20 +1090,20 @@ class GameExplorer {
                         $snapshot['search_tokens'][ $token_value ] = 0;
                     }
 
-                    $snapshot['search_tokens'][ $token_value ]++;
+                    ++$snapshot['search_tokens'][ $token_value ];
                 }
             }
 
             self::sync_post_index_meta(
                 $post_id,
                 array(
-                    'letter'        => $letter,
-                    'developer'     => $developer_key,
-                    'publisher'     => $publisher_key,
-                    'availability'  => $availability['status'],
-                    'release_year'  => $release_year !== null ? (string) $release_year : '',
-                    'search_index'  => $search_index,
-                    'platform_index'=> $platform_index,
+                    'letter'         => $letter,
+                    'developer'      => $developer_key,
+                    'publisher'      => $publisher_key,
+                    'availability'   => $availability['status'],
+                    'release_year'   => $release_year !== null ? (string) $release_year : '',
+                    'search_index'   => $search_index,
+                    'platform_index' => $platform_index,
                 )
             );
 
@@ -1129,13 +1129,13 @@ class GameExplorer {
                 'search_index'    => $search_index,
                 'popularity'      => (int) $popularity_score,
                 'index_meta'      => array(
-                    'letter'        => $letter,
-                    'developer'     => $developer_key,
-                    'publisher'     => $publisher_key,
-                    'availability'  => $availability['status'],
-                    'release_year'  => $release_year !== null ? (string) $release_year : '',
-                    'search_index'  => $search_index,
-                    'platform_index'=> $platform_index,
+                    'letter'         => $letter,
+                    'developer'      => $developer_key,
+                    'publisher'      => $publisher_key,
+                    'availability'   => $availability['status'],
+                    'release_year'   => $release_year !== null ? (string) $release_year : '',
+                    'search_index'   => $search_index,
+                    'platform_index' => $platform_index,
                 ),
             );
         }
@@ -1275,10 +1275,10 @@ class GameExplorer {
             $query_args['orderby']   = 'meta_value_num';
             $query_args['meta_type'] = 'DECIMAL';
         } elseif ( $orderby === 'popularity' ) {
-            $popularity_meta_key      = '_jlg_user_rating_count';
-            $query_args['meta_key']   = $popularity_meta_key;
-            $query_args['meta_type']  = 'NUMERIC';
-            $query_args['orderby']    = array(
+            $popularity_meta_key     = '_jlg_user_rating_count';
+            $query_args['meta_key']  = $popularity_meta_key;
+            $query_args['meta_type'] = 'NUMERIC';
+            $query_args['orderby']   = array(
                 'meta_value_num' => $order,
                 'date'           => 'DESC',
             );
@@ -1460,7 +1460,7 @@ class GameExplorer {
             }
         }
 
-        $developers_map  = isset( $snapshot['developers_map'] ) && is_array( $snapshot['developers_map'] ) ? $snapshot['developers_map'] : array();
+        $developers_map = isset( $snapshot['developers_map'] ) && is_array( $snapshot['developers_map'] ) ? $snapshot['developers_map'] : array();
         if ( $developer_filter_key !== '' && $developer_filter !== '' && ! isset( $developers_map[ $developer_filter_key ] ) ) {
             $developers_map[ $developer_filter_key ] = $developer_filter;
         }
@@ -1476,7 +1476,7 @@ class GameExplorer {
             }
         }
 
-        $publishers_map  = isset( $snapshot['publishers_map'] ) && is_array( $snapshot['publishers_map'] ) ? $snapshot['publishers_map'] : array();
+        $publishers_map = isset( $snapshot['publishers_map'] ) && is_array( $snapshot['publishers_map'] ) ? $snapshot['publishers_map'] : array();
         if ( $publisher_filter_key !== '' && $publisher_filter !== '' && ! isset( $publishers_map[ $publisher_filter_key ] ) ) {
             $publishers_map[ $publisher_filter_key ] = $publisher_filter;
         }
@@ -1524,9 +1524,9 @@ class GameExplorer {
             'unknown'   => esc_html__( 'À confirmer', 'notation-jlg' ),
         );
 
-        $years_meta_raw    = isset( $snapshot['years'] ) && is_array( $snapshot['years'] ) ? $snapshot['years'] : array();
-        $year_buckets_raw  = isset( $years_meta_raw['buckets'] ) && is_array( $years_meta_raw['buckets'] ) ? $years_meta_raw['buckets'] : array();
-        $year_buckets      = array();
+        $years_meta_raw   = isset( $snapshot['years'] ) && is_array( $snapshot['years'] ) ? $snapshot['years'] : array();
+        $year_buckets_raw = isset( $years_meta_raw['buckets'] ) && is_array( $years_meta_raw['buckets'] ) ? $years_meta_raw['buckets'] : array();
+        $year_buckets     = array();
         foreach ( $year_buckets_raw as $bucket_year => $bucket_count ) {
             if ( is_int( $bucket_year ) ) {
                 $year_key = $bucket_year;
@@ -1687,7 +1687,7 @@ class GameExplorer {
                 'ignore_sticky_posts' => true,
             );
 
-            $query = new \WP_Query( $query_args );
+            $query                = new \WP_Query( $query_args );
             $query->found_posts   = $total_items;
             $query->max_num_pages = $total_pages;
         } else {
@@ -1723,8 +1723,8 @@ class GameExplorer {
 
             if ( $adjusted_paged !== $query_args['paged'] ) {
                 $query_args['paged'] = $adjusted_paged;
-                $query                = new \WP_Query( $query_args );
-                $total_items          = isset( $query->found_posts ) ? (int) $query->found_posts : (int) $query->post_count;
+                $query               = new \WP_Query( $query_args );
+                $total_items         = isset( $query->found_posts ) ? (int) $query->found_posts : (int) $query->post_count;
                 if ( $total_items < 0 ) {
                     $total_items = 0;
                 }
@@ -1846,10 +1846,10 @@ class GameExplorer {
                 $posts_per_page,
                 $requested_paged,
                 array(
-                    'post_ids'      => $post_ids_for_cache,
-                    'total_items'   => $total_items,
-                    'total_pages'   => $total_pages,
-                    'adjusted_paged'=> $paged,
+                    'post_ids'       => $post_ids_for_cache,
+                    'total_items'    => $total_items,
+                    'total_pages'    => $total_pages,
+                    'adjusted_paged' => $paged,
                 )
             );
         }
@@ -1863,7 +1863,7 @@ class GameExplorer {
         $message = $total_items === 0 ? $no_results_message : '';
 
         $config_payload = array(
-            'atts'    => array(
+            'atts'        => array(
                 'id'             => $atts['id'],
                 'posts_per_page' => $posts_per_page,
                 'columns'        => $columns,
@@ -1877,7 +1877,7 @@ class GameExplorer {
                 'annee'          => $atts['annee'],
                 'recherche'      => $atts['recherche'],
             ),
-            'state'   => array(
+            'state'       => array(
                 'orderby'      => $orderby,
                 'order'        => $order,
                 'letter'       => $letter_filter,
@@ -1892,21 +1892,21 @@ class GameExplorer {
                 'total_items'  => $total_items,
                 'total_pages'  => $total_pages,
             ),
-            'request' => array(
+            'request'     => array(
                 'prefix' => $request_prefix,
                 'keys'   => $request_keys,
             ),
-            'cache'   => array(
+            'cache'       => array(
                 'query' => $query_cache_status,
             ),
-            'meta'    => array(
+            'meta'        => array(
                 'years' => array(
                     'min'     => $year_min,
                     'max'     => $year_max,
                     'buckets' => $year_buckets,
                 ),
             ),
-            'sorts'  => array(
+            'sorts'       => array(
                 'options' => self::get_sort_options(),
                 'active'  => array(
                     'orderby' => $orderby,

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameInfo.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameInfo.php
@@ -7,7 +7,7 @@ use JLG\Notation\Helpers;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class GameInfo {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/ProsCons.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/ProsCons.php
@@ -6,7 +6,7 @@ use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class ProsCons {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/RatingBlock.php
@@ -7,7 +7,7 @@ use JLG\Notation\Helpers;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class RatingBlock {
@@ -19,13 +19,13 @@ class RatingBlock {
     public function render( $atts, $content = '', $shortcode_tag = '' ) {
         $atts = shortcode_atts(
             array(
-                'post_id'             => get_the_ID(),
-                'score_layout'        => '',
-                'animations'          => '',
-                'accent_color'        => '',
-                'display_mode'        => '',
-                'preview_theme'       => '',
-                'preview_animations'  => '',
+                'post_id'            => get_the_ID(),
+                'score_layout'       => '',
+                'animations'         => '',
+                'accent_color'       => '',
+                'display_mode'       => '',
+                'preview_theme'      => '',
+                'preview_animations' => '',
             ),
             $atts,
             'bloc_notation_jeu'
@@ -153,12 +153,12 @@ class RatingBlock {
             $css_variables = $this->merge_css_variables( $css_variables, $theme_variables );
         }
 
-        $extra_classes = array_values( array_unique( array_filter( $extra_classes ) ) );
+        $extra_classes        = array_values( array_unique( array_filter( $extra_classes ) ) );
         $extra_classes_string = implode( ' ', $extra_classes );
 
         if ( $average_score === null ) {
             if ( $this->is_editor_preview_context() ) {
-                $shortcode_handle     = $shortcode_tag ?: 'bloc_notation_jeu';
+                $shortcode_handle    = $shortcode_tag ?: 'bloc_notation_jeu';
                 $placeholder_context = $this->build_editor_placeholder_context(
                     $post,
                     $post_id,
@@ -261,10 +261,10 @@ class RatingBlock {
                 : 1.0;
 
             $category_scores[] = array(
-                'id'    => $category_id,
-                'label' => $label,
-                'score' => $placeholder_score,
-                'weight'=> $weight,
+                'id'     => $category_id,
+                'label'  => $label,
+                'score'  => $placeholder_score,
+                'weight' => $weight,
             );
 
             if ( $category_id !== '' ) {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/SummaryDisplay.php
@@ -12,7 +12,7 @@ use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class SummaryDisplay {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/Tagline.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/Tagline.php
@@ -6,7 +6,7 @@ use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Tagline {

--- a/plugin-notation-jeux_V4/includes/Shortcodes/UserRating.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/UserRating.php
@@ -6,7 +6,7 @@ use JLG\Notation\Frontend;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class UserRating {
@@ -63,18 +63,18 @@ class UserRating {
         return Frontend::get_template_html(
             'shortcode-user-rating',
             array(
-                                'options'    => $options,
-                                'post_id'    => $post_id,
-                                'avg_rating' => get_post_meta( $post_id, '_jlg_user_rating_avg', true ),
-                                'count'      => get_post_meta( $post_id, '_jlg_user_rating_count', true ),
-                                'rating_breakdown' => Frontend::get_user_rating_breakdown_for_post( $post_id ),
-                                'has_voted'  => $has_voted,
-                                'user_vote'  => $user_vote,
-                                'requires_login' => $requires_login,
-                                'login_required' => $login_required,
-                                'login_url'      => $login_url,
-                                'is_logged_in'   => $is_logged_in,
-                        )
+				'options'          => $options,
+				'post_id'          => $post_id,
+				'avg_rating'       => get_post_meta( $post_id, '_jlg_user_rating_avg', true ),
+				'count'            => get_post_meta( $post_id, '_jlg_user_rating_count', true ),
+				'rating_breakdown' => Frontend::get_user_rating_breakdown_for_post( $post_id ),
+				'has_voted'        => $has_voted,
+				'user_vote'        => $user_vote,
+				'requires_login'   => $requires_login,
+				'login_required'   => $login_required,
+				'login_url'        => $login_url,
+				'is_logged_in'     => $is_logged_in,
+			)
         );
     }
 }

--- a/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
+++ b/plugin-notation-jeux_V4/includes/Utils/FormRenderer.php
@@ -11,7 +11,7 @@ namespace JLG\Notation\Utils;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class FormRenderer {
@@ -41,11 +41,11 @@ class FormRenderer {
 
         $classes = array( 'wp-color-picker', 'jlg-color-picker' );
         if ( $allow_transparent ) {
-            $classes[] = 'jlg-color-picker--allow-transparent';
+            $classes[]                                 = 'jlg-color-picker--allow-transparent';
             $data_attributes['data-allow-transparent'] = 'true';
         }
 
-        $default_attr_value                  = is_string( $default_value ) ? $default_value : '';
+        $default_attr_value                    = is_string( $default_value ) ? $default_value : '';
         $data_attributes['data-default-color'] = $default_attr_value;
 
         $attributes = '';

--- a/plugin-notation-jeux_V4/includes/Utils/TemplateLoader.php
+++ b/plugin-notation-jeux_V4/includes/Utils/TemplateLoader.php
@@ -3,7 +3,7 @@
 namespace JLG\Notation\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class TemplateLoader {

--- a/plugin-notation-jeux_V4/includes/Utils/Validator.php
+++ b/plugin-notation-jeux_V4/includes/Utils/Validator.php
@@ -6,11 +6,11 @@ use DateTime;
 use JLG\Notation\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 class Validator {
-    private static $allowed_pegi_values = array( '3', '7', '12', '16', '18' );
+    private static $allowed_pegi_values     = array( '3', '7', '12', '16', '18' );
     private static $allowed_video_providers = array(
         'youtube'     => array(
             'label'   => 'YouTube',
@@ -295,7 +295,7 @@ class Validator {
     }
 
     public static function sanitize_review_video_data( $url, $provider = '' ) {
-        $raw_url      = is_string( $url ) ? trim( $url ) : '';
+        $raw_url            = is_string( $url ) ? trim( $url ) : '';
         $sanitized_provider = self::sanitize_video_provider( $provider );
 
         if ( $raw_url === '' ) {

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -13,7 +13,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 $autoload_path = __DIR__ . '/vendor/autoload.php';
@@ -32,7 +32,7 @@ if ( ! defined( 'JLG_NOTATION_FALLBACK_AUTOLOADER' ) ) {
                 'JLG\\Notation\\Admin\\'      => 'includes/Admin/',
                 'JLG\\Notation\\Utils\\'      => 'includes/Utils/',
                 'JLG\\Notation\\Shortcodes\\' => 'includes/Shortcodes/',
-                'JLG\\Notation\\'              => 'includes/',
+                'JLG\\Notation\\'             => 'includes/',
             );
 
             foreach ( $prefixes as $prefix => $directory ) {
@@ -99,13 +99,13 @@ if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
  * Classe principale refactorisée
  */
 final class JLG_Plugin_De_Notation_Main {
-    private static $instance                = null;
-    private $admin                          = null;
-    private $assets                         = null;
-    private $frontend                       = null;
-    private $blocks                         = null;
-    private const MIGRATION_BATCH_SIZE      = 50;
-    private const MIGRATION_SCAN_BATCH_SIZE = 200;
+    private static $instance                       = null;
+    private $admin                                 = null;
+    private $assets                                = null;
+    private $frontend                              = null;
+    private $blocks                                = null;
+    private const MIGRATION_BATCH_SIZE             = 50;
+    private const MIGRATION_SCAN_BATCH_SIZE        = 200;
     private const SCORE_SCALE_MIGRATION_BATCH_SIZE = 40;
 
     public static function get_instance() {
@@ -173,7 +173,7 @@ final class JLG_Plugin_De_Notation_Main {
                 'widgets_init',
                 function () {
                                         register_widget( \JLG\Notation\LatestReviewsWidget::class );
-                                }
+				}
             );
         }
 

--- a/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
+++ b/plugin-notation-jeux_V4/templates/game-explorer-fragment.php
@@ -3,19 +3,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$games       = is_array( $games ) ? $games : array();
-$message     = isset( $message ) ? $message : '';
-$pagination  = is_array( $pagination ) ? $pagination : array(
-        'current' => 1,
-        'total'   => 0,
+$games           = is_array( $games ) ? $games : array();
+$message         = isset( $message ) ? $message : '';
+$pagination      = is_array( $pagination ) ? $pagination : array(
+	'current' => 1,
+	'total'   => 0,
 );
-$total_items = isset( $total_items ) ? (int) $total_items : 0;
-$score_position = isset( $score_position )
+$total_items     = isset( $total_items ) ? (int) $total_items : 0;
+$score_position  = isset( $score_position )
     ? \JLG\Notation\Helpers::normalize_game_explorer_score_position( $score_position )
     : \JLG\Notation\Helpers::normalize_game_explorer_score_position( '' );
-$score_max_value  = isset( $score_max ) ? max( 1, (float) $score_max ) : \JLG\Notation\Helpers::get_score_max();
-$score_max_label  = number_format_i18n( $score_max_value );
-$score_classes = array(
+$score_max_value = isset( $score_max ) ? max( 1, (float) $score_max ) : \JLG\Notation\Helpers::get_score_max();
+$score_max_label = number_format_i18n( $score_max_value );
+$score_classes   = array(
     'jlg-ge-card__score',
     'jlg-ge-card__score--' . sanitize_html_class( $score_position ),
 );
@@ -86,7 +86,7 @@ if ( isset( $pagination['current'] ) && (int) $pagination['current'] > 1 ) {
     $base_query_params[ $namespaced_keys['paged'] ] = (string) (int) $pagination['current'];
 }
 
-$prepare_hidden_params = static function( array $exclude = array(), array $overrides = array() ) use ( $base_query_params ) {
+$prepare_hidden_params = static function ( array $exclude = array(), array $overrides = array() ) use ( $base_query_params ) {
     $params = $base_query_params;
 
     foreach ( $exclude as $exclude_key ) {
@@ -105,7 +105,7 @@ $prepare_hidden_params = static function( array $exclude = array(), array $overr
     return $params;
 };
 
-$render_hidden_inputs = static function( array $params ) {
+$render_hidden_inputs = static function ( array $params ) {
     foreach ( $params as $name => $value ) {
         $value_string = (string) $value;
 
@@ -160,13 +160,14 @@ if ( empty( $games ) ) {
                     <span class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $score_classes ) ) ); ?>" style="--jlg-ge-score-color: <?php echo esc_attr( $score_color ); ?>;">
                         <?php echo esc_html( $score_display ); ?>
                         <?php if ( $has_score ) : ?>
-                            <span class="jlg-ge-card__score-outof"><?php
-                                printf(
-                                    /* translators: %s: Maximum possible rating value. */
-                                    esc_html__( '/%s', 'notation-jlg' ),
-                                    esc_html( $score_max_label )
-                                );
-                            ?></span>
+                            <?php
+                            $score_suffix = sprintf(
+                                /* translators: %s: Maximum possible rating value. */
+                                esc_html__( '/%s', 'notation-jlg' ),
+                                esc_html( $score_max_label )
+                            );
+                            ?>
+                            <span class="jlg-ge-card__score-outof"><?php echo $score_suffix; ?></span>
                         <?php endif; ?>
                     </span>
                 <?php endif; ?>
@@ -233,10 +234,10 @@ $current_page = isset( $pagination['current'] ) ? (int) $pagination['current'] :
 $total_pages  = isset( $pagination['total'] ) ? (int) $pagination['total'] : 0;
 
 if ( $total_pages > 1 ) :
-    $prev_page      = max( 1, $current_page - 1 );
-    $next_page      = min( $total_pages, $current_page + 1 );
-    $prev_disabled  = ( $current_page <= 1 );
-    $next_disabled  = ( $current_page >= $total_pages );
+    $prev_page     = max( 1, $current_page - 1 );
+    $next_page     = min( $total_pages, $current_page + 1 );
+    $prev_disabled = ( $current_page <= 1 );
+    $next_disabled = ( $current_page >= $total_pages );
     ?>
     <nav class="jlg-ge-pagination" data-role="pagination" aria-label="<?php esc_attr_e( 'Navigation des pages du Game Explorer', 'notation-jlg' ); ?>">
         <form method="get" class="jlg-ge-pagination__form">

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -19,7 +19,7 @@ $average_percentage_value = isset( $average_score_percentage ) && is_numeric( $a
 $category_percentages = isset( $category_percentages ) && is_array( $category_percentages )
     ? $category_percentages
     : array();
-$style_attribute = '';
+$style_attribute      = '';
 if ( ! empty( $css_variables ) ) {
     $style_attribute = ' style="' . esc_attr( $css_variables ) . '"';
 }
@@ -183,7 +183,7 @@ if ( $average_score_display !== '' ) {
                 <div class="jlg-aio-score-label"><?php echo esc_html__( 'Note Globale', 'notation-jlg' ); ?></div>
             </div>
             <?php else : ?>
-            <?php echo $global_score_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo $global_score_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
             <div class="jlg-aio-score-label"><?php echo esc_html__( 'Note Globale', 'notation-jlg' ); ?></div>
             <?php endif; ?>
         </div>
@@ -197,20 +197,20 @@ if ( $average_score_display !== '' ) {
                     continue;
                 }
 
-                $label     = isset( $category['label'] ) ? $category['label'] : '';
-                $weight    = isset( $category['weight'] )
+                $label              = isset( $category['label'] ) ? $category['label'] : '';
+                $weight             = isset( $category['weight'] )
                     ? \JLG\Notation\Helpers::normalize_category_weight( $category['weight'], 1.0 )
                     : 1.0;
-                $show_weight = abs( $weight - 1.0 ) > 0.001;
-                $bar_color = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
-                $category_id = isset( $category['id'] ) ? (string) $category['id'] : '';
-                $percentage_value = ( $category_id !== '' && isset( $category_percentages[ $category_id ] ) )
+                $show_weight        = abs( $weight - 1.0 ) > 0.001;
+                $bar_color          = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
+                $category_id        = isset( $category['id'] ) ? (string) $category['id'] : '';
+                $percentage_value   = ( $category_id !== '' && isset( $category_percentages[ $category_id ] ) )
                     ? max( 0, min( 100, (float) $category_percentages[ $category_id ] ) )
                     : null;
                 $percentage_display = is_numeric( $percentage_value )
                     ? esc_html( number_format_i18n( $percentage_value, 1 ) )
                     : '';
-                $label_text = wp_strip_all_tags( (string) $label );
+                $label_text         = wp_strip_all_tags( (string) $label );
                 ?>
             <div class="jlg-aio-score-item">
                 <div class="jlg-aio-score-header">
@@ -230,7 +230,7 @@ if ( $average_score_display !== '' ) {
                     </span>
                     <?php
                     $formatted_score_value = esc_html( number_format_i18n( $score_value, 1 ) );
-                    $score_max_for_output = esc_html( $score_max_label );
+                    $score_max_for_output  = esc_html( $score_max_label );
 
                     if ( $display_mode === 'percent' && $percentage_display !== '' ) {
                         $visible_percentage = sprintf(

--- a/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-game-explorer.php
@@ -99,7 +99,7 @@ if ( isset( $pagination['current'] ) && (int) $pagination['current'] > 1 && isse
     $active_query_params[ $namespaced_keys['paged'] ] = (string) (int) $pagination['current'];
 }
 
-$prepare_hidden_params = static function( array $exclude = array(), array $overrides = array() ) use ( $active_query_params ) {
+$prepare_hidden_params = static function ( array $exclude = array(), array $overrides = array() ) use ( $active_query_params ) {
     $params = $active_query_params;
 
     foreach ( $exclude as $exclude_key ) {
@@ -118,7 +118,7 @@ $prepare_hidden_params = static function( array $exclude = array(), array $overr
     return $params;
 };
 
-$render_hidden_inputs = static function( array $params ) {
+$render_hidden_inputs = static function ( array $params ) {
     foreach ( $params as $name => $value ) {
         $value_string = (string) $value;
 
@@ -537,16 +537,16 @@ $reset_url = remove_query_arg( array_values( $namespaced_keys ), '' );
         echo \JLG\Notation\Frontend::get_template_html(
             'game-explorer-fragment',
             array(
-                                'games'           => $games,
-                                'message'         => isset( $message ) ? $message : '',
-                                'pagination'      => $pagination,
-                                'total_items'     => $total_items,
-                                'current_filters' => $current_filters,
-                                'request_keys'    => $request_keys,
-                                'sort_key'        => $sort_key,
-                                'sort_order'      => $sort_order,
-                                'query_params'    => $active_query_params,
-                        )
+				'games'           => $games,
+				'message'         => isset( $message ) ? $message : '',
+				'pagination'      => $pagination,
+				'total_items'     => $total_items,
+				'current_filters' => $current_filters,
+				'request_keys'    => $request_keys,
+				'sort_key'        => $sort_key,
+				'sort_order'      => $sort_order,
+				'query_params'    => $active_query_params,
+			)
         );
         ?>
     </div>

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block-empty.php
@@ -76,9 +76,9 @@ if ( isset( $category_scores ) && is_array( $category_scores ) ) {
             : $average_percentage_value;
 
         $categories_for_display[] = array(
-            'label'    => $label,
-            'score'    => $score_value,
-            'percent'  => $percentage_value,
+            'label'   => $label,
+            'score'   => $score_value,
+            'percent' => $percentage_value,
         );
     }
 }
@@ -99,10 +99,10 @@ if ( empty( $categories_for_display ) ) {
     }
 }
 
-$score_max_label      = esc_html( number_format_i18n( $resolved_score_max ) );
-$average_score_label  = esc_html( number_format_i18n( $placeholder_average, 1 ) );
-$percentage_label     = esc_html( number_format_i18n( $average_percentage_value, 1 ) );
-$user_rating_value    = isset( $user_rating_average ) && is_numeric( $user_rating_average )
+$score_max_label       = esc_html( number_format_i18n( $resolved_score_max ) );
+$average_score_label   = esc_html( number_format_i18n( $placeholder_average, 1 ) );
+$percentage_label      = esc_html( number_format_i18n( $average_percentage_value, 1 ) );
+$user_rating_value     = isset( $user_rating_average ) && is_numeric( $user_rating_average )
     ? (float) $user_rating_average
     : $placeholder_average;
 $user_rating_delta     = isset( $user_rating_delta ) && is_numeric( $user_rating_delta )
@@ -128,7 +128,7 @@ if ( $resolved_display_mode === 'percent' && $percentage_label !== '' ) {
     $global_visible_value = $average_score_label;
 }
 
-$placeholder_notice = esc_html__( 'Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes.', 'notation-jlg' );
+$placeholder_notice   = esc_html__( 'Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes.', 'notation-jlg' );
 $css_variables_string = isset( $css_variables ) && is_string( $css_variables ) ? trim( $css_variables ) : '';
 $extra_classes_string = isset( $extra_classes ) && is_string( $extra_classes ) ? trim( $extra_classes ) : '';
 $extra_classes_list   = $extra_classes_string !== '' ? preg_split( '/\s+/', $extra_classes_string ) : array();
@@ -138,7 +138,7 @@ if ( ! empty( $animations_enabled ) ) {
     $wrapper_classes[] = 'jlg-animate';
 }
 
-$wrapper_classes = array_unique( array_filter( array_map( 'trim', $wrapper_classes ) ) );
+$wrapper_classes         = array_unique( array_filter( array_map( 'trim', $wrapper_classes ) ) );
 $wrapper_class_attribute = ! empty( $wrapper_classes ) ? implode( ' ', $wrapper_classes ) : 'review-box-jlg is-placeholder';
 $style_attribute         = $css_variables_string !== '' ? ' style="' . esc_attr( $css_variables_string ) . '"' : '';
 ?>
@@ -199,13 +199,13 @@ $style_attribute         = $css_variables_string !== '' ? ' style="' . esc_attr(
                     continue;
                 }
 
-                $category_score_value = isset( $category['score'] ) && is_numeric( $category['score'] )
+                $category_score_value   = isset( $category['score'] ) && is_numeric( $category['score'] )
                     ? (float) $category['score']
                     : $placeholder_average;
                 $category_percent_value = isset( $category['percent'] ) && is_numeric( $category['percent'] )
                     ? max( 0, min( 100, (float) $category['percent'] ) )
                     : $average_percentage_value;
-                $percent_attr = number_format( $category_percent_value, 2, '.', '' );
+                $percent_attr           = number_format( $category_percent_value, 2, '.', '' );
                 ?>
                 <div class="rating-item">
                     <div class="rating-label">

--- a/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-rating-block.php
@@ -44,17 +44,17 @@ $category_percentages = isset( $category_percentages ) && is_array( $category_pe
     ? $category_percentages
     : array();
 
-$css_variables_string = is_string( $css_variables ) ? $css_variables : '';
-$should_display_badge = ! empty( $should_show_rating_badge );
+$css_variables_string      = is_string( $css_variables ) ? $css_variables : '';
+$should_display_badge      = ! empty( $should_show_rating_badge );
 $user_rating_average_value = isset( $user_rating_average ) && is_numeric( $user_rating_average )
     ? (float) $user_rating_average
     : null;
-$user_rating_delta_value = isset( $user_rating_delta ) && is_numeric( $user_rating_delta )
+$user_rating_delta_value   = isset( $user_rating_delta ) && is_numeric( $user_rating_delta )
     ? (float) $user_rating_delta
     : null;
-$extra_classes_string = isset( $extra_classes ) && is_string( $extra_classes ) ? trim( $extra_classes ) : '';
-$extra_classes_list   = $extra_classes_string !== '' ? preg_split( '/\s+/', $extra_classes_string ) : array();
-$wrapper_classes      = array_merge( array( 'review-box-jlg' ), is_array( $extra_classes_list ) ? $extra_classes_list : array() );
+$extra_classes_string      = isset( $extra_classes ) && is_string( $extra_classes ) ? trim( $extra_classes ) : '';
+$extra_classes_list        = $extra_classes_string !== '' ? preg_split( '/\s+/', $extra_classes_string ) : array();
+$wrapper_classes           = array_merge( array( 'review-box-jlg' ), is_array( $extra_classes_list ) ? $extra_classes_list : array() );
 
 if ( $animations_on ) {
     $wrapper_classes[] = 'jlg-animate';
@@ -81,7 +81,7 @@ if ( $css_variables_string === '' ) {
     $css_variables_string = ! empty( $style_rules ) ? implode( ';', $style_rules ) : '';
 }
 
-$style_attribute = $css_variables_string !== '' ? ' style="' . esc_attr( $css_variables_string ) . '"' : '';
+$style_attribute         = $css_variables_string !== '' ? ' style="' . esc_attr( $css_variables_string ) . '"' : '';
 $wrapper_class_attribute = ! empty( $wrapper_classes ) ? implode( ' ', $wrapper_classes ) : 'review-box-jlg';
 
 $score_max_label_safe       = esc_html( $score_max_label );
@@ -198,20 +198,20 @@ if ( $display_mode === 'percent' && $average_percentage_display !== '' ) {
                 continue;
             }
 
-            $label     = isset( $category['label'] ) ? $category['label'] : '';
-            $weight    = isset( $category['weight'] )
+            $label              = isset( $category['label'] ) ? $category['label'] : '';
+            $weight             = isset( $category['weight'] )
                 ? \JLG\Notation\Helpers::normalize_category_weight( $category['weight'], 1.0 )
                 : 1.0;
-            $show_weight = abs( $weight - 1.0 ) > 0.001;
-            $bar_color = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
-            $category_id = isset( $category['id'] ) ? (string) $category['id'] : '';
-            $percentage_value = ( $category_id !== '' && isset( $category_percentages[ $category_id ] ) )
+            $show_weight        = abs( $weight - 1.0 ) > 0.001;
+            $bar_color          = \JLG\Notation\Helpers::calculate_color_from_note( $score_value, $options );
+            $category_id        = isset( $category['id'] ) ? (string) $category['id'] : '';
+            $percentage_value   = ( $category_id !== '' && isset( $category_percentages[ $category_id ] ) )
                 ? max( 0, min( 100, (float) $category_percentages[ $category_id ] ) )
                 : null;
             $percentage_display = is_numeric( $percentage_value )
                 ? esc_html( number_format_i18n( $percentage_value, 1 ) )
                 : '';
-            $label_text = wp_strip_all_tags( (string) $label );
+            $label_text         = wp_strip_all_tags( (string) $label );
             ?>
             <div class="rating-item">
                 <div class="rating-label">
@@ -232,7 +232,7 @@ if ( $display_mode === 'percent' && $average_percentage_display !== '' ) {
                     <span>
                         <?php
                         $formatted_score_value = esc_html( number_format_i18n( $score_value, 1 ) );
-                        $score_max_for_output = esc_html( $score_max_label );
+                        $score_max_for_output  = esc_html( $score_max_label );
 
                         if ( $display_mode === 'percent' && $percentage_display !== '' ) {
                             $visible_percentage = sprintf(

--- a/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-user-rating.php
@@ -20,16 +20,16 @@ $login_link_label   = __( 'Se connecter', 'notation-jlg' );
 $login_message_html = '';
 
 if ( $login_required ) {
-        if ( $login_url !== '' ) {
-                $login_message_html = sprintf(
-                        '<span class="jlg-user-rating-login-text">%s</span> <a class="jlg-user-rating-login-link" href="%s">%s</a>',
-                        esc_html( $login_message_text ),
-                        esc_url( $login_url ),
-                        esc_html( $login_link_label )
-                );
-        } else {
-                $login_message_html = esc_html( $login_message_text );
-        }
+	if ( $login_url !== '' ) {
+			$login_message_html = sprintf(
+                '<span class="jlg-user-rating-login-text">%s</span> <a class="jlg-user-rating-login-link" href="%s">%s</a>',
+                esc_html( $login_message_text ),
+                esc_url( $login_url ),
+                esc_html( $login_link_label )
+			);
+	} else {
+			$login_message_html = esc_html( $login_message_text );
+	}
 }
 
 $is_interaction_disabled = $has_voted || $login_required;
@@ -83,10 +83,11 @@ if ( $login_required && $login_url !== '' ) {
         aria-label="<?php echo esc_attr__( 'Choisissez une note', 'notation-jlg' ); ?>"
         <?php echo $is_interaction_disabled ? 'aria-disabled="true"' : ''; ?>
     >
-        <?php for ( $i = 1; $i <= 5; $i++ ) :
+        <?php
+        for ( $i = 1; $i <= 5; $i++ ) :
                 $is_selected      = $has_voted && $i <= $user_vote;
                 $is_checked_radio = $has_voted && intval( $user_vote ) === $i;
-                ?>
+			?>
             <button
                 type="button"
                 class="jlg-user-star<?php echo $is_selected ? ' selected' : ''; ?>"
@@ -94,10 +95,12 @@ if ( $login_required && $login_url !== '' ) {
                 role="radio"
                 aria-checked="<?php echo $is_checked_radio ? 'true' : 'false'; ?>"
                 <?php echo $is_interaction_disabled ? 'aria-disabled="true" disabled="disabled"' : ''; ?>
-                aria-label="<?php
+                aria-label="
+                <?php
                     /* translators: 1: Selected rating value. 2: Maximum possible rating. */
                     echo esc_attr( sprintf( __( 'Attribuer %1$s sur %2$s', 'notation-jlg' ), number_format_i18n( $i ), number_format_i18n( 5 ) ) );
-                ?>"
+                ?>
+                "
             >★</button>
         <?php endfor; ?>
     </div>
@@ -112,7 +115,8 @@ if ( $login_required && $login_url !== '' ) {
         data-total-votes="<?php echo esc_attr( $total_breakdown_votes ); ?>"
     >
         <ul class="jlg-user-rating-breakdown-list" role="list">
-            <?php for ( $star = 5; $star >= 1; $star-- ) :
+            <?php
+            for ( $star = 5; $star >= 1; $star-- ) :
                 $count_for_star = isset( $normalized_breakdown[ $star ] ) ? $normalized_breakdown[ $star ] : 0;
                 $percent_value  = $total_breakdown_votes > 0 ? ( $count_for_star / $total_breakdown_votes ) * 100 : 0;
                 $percent_label  = $total_breakdown_votes > 0 ? number_format_i18n( $percent_value, 1 ) : number_format_i18n( 0 );

--- a/plugin-notation-jeux_V4/templates/summary-table-fragment.php
+++ b/plugin-notation-jeux_V4/templates/summary-table-fragment.php
@@ -204,8 +204,8 @@ if ( ! function_exists( 'jlg_print_sortable_header' ) ) {
             $class .= ' sorted ' . strtolower( $current_order );
         }
 
-        $column_label_text   = wp_strip_all_tags( $display_label );
-        $next_direction_text = $new_order === 'ASC'
+        $column_label_text      = wp_strip_all_tags( $display_label );
+        $next_direction_text    = $new_order === 'ASC'
             ? esc_html__( 'ordre croissant', 'notation-jlg' )
             : esc_html__( 'ordre décroissant', 'notation-jlg' );
         $current_direction_text = $is_active
@@ -355,8 +355,8 @@ else :
                                 if ( ! isset( $available_columns[ $col ] ) ) {
                                     continue;
                                 }
-                                $column_info        = $available_columns[ $col ];
-                                $column_label_attr  = jlg_get_summary_column_label( $column_info );
+                                $column_info       = $available_columns[ $col ];
+                                $column_label_attr = jlg_get_summary_column_label( $column_info );
                                 echo '<td data-label="' . esc_attr( $column_label_attr ) . '">';
 
                                 switch ( $col ) {
@@ -394,9 +394,9 @@ else :
                                         break;
                                     default:
                                         if ( isset( $category_column_map[ $col ] ) ) {
-                                            $definition   = $category_column_map[ $col ];
-                                            $category_id  = isset( $definition['id'] ) ? $definition['id'] : '';
-                                            $score_value  = null;
+                                            $definition  = $category_column_map[ $col ];
+                                            $category_id = isset( $definition['id'] ) ? $definition['id'] : '';
+                                            $score_value = null;
 
                                             if ( $category_id !== '' && isset( $category_score_map[ $category_id ] ) ) {
                                                 $stored_entry = $category_score_map[ $category_id ];
@@ -407,7 +407,7 @@ else :
                                             } elseif ( $category_id !== '' ) {
                                                 $resolved = \JLG\Notation\Helpers::resolve_category_meta_value( $post_id, $definition, true );
                                                 if ( $resolved !== null ) {
-                                                    $score_value = (float) $resolved;
+                                                    $score_value                        = (float) $resolved;
                                                     $category_score_map[ $category_id ] = array(
                                                         'score'  => $score_value,
                                                         'weight' => \JLG\Notation\Helpers::normalize_category_weight(


### PR DESCRIPTION
## Summary
- reformat the plugin PHP sources with the WordPress coding standards to resolve the outstanding phpcs violations
- update helper and frontend logic to satisfy strict phpcs checks while preserving behaviour
- adjust the game explorer score suffix markup so automated tests continue to pass after the whitespace cleanup

## Testing
- `composer cs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68e381d66ffc832e88649d5c973320d1