### PR TITLE
Improve score insights badge focus styles

### DIFF
--- a/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-frontend.css
@@ -560,11 +560,16 @@
     border-bottom: 1px solid transparent;
 }
 
-.jlg-score-insights__badge-link:focus,
 .jlg-score-insights__badge-link:hover,
+.jlg-score-insights__badge-link:focus {
+    border-bottom-color: currentColor;
+}
+
 .jlg-score-insights__badge-link:focus-visible {
     border-bottom-color: currentColor;
-    outline: none;
+    outline: 2px solid var(--jlg-focus-ring-color);
+    outline-offset: 3px;
+    border-radius: 4px;
 }
 
 .jlg-score-insights__badge-summary {


### PR DESCRIPTION
## Summary
- restore a visible focus indicator for score insights badge links and share hover/focus styling
- leverage the existing focus ring palette to provide an accessible outline with proper offset

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e551c367c8832e83291e912f0c5430