### PR TITLE
Improve focus ring accessibility with dynamic CSS variables

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -1,4 +1,5 @@
 /* Rating Block */
+:root{--jlg-focus-ring-color:var(--jlg-score-gradient-1,#60a5fa);--jlg-focus-ring-contrast-color:#ffffff;}
 .review-box-jlg {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     background-color: var(--jlg-bg-color);
@@ -296,7 +297,7 @@
 .jlg-game-explorer .jlg-ge-search label{font-size:0.875rem;font-weight:500;color:var(--jlg-ge-text-muted,var(--jlg-secondary-text-color,#4b5563));}
 .jlg-game-explorer .jlg-ge-search input[type="search"]{width:100%;padding:0.45rem 0.75rem;border-radius:0.5rem;border:1px solid var(--jlg-ge-card-border,var(--jlg-border-color,#d1d5db));background-color:var(--jlg-ge-card-bg,var(--jlg-bg-color,#fff));color:var(--jlg-ge-text,var(--jlg-main-text-color,#111827));transition:box-shadow .2s ease,border-color .2s ease;}
 .jlg-game-explorer .jlg-ge-search input[type="search"]::placeholder{color:var(--jlg-ge-text-muted,var(--jlg-secondary-text-color,#6b7280));opacity:0.85;}
-.jlg-game-explorer .jlg-ge-search input[type="search"]:focus{outline:2px solid var(--jlg-ge-accent,var(--jlg-score-gradient-1,#2563eb));outline-offset:2px;box-shadow:0 0 0 2px rgba(37,99,235,0.15);}
+.jlg-game-explorer .jlg-ge-search input[type="search"]:focus{outline:2px solid var(--jlg-ge-accent,var(--jlg-focus-ring-color));outline-offset:2px;box-shadow:0 0 0 2px rgba(37,99,235,0.15);}
 @media (max-width:640px){.jlg-game-explorer .jlg-ge-search{flex-basis:100%;min-width:100%;}}
 
 /* Summary Display */
@@ -316,13 +317,15 @@
 .jlg-game-card .jlg-genre-badges{position:absolute;left:15px;right:15px;bottom:15px;z-index:2;gap:6px;pointer-events:none;}
 .jlg-game-card .jlg-genre-badge{background-color:rgba(0,0,0,.65);color:#fff;}
 .jlg-game-card-title{position:absolute;bottom:0;left:0;right:0;z-index:2;background:linear-gradient(to top,rgba(0,0,0,.9) 0%,rgba(0,0,0,0) 100%);padding:30px 15px 60px;}
-.jlg-summary-wrapper .jlg-summary-letter-filter button:focus{outline:2px solid var(--jlg-score-gradient-1);outline-offset:2px;}
-.jlg-summary-wrapper .jlg-summary-letter-filter button.is-active:focus{outline:2px solid rgba(255,255,255,.9);}
+.jlg-summary-wrapper .jlg-summary-letter-filter button:focus-visible{outline:2px solid var(--jlg-focus-ring-color);outline-offset:2px;}
+.jlg-summary-wrapper .jlg-summary-letter-filter button.is-active:focus-visible{outline:2px solid var(--jlg-focus-ring-contrast-color);}
 .jlg-summary-filters-form input[type="submit"]{margin-left:auto;}
 @media (min-width:768px){.jlg-summary-filters{flex-direction:row;align-items:flex-start;justify-content:space-between;}.jlg-summary-filters-form{justify-content:flex-end;}}
 .jlg-summary-filters select,
 .jlg-summary-filters input[type="submit"]{padding:8px 12px;border-radius:4px;border:1px solid var(--jlg-border-color);background-color:var(--jlg-bg-color);color:var(--jlg-main-text-color);vertical-align:middle;transition:all .2s ease;}
 .jlg-summary-filters input[type="submit"]{background-color:var(--jlg-score-gradient-1);color:#fff;border-color:var(--jlg-score-gradient-1);cursor:pointer;}
+.jlg-summary-filters select:focus-visible{outline:2px solid var(--jlg-focus-ring-color);outline-offset:2px;}
+.jlg-summary-filters input[type="submit"]:focus-visible{outline:2px solid var(--jlg-focus-ring-contrast-color);outline-offset:2px;}
 .jlg-summary-filters input[type="submit"]:hover{background-color:var(--jlg-score-gradient-1-hover);border-color:var(--jlg-score-gradient-1-hover);}
 .jlg-summary-table-wrapper{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow-x:auto;-webkit-overflow-scrolling:touch;}
 .jlg-summary-table{width:100%;border-collapse:collapse;margin:2em 0;font-size:0.9em;color:var(--jlg-table-row-text-color);background-color:var(--jlg-table-row-bg-color);}

--- a/plugin-notation-jeux_V4/includes/DynamicCss.php
+++ b/plugin-notation-jeux_V4/includes/DynamicCss.php
@@ -214,6 +214,19 @@ class DynamicCss {
         $table_row_hover_color  = $this->sanitize_color_value( Helpers::adjust_hex_brightness( $bg_color_secondary, 5 ) );
         $table_link_color       = $this->sanitize_color_value( Helpers::adjust_hex_brightness( $table_row_text_color, 20 ) );
         $score_gradient_1_hover = $this->sanitize_color_value( Helpers::adjust_hex_brightness( $score_gradient_1, 20 ) );
+        $focus_ring_color       = $this->sanitize_color_value( Helpers::adjust_hex_brightness( $score_gradient_1, 10 ) );
+
+        if ( $focus_ring_color === '' ) {
+            $focus_ring_color = $score_gradient_1 !== '' ? $score_gradient_1 : $default_score_gradient_1;
+        }
+
+        $focus_ring_contrast_color = $this->sanitize_color_value(
+            Helpers::get_high_contrast_color( $focus_ring_color )
+        );
+
+        if ( $focus_ring_contrast_color === '' ) {
+            $focus_ring_contrast_color = '#ffffff';
+        }
 
         $inline_css = ':root{'
             . '--jlg-bg-color:' . $bg_color . ';'
@@ -239,6 +252,8 @@ class DynamicCss {
             . '--jlg-table-link-color:' . $table_link_color . ';'
             . '--jlg-score-gradient-1-hover:' . $score_gradient_1_hover . ';'
             . '--jlg-table-zebra-bg-color:' . $table_zebra_bg_color . ';'
+            . '--jlg-focus-ring-color:' . $focus_ring_color . ';'
+            . '--jlg-focus-ring-contrast-color:' . $focus_ring_contrast_color . ';'
             . '}';
 
         $inline_css .= $this->build_table_zebra_css( $options, $table_zebra_bg_color );

--- a/plugin-notation-jeux_V4/includes/Helpers.php
+++ b/plugin-notation-jeux_V4/includes/Helpers.php
@@ -2189,6 +2189,41 @@ class Helpers {
                 str_pad( dechex( $b ), 2, '0', STR_PAD_LEFT );
     }
 
+    public static function get_high_contrast_color( $hex_color, $light_fallback = '#ffffff', $dark_fallback = '#000000' ) {
+        $light = sanitize_hex_color( $light_fallback );
+        $dark  = sanitize_hex_color( $dark_fallback );
+
+        if ( $light === '' ) {
+            $light = '#ffffff';
+        }
+
+        if ( $dark === '' ) {
+            $dark = '#000000';
+        }
+
+        $sanitized = sanitize_hex_color( $hex_color );
+
+        if ( $sanitized === '' ) {
+            return $light;
+        }
+
+        $color = ltrim( $sanitized, '#' );
+
+        if ( strlen( $color ) === 3 ) {
+            $color = $color[0] . $color[0]
+                . $color[1] . $color[1]
+                . $color[2] . $color[2];
+        }
+
+        $red   = hexdec( substr( $color, 0, 2 ) );
+        $green = hexdec( substr( $color, 2, 2 ) );
+        $blue  = hexdec( substr( $color, 4, 2 ) );
+
+        $yiq = ( ( $red * 299 ) + ( $green * 587 ) + ( $blue * 114 ) ) / 1000;
+
+        return $yiq >= 128 ? $dark : $light;
+    }
+
     public static function calculate_color_from_note( $note, $options = null ) {
         if ( $options === null ) {
             $options = self::get_plugin_options();

--- a/plugin-notation-jeux_V4/tests/DynamicCssBuilderTest.php
+++ b/plugin-notation-jeux_V4/tests/DynamicCssBuilderTest.php
@@ -85,6 +85,8 @@ class DynamicCssBuilderTest extends TestCase
                     '--jlg-table-link-color' => '#bebebe',
                     '--jlg-score-gradient-1-hover' => '#252525',
                     '--jlg-table-zebra-bg-color' => '#bbbbbb',
+                    '--jlg-focus-ring-color' => '#1b1b1b',
+                    '--jlg-focus-ring-contrast-color' => '#ffffff',
                 ],
             ],
             'light theme falling back to defaults when colors missing' => [
@@ -128,6 +130,8 @@ class DynamicCssBuilderTest extends TestCase
                     '--jlg-table-link-color' => '#b5b5be',
                     '--jlg-score-gradient-1-hover' => '#74b9ff',
                     '--jlg-table-zebra-bg-color' => '#27272a',
+                    '--jlg-focus-ring-color' => '#6aafff',
+                    '--jlg-focus-ring-contrast-color' => '#000000',
                 ],
             ],
             'transparent palette entries keep permitted values' => [
@@ -175,6 +179,8 @@ class DynamicCssBuilderTest extends TestCase
                     '--jlg-table-link-color' => '#26486a',
                     '--jlg-score-gradient-1-hover' => '#232323',
                     '--jlg-table-zebra-bg-color' => 'transparent',
+                    '--jlg-focus-ring-color' => '#191919',
+                    '--jlg-focus-ring-contrast-color' => '#ffffff',
                 ],
             ],
         ];

--- a/plugin-notation-jeux_V4/tests/HelpersFocusRingTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersFocusRingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersFocusRingTest extends TestCase
+{
+    public function test_returns_dark_contrast_for_light_colors(): void
+    {
+        $this->assertSame('#000000', \JLG\Notation\Helpers::get_high_contrast_color('#fafafa'));
+    }
+
+    public function test_returns_light_contrast_for_dark_colors(): void
+    {
+        $this->assertSame('#ffffff', \JLG\Notation\Helpers::get_high_contrast_color('#111111'));
+    }
+
+    public function test_falls_back_to_light_when_color_invalid(): void
+    {
+        $this->assertSame('#ffffff', \JLG\Notation\Helpers::get_high_contrast_color('not-a-color'));
+    }
+}


### PR DESCRIPTION
## Summary
- add focus ring CSS variables injected via the dynamic stylesheet to better align interactive outlines with theme colors
- expose a Helpers::get_high_contrast_color utility with PHPUnit coverage and extend dynamic CSS tests to cover the new variables
- update frontend styles to use the new focus ring tokens and :focus-visible for consistent keyboard accessibility

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e53eb54d70832e91d4b172d3a3dffe