### PR TITLE
Améliore la robustesse temporelle et le mode debug du Game Explorer

### DIFF
--- a/plugin-notation-jeux_V4/docs/benchmark-2025-10-07.md
+++ b/plugin-notation-jeux_V4/docs/benchmark-2025-10-07.md
@@ -1,0 +1,23 @@
+# Benchmark – 2025-10-07
+
+## Références analysées
+- **IGN** – Portails tests & fiches jeux : filtrage avancé (plateformes, genres, notes), timelines d'actualités, intégration vidéo systématique.
+- **GameSpot** – Hub tests avec résumé en tuiles, différenciation claire pro / lecteurs, filtres dynamiques et cartes plates-formes.
+- **OpenCritic** – Agrégateur orienté data : indicateurs de tendance (« Mighty », « Weak »), segmentation par plateformes/éditions, API publique performante.
+
+## Évaluation de la base actuelle
+| Critère | Référence pro | Plugin WP Notation |
+| --- | --- | --- |
+| **Fiabilité des métadonnées** | OpenCritic expose des timestamps unifiés (UTC) et des API cohérentes | ✨ Amélioration : remplacement des `current_time('timestamp')` par une récupération normalisée pour éviter les dérives de fuseau |
+| **Transparence debug** | GameSpot/IGN disposent de consoles internes exportables (JSON) | ✨ Amélioration : logs admin convertis en JSON lisible + sanitation renforcée |
+| **Internationalisation** | IGN/GameSpot déclinent accents/uppercase correctement pour l'index alphabétique | ✨ Amélioration : suppression des silencieux `@iconv` et gestion Unicode durcie |
+| **Qualité des métaboxes** | GameSpot admin distingue visuellement plateformes & CTA, support multi-plateforme strict | ✨ Amélioration : sélection stricte des plateformes + contrôles nonce maintenus |
+
+## Chantiers complémentaires identifiés
+1. **Parité « pro vs lecteurs »** : implémenter une vue côte à côte style GameSpot combinant score rédaction, score lecteurs et historique (sparkline) – prévoir stockage statistique.
+2. **Badges de tendance** : inspiré d'OpenCritic, ajouter des badges dynamiques (« À surveiller », « Coup de cœur ») basés sur poids des catégories et variance des notes.
+3. **Comparateur multi-jeux** : IGN propose des comparatifs directs (ex. « vs »). Ajouter un shortcode pour sélectionner deux jeux et comparer critères pondérés.
+4. **Streaming & vidéo** : automatiser l’enrichissement des fiches via API YouTube/Twitch avec fallback poster, car IGN/GameSpot multiplient les formats.
+5. **API partenaire** : documenter un endpoint JSON read-only (score + métadonnées) pour intégrer le plugin dans des apps mobiles, à l’image de l’API OpenCritic.
+
+Ces améliorations guideront les prochaines itérations produit pour se rapprocher des expériences professionnelles identifiées.

--- a/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
@@ -67,6 +67,8 @@ class Metaboxes {
     }
 
     public function register_metaboxes( $post_type, $post = null ) {
+        unset( $post );
+
         // Vérifier qu'on est bien sur un post
         $allowed_post_types = $this->get_allowed_post_types();
 
@@ -245,7 +247,7 @@ class Metaboxes {
             }
 
             $display_label = $platform_label;
-            $checked       = in_array( $platform_value, $selected ) ? 'checked' : '';
+            $checked       = in_array( $platform_value, $selected, true ) ? 'checked' : '';
             echo '<label style="margin-right:15px;">';
             echo '<input type="checkbox" name="jlg_plateformes[]" value="' . esc_attr( $platform_value ) . '" ' . $checked . '> ';
             echo esc_html( $display_label );

--- a/plugin-notation-jeux_V4/includes/Admin/Platforms.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Platforms.php
@@ -308,7 +308,7 @@ class Platforms {
 
         // Debug : Vérifier les données POST
         if ( ! empty( $_POST ) ) {
-            $this->log_debug( '📨 Données POST reçues : ' . json_encode( array_keys( $_POST ) ) );
+            $this->log_debug( '📨 Données POST reçues : ' . wp_json_encode( array_keys( $_POST ) ) );
         }
 
         if ( ! isset( $_POST['jlg_platform_action'] ) ) {
@@ -476,7 +476,7 @@ class Platforms {
         $platforms['order'][ $key ]            = $max_order + 1;
 
         $this->log_debug( '💾 Tentative de sauvegarde dans la DB' );
-        $this->log_debug( '📊 Données à sauvegarder : ' . json_encode( $platforms['custom_platforms'][ $key ] ) );
+        $this->log_debug( '📊 Données à sauvegarder : ' . wp_json_encode( $platforms['custom_platforms'][ $key ] ) );
 
         $result = update_option( $this->option_name, $platforms );
 
@@ -801,11 +801,15 @@ class Platforms {
                     </ul>
                 </details>
                 
-                <?php if ( ! empty( $_POST ) ) : ?>
+                <?php
+                if ( ! empty( $_POST ) ) :
+                    $post_payload = wp_unslash( $_POST );
+                    $post_json    = wp_json_encode( $post_payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+                    ?>
                 <details style="margin-top: 15px;">
                     <summary style="cursor: pointer; font-weight: bold;">📨 Données POST reçues</summary>
                     <pre style="background: #f5f5f5; padding: 10px; overflow: auto; margin-top: 10px; font-size: 11px;">
-                        <?php echo esc_html( print_r( $_POST, true ) ); ?>
+                        <?php echo esc_html( $post_json ? $post_json : '' ); ?>
                     </pre>
                 </details>
                 <?php endif; ?>

--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -572,9 +572,9 @@ class Helpers {
         );
     }
 
-    public static function normalize_category_weight( $weight, $default = 1.0 ) {
+    public static function normalize_category_weight( $weight, $fallback_weight = 1.0 ) {
         if ( is_array( $weight ) ) {
-            return (float) $default;
+            return (float) $fallback_weight;
         }
 
         if ( is_string( $weight ) ) {
@@ -583,11 +583,11 @@ class Helpers {
         }
 
         if ( $weight === '' || $weight === null ) {
-            $weight = $default;
+            $weight = $fallback_weight;
         }
 
         if ( ! is_numeric( $weight ) ) {
-            return (float) $default;
+            return (float) $fallback_weight;
         }
 
         $normalized = (float) $weight;

--- a/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/GameExplorer.php
@@ -562,13 +562,13 @@ class GameExplorer {
         }
     }
 
-    private static function substr_unicode( $string, $start, $length = null, $encoding = 'UTF-8' ) {
-        $string = (string) $string;
+    private static function substr_unicode( $text, $start, $length = null, $encoding = 'UTF-8' ) {
+        $text = (string) $text;
 
         if ( function_exists( 'mb_substr' ) ) {
             $result = $length === null
-                ? mb_substr( $string, $start, null, $encoding )
-                : mb_substr( $string, $start, $length, $encoding );
+                ? mb_substr( $text, $start, null, $encoding )
+                : mb_substr( $text, $start, $length, $encoding );
 
             return $result === false ? '' : $result;
         }
@@ -577,16 +577,16 @@ class GameExplorer {
             if ( $length === null ) {
                 $iconv_length = null;
                 if ( function_exists( 'iconv_strlen' ) ) {
-                    $computed_length = iconv_strlen( $string, $encoding );
+                    $computed_length = iconv_strlen( $text, $encoding );
                     if ( $computed_length !== false ) {
                         $iconv_length = $computed_length;
                     }
                 }
                 $result = $iconv_length === null
-                    ? iconv_substr( $string, $start, strlen( $string ), $encoding )
-                    : iconv_substr( $string, $start, $iconv_length, $encoding );
+                    ? iconv_substr( $text, $start, strlen( $text ), $encoding )
+                    : iconv_substr( $text, $start, $iconv_length, $encoding );
             } else {
-                $result = iconv_substr( $string, $start, $length, $encoding );
+                $result = iconv_substr( $text, $start, $length, $encoding );
             }
 
             if ( $result !== false && $result !== null ) {
@@ -594,12 +594,12 @@ class GameExplorer {
             }
         }
 
-        if ( $string === '' ) {
+        if ( $text === '' ) {
             return '';
         }
 
         if ( function_exists( 'wp_strlen' ) ) {
-            $chars = preg_split( '//u', $string, -1, PREG_SPLIT_NO_EMPTY );
+            $chars = preg_split( '//u', $text, -1, PREG_SPLIT_NO_EMPTY );
             if ( is_array( $chars ) ) {
                 $slice = $length === null ? array_slice( $chars, $start ) : array_slice( $chars, $start, $length );
                 return implode( '', $slice );
@@ -607,31 +607,36 @@ class GameExplorer {
         }
 
         if ( $length === null ) {
-            return substr( $string, $start );
+            return substr( $text, $start );
         }
 
-        return substr( $string, $start, $length );
+        return substr( $text, $start, $length );
     }
 
-    private static function strtoupper_unicode( $string, $encoding = 'UTF-8' ) {
-        $string = (string) $string;
+    private static function strtoupper_unicode( $text, $encoding = 'UTF-8' ) {
+        $text = (string) $text;
 
         if ( function_exists( 'mb_strtoupper' ) ) {
-            return mb_strtoupper( $string, $encoding );
+            return mb_strtoupper( $text, $encoding );
         }
 
         if ( function_exists( 'wp_strtoupper' ) ) {
-            return wp_strtoupper( $string );
+            return wp_strtoupper( $text );
         }
 
-        if ( function_exists( 'iconv' ) ) {
-            $converted = @iconv( $encoding, 'UTF-8//TRANSLIT', $string );
-            if ( $converted !== false ) {
-                $string = $converted;
+        return strtoupper( $text );
+    }
+
+    private static function get_current_timestamp() {
+        if ( function_exists( 'current_datetime' ) ) {
+            $datetime = current_datetime();
+
+            if ( $datetime instanceof \DateTimeInterface ) {
+                return $datetime->getTimestamp();
             }
         }
 
-        return strtoupper( $string );
+        return time();
     }
 
     protected static function resolve_category_id( $value ) {
@@ -734,7 +739,7 @@ class GameExplorer {
             );
         }
 
-        if ( $release_date->getTimestamp() > (int) current_time( 'timestamp' ) ) {
+        if ( $release_date->getTimestamp() > (int) self::get_current_timestamp() ) {
             return array(
                 'status' => 'upcoming',
                 'label'  => esc_html__( 'À venir', 'notation-jlg' ),

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -27,7 +27,7 @@ if ( ! defined( 'JLG_NOTATION_FALLBACK_AUTOLOADER' ) ) {
     define( 'JLG_NOTATION_FALLBACK_AUTOLOADER', true );
 
     spl_autoload_register(
-        static function ( $class ) {
+        static function ( $class_name ) {
             $prefixes = array(
                 'JLG\\Notation\\Admin\\'      => 'includes/Admin/',
                 'JLG\\Notation\\Utils\\'      => 'includes/Utils/',
@@ -36,11 +36,11 @@ if ( ! defined( 'JLG_NOTATION_FALLBACK_AUTOLOADER' ) ) {
             );
 
             foreach ( $prefixes as $prefix => $directory ) {
-                if ( strpos( $class, $prefix ) !== 0 ) {
+                if ( strpos( $class_name, $prefix ) !== 0 ) {
                     continue;
                 }
 
-                $relative_class = substr( $class, strlen( $prefix ) );
+                $relative_class = substr( $class_name, strlen( $prefix ) );
                 if ( $relative_class === false ) {
                     return;
                 }


### PR DESCRIPTION
## Résumé
- harmonise l’obtention des timestamps côté frontend et Game Explorer pour éviter les dérives de fuseau horaire
- renforce le mode debug des plateformes (logs JSON, sanitation) et corrige les avertissements de codestyle restants
- ajoute une note de benchmark 2025-10-07 en comparant IGN, GameSpot et OpenCritic afin d’orienter les prochaines améliorations

## Tests
- `composer test`
- `composer cs`


------
https://chatgpt.com/codex/tasks/task_e_68e447e35708832ea23d5de5fc76166d