### PR TITLE
Harden latest reviews widget sanitization and align tests with PHP 8.4

### DIFF
--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -80,7 +80,7 @@ class LatestReviewsWidget extends WP_Widget {
 
     public function update( $new_instance, $old_instance ) {
         $instance           = array();
-        $instance['title']  = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+        $instance['title']  = ( ! empty( $new_instance['title'] ) ) ? wp_strip_all_tags( $new_instance['title'] ) : '';
         $instance['number'] = ( ! empty( $new_instance['number'] ) ) ? absint( $new_instance['number'] ) : 5;
         return $instance;
     }

--- a/plugin-notation-jeux_V4/tests/GameExplorerSnapshotInvalidationTest.php
+++ b/plugin-notation-jeux_V4/tests/GameExplorerSnapshotInvalidationTest.php
@@ -25,14 +25,14 @@ final class GameExplorerSnapshotInvalidationTest extends TestCase
         $GLOBALS['jlg_test_meta'] = [];
         $GLOBALS['jlg_test_filters'] = [];
 
-        $this->filtersSnapshotProperty->setValue(null);
+        $this->filtersSnapshotProperty->setValue(null, null);
         \JLG\Notation\Helpers::flush_plugin_options_cache();
     }
 
     protected function tearDown(): void
     {
         \JLG\Notation\Shortcodes\GameExplorer::clear_filters_snapshot();
-        $this->filtersSnapshotProperty->setValue(null);
+        $this->filtersSnapshotProperty->setValue(null, null);
 
         parent::tearDown();
     }
@@ -123,7 +123,7 @@ final class GameExplorerSnapshotInvalidationTest extends TestCase
         $snapshot = ['primed' => uniqid('snapshot_', true)];
 
         set_transient(self::SNAPSHOT_KEY, $snapshot);
-        $this->filtersSnapshotProperty->setValue($snapshot);
+        $this->filtersSnapshotProperty->setValue(null, $snapshot);
 
         return $snapshot;
     }

--- a/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
+++ b/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use JLG\Notation\LatestReviewsWidget;
+use PHPUnit\Framework\TestCase;
+
+final class LatestReviewsWidgetTest extends TestCase
+{
+    public function test_update_removes_script_content_from_title(): void
+    {
+        $widget = new LatestReviewsWidget();
+
+        $dirty_instance = [
+            'title'  => "Top <strong>Jeu</strong> <script>alert('x');</script> Edition",
+            'number' => '-8',
+        ];
+
+        $clean_instance = $widget->update($dirty_instance, ['title' => 'Ancien', 'number' => 2]);
+
+        $this->assertArrayHasKey('title', $clean_instance);
+        $this->assertStringNotContainsString('alert', $clean_instance['title']);
+        $this->assertSame('Top Jeu Edition', preg_replace('/\s+/', ' ', $clean_instance['title']));
+        $this->assertSame(8, $clean_instance['number']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -1414,8 +1414,19 @@ if (!function_exists('sanitize_hex_color')) {
 }
 
 if (!function_exists('wp_strip_all_tags')) {
-    function wp_strip_all_tags($string) {
-        return is_string($string) ? strip_tags($string) : '';
+    function wp_strip_all_tags($string, $remove_breaks = false) {
+        if (!is_string($string)) {
+            return '';
+        }
+
+        $string = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $string);
+        $string = strip_tags($string);
+
+        if ($remove_breaks) {
+            $string = preg_replace('/[\r\n\t ]+/', ' ', $string);
+        }
+
+        return trim((string) $string);
     }
 }
 


### PR DESCRIPTION
## Summary
- switch the latest reviews widget over to `wp_strip_all_tags()` so malicious script contents are stripped from saved titles
- update the test bootstrap helper to mimic WordPress' tag stripping behaviour and cover the regression with a dedicated unit test
- modernise the snapshot invalidation tests to avoid deprecated Reflection usage under PHP 8.4

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e39c6e9158832ebd35385afbd8b6ed