### PR TITLE
Fix responsive layout for rating categories manager

### DIFF
--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -1554,10 +1554,10 @@ class Settings {
             echo '.jlg-rating-categories__list{display:flex;flex-direction:column;gap:12px;margin-bottom:12px;}';
             echo '.jlg-rating-category{border:1px solid #dcdcde;background:#fff;padding:12px;border-radius:4px;}';
             echo '.jlg-rating-category__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;}';
-            echo '.jlg-rating-category__actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;}';
+            echo '.jlg-rating-category__actions{display:flex;flex-wrap:wrap;align-items:center;justify-content:flex-end;gap:8px;grid-column:1/-1;}';
             echo '.jlg-rating-category__actions .button{margin:0;}';
             echo '.jlg-rating-category__remove{color:#a00;}';
-            echo '@media (max-width:782px){.jlg-rating-category__grid{grid-template-columns:1fr;}}';
+            echo '@media (max-width:782px){.jlg-rating-category__grid{grid-template-columns:1fr;}.jlg-rating-category__actions{justify-content:flex-start;}}';
             echo '</style>';
             $styles_printed = true;
         }


### PR DESCRIPTION
## Summary
- allow the rating category action buttons to wrap and span the full row so the manager stays readable on small screens
- tweak the mobile breakpoint styling to left-align the actions in narrow viewports

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e43e8126b4832e9bfe12f0cc5a946f