### PR TITLE
Automate review status finalization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un système complet de notation destiné aux sites de tests de jeux vidéo. Il fournit un rendu professionnel pour vos reviews avec des shortcodes prêts à l'emploi, un widget et des helpers PHP pour intégrer la note partout dans votre thème.
 
 ## Présentation rapide
-- **Fonctionnalités clés :** 6 catégories de notes personnalisables avec badge « Coup de cœur » éditorial, notation lecteurs avec histogramme dynamique, remplissage RAWG, validation PEGI/date/nom du jeu, Game Explorer filtrable, Score Insights (moyenne, médiane, histogramme, top plateformes), tableau récapitulatif triable, widget des derniers tests, indicateur de statut éditorial (brouillon/mise à jour/final) et guides associés configurables pour orienter les lecteurs vers des contenus complémentaires.
+- **Fonctionnalités clés :** 6 catégories de notes personnalisables avec badge « Coup de cœur » éditorial, notation lecteurs avec histogramme dynamique, remplissage RAWG, validation PEGI/date/nom du jeu, Game Explorer filtrable, Score Insights (moyenne, médiane, histogramme, top plateformes), tableau récapitulatif triable, widget des derniers tests, indicateur de statut éditorial (brouillon/mise à jour/final) avec automatisation configurable pour repasser les reviews en « Version finale » après X jours sans patch, et guides associés configurables pour orienter les lecteurs vers des contenus complémentaires.
 - **Prérequis techniques :** WordPress 5.0 minimum et PHP 7.4 ou supérieur, vérifiés automatiquement à l’activation du plugin.
 - **Architecture :** le cœur du plugin charge dynamiquement les composants admin et front-office, inclut un widget et expose des fonctions helper globales (`jlg_notation()`, `jlg_get_post_rating()`, `jlg_display_post_rating()`).
 
 ## Installation et configuration initiale
 1. **Installer le plugin** depuis ce dépôt (copier `plugin-notation-jeux_V4` dans `wp-content/plugins/`) puis l’activer depuis le menu *Extensions* de WordPress.
 2. **Remplir les metaboxes** dédiées aux notes et aux détails du test dans l’éditeur d’articles : les six catégories sont notées sur 10 et la metabox principale capture fiche technique, plateformes, taglines bilingues, points forts/faibles, etc.
-3. **Configurer l’onglet Réglages** (`Notation – JLG > Réglages`) pour ajuster libellés, présentation de la note globale, thèmes clair/sombre, couleurs sémantiques, effets neon/pulsation et modules optionnels. La section *Contenus* permet désormais de sélectionner les types de publications (articles, CPT publics…) autorisés pour la notation ; au besoin, un développeur peut toujours compléter ou restreindre cette liste via le filtre PHP `jlg_rated_post_types`.
+3. **Configurer l’onglet Réglages** (`Notation – JLG > Réglages`) pour ajuster libellés, présentation de la note globale, thèmes clair/sombre, couleurs sémantiques, effets neon/pulsation et modules optionnels. La section *Contenus* permet désormais de sélectionner les types de publications (articles, CPT publics…) autorisés pour la notation ; au besoin, un développeur peut toujours compléter ou restreindre cette liste via le filtre PHP `jlg_rated_post_types`. Le module *Statut de review* propose un toggle « Finalisation auto du statut » ainsi qu’un champ « Délai avant finalisation » (en jours) pour laisser le cron `jlg_review_status_auto_finalize` ramener automatiquement les tests en « Version finale » après vérification des patchs.
 4. **Gérer les plateformes** dans l’onglet dédié afin d’ajouter, trier, supprimer ou réinitialiser la liste proposée dans les metaboxes.
 5. **Saisir la clé RAWG (facultatif)** dans la section *API* des réglages pour activer le remplissage automatique des données de jeu.
 
@@ -39,6 +39,7 @@ Le dépôt regroupe la version 5.0 du plugin WordPress **Notation JLG**, un syst
 ## Ressources développeur
 - **Composer** : `composer.json` définit PHP >=7.4 et fournit les scripts `composer test`, `composer cs`, `composer cs-fix` pour lancer PHPUnit et PHPCS (WPCS).
 - **Gestion des traductions** : le modèle `languages/notation-jlg.pot` est prêt pour générer les fichiers `.po/.mo`.
+- **Automatisation du statut** : l’événement planifié `jlg_review_status_auto_finalize` inspecte la métadonnée `_jlg_last_patch_date` et bascule les articles éligibles vers le statut « final » ; le hook `jlg_review_status_transition` se déclenche lors de chaque bascule (manuelle ou automatique) pour journaliser l’action ou notifier des services tiers.
 - **Routine de désinstallation** : `uninstall.php` supprime proprement options, métadonnées et transients si l’utilisateur choisit de purger les données lors de la désactivation définitive.
 - **Assets & templates** :
   - [`assets/`](plugin-notation-jeux_V4/assets) regroupe styles, scripts et images front/back.

--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -25,6 +25,8 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 - **Multiples shortcodes** : bloc de notation, fiche technique, points forts/faibles, taglines bilingues
 - **Notation utilisateurs** : Permettez à vos lecteurs de voter, visualisez la répartition des notes dans un histogramme accessible mis à jour en direct et laissez le script AJAX gérer la prévention des doubles soumissions
 - **Badge coup de cœur** : Activez un badge éditorial lorsque la note dépasse un seuil configurable et affichez en parallèle la moyenne des lecteurs ainsi que l'écart avec la rédaction
+- **Sous-bloc verdict éditorial** : Résumez l’avis de la rédaction (résumé court, statut, date de mise à jour) et proposez un CTA vers la review complète directement dans le bloc tout-en-un
+- **Automatisation du statut** : Programmez un retour automatique en « Version finale » via le cron `jlg_review_status_auto_finalize`, déclenché X jours après le dernier patch vérifié, et écoutez le hook `jlg_review_status_transition` pour tracer les bascules
 - **Tableau récapitulatif** : Vue d'ensemble de tous vos tests avec tri et filtrage
 - **Nom de jeu personnalisé** : Remplacez le titre WordPress dans les tableaux, widgets et données structurées
 - **Widget** : Affichez vos derniers tests notés
@@ -56,9 +58,16 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 - Le champ **Nom du jeu** est nettoyé (espaces superflus, longueur maximale) avant sauvegarde pour garantir un affichage cohérent.
 - Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
 
+### Carte verdict & statut éditorial
+
+- Une section **📝 Verdict de la rédaction** est disponible dans la metabox principale : renseignez un résumé court (supportant du HTML basique), un libellé et une URL de bouton dédiés au verdict.
+- Le statut éditorial (`Brouillon`, `Mise à jour en cours`, `Version finale`) reste accessible via le sélecteur et s’affiche désormais dans la carte verdict avec la date de dernière mise à jour automatiquement formatée.
+- Un champ « Dernier patch vérifié » alimente l’automatisation : une fois le délai configuré écoulé, le cron repasse la review en « Version finale » et déclenche le hook `jlg_review_status_transition`.
+- Si l’URL du bouton est laissée vide, le plugin réutilise le permalien de l’article pour créer un CTA « Lire le test complet ».
+
 ### Shortcodes disponibles
 
-- `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+- `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles, tagline et carte verdict. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline`, `afficher_verdict` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 - `[bloc_notation_jeu]` - Bloc de notation principal. Attributs : `post_id` (ID du test), `score_layout` (`text` ou `circle`), `animations` (`oui`/`non`), `accent_color`, `display_mode` (`absolute` ou `percent`) pour choisir entre une note affichée en valeur absolue ou en pourcentage, ainsi que `preview_theme` (`light` ou `dark`) et `preview_animations` (`inherit`, `enabled`, `disabled`) pour forcer un thème et simuler l’état des animations dans les aperçus (éditeur, shortcodes dans Gutenberg, etc.). Lorsque le badge « Coup de cœur » est activé dans les réglages et que la note atteint le seuil défini, le bloc met en avant la sélection de la rédaction et affiche la moyenne lecteurs ainsi que le delta.
 - `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher, utilise l'article courant sinon), `champs` (liste de champs séparés par des virgules) et `titre`.
 - `[tagline_notation_jlg]` - Phrase d'accroche bilingue
@@ -120,7 +129,7 @@ programmatiques pour les intégrations avancées.
 1. Téléchargez le plugin et décompressez l'archive
 2. Uploadez le dossier `plugin-notation-jeux` dans `/wp-content/plugins/`
 3. Activez le plugin depuis le menu 'Extensions' de WordPress
-4. Configurez le plugin dans 'Notation - JLG' > 'Réglages'
+4. Configurez le plugin dans 'Notation - JLG' > 'Réglages' (modules, finalisation automatique du statut et délai avant retour en version finale)
 5. Créez votre premier test avec notation !
 
 ## Tests manuels de sécurité CSS
@@ -153,7 +162,7 @@ Le plugin est conçu pour être compatible avec tous les thèmes WordPress stand
 
 ### Puis-je désactiver certains modules ?
 
-Oui, vous pouvez activer/désactiver individuellement : notation utilisateurs, badge « Coup de cœur », taglines, animations, schema SEO.
+Oui, vous pouvez activer/désactiver individuellement : notation utilisateurs, badge « Coup de cœur », taglines, animations, schema SEO ainsi que l’automatisation du statut de review.
 
 ### Comment obtenir une clé API RAWG ?
 

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -34,6 +34,7 @@ Le plugin Notation JLG est un système complet de notation spécialement conçu 
 * **Accessibilité renforcée** : respect de `prefers-reduced-motion`, focus visibles, aria-current sur la navigation et boutons de filtres annotés.
 * **Gestion dynamique des plateformes** : ajoutez, triez, supprimez ou réinitialisez depuis l'onglet Plateformes.
 * **Responsive** : design adapté mobile/tablette et chargement conditionnel des assets via `JLG_Frontend::mark_shortcode_rendered()`.
+* **Sous-bloc verdict éditorial** : affichez un résumé court, le statut du test, la date de mise à jour et un CTA dédié dans le bloc tout-en-un.
 
 = Histogramme des votes lecteurs =
 
@@ -54,9 +55,16 @@ Accédez à l'onglet **Plateformes** depuis le menu d'administration **Notation 
 * Le champ **Nom du jeu** est normalisé (espaces superflus, longueur maximale) avant sauvegarde pour garantir un affichage homogène.
 * Les formulaires d'édition utilisent un champ HTML `type="date"` et les réponses de l'API RAWG sont normalisées pour renvoyer le format `AAAA-MM-JJ` ainsi qu'une valeur PEGI conforme lorsque disponible, garantissant une expérience cohérente.
 
+= Carte verdict & statut éditorial =
+
+* Une section **📝 Verdict de la rédaction** est disponible dans la metabox principale : saisissez un résumé court (HTML léger autorisé), un libellé et une URL pour le bouton de verdict.
+* Le statut éditorial (`Brouillon`, `Mise à jour en cours`, `Version finale`) reste géré via le sélecteur existant et s'affiche dans la carte verdict avec la date de dernière mise à jour calculée automatiquement.
+* Le champ « Dernier patch vérifié » pilote désormais une finalisation automatique : après le délai configuré, le cron `jlg_review_status_auto_finalize` repasse la review en « Version finale » et déclenche le hook `jlg_review_status_transition` pour vos intégrations.
+* Si l'URL est vide, le permalien de l'article est utilisé pour proposer un CTA « Lire le test complet ».
+
 = Shortcodes disponibles =
 
-* `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles et tagline. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
+* `[jlg_bloc_complet]` (alias `[bloc_notation_complet]`) — Bloc tout-en-un combinant notation, points forts/faibles, tagline et carte verdict. Principaux attributs : `post_id` (ID de l'article ciblé), `style` (`moderne`, `classique`, `compact`), `afficher_notation`, `afficher_points`, `afficher_tagline`, `afficher_verdict` (valeurs `oui`/`non`), `couleur_accent`, `titre_points_forts`, `titre_points_faibles`, `display_mode` (`absolute` ou `percent`). Remplace l'utilisation combinée des shortcodes `[bloc_notation_jeu]`, `[jlg_points_forts_faibles]` et `[tagline_notation_jlg]` pour un rendu unifié.
 * `[bloc_notation_jeu]` - Bloc de notation principal. Attributs : `post_id` (ID du test), `score_layout` (`text` ou `circle`), `animations` (`oui`/`non`), `accent_color`, `display_mode` (`absolute` ou `percent`) pour choisir entre une note affichée en valeur absolue ou en pourcentage, ainsi que `preview_theme` (`light` ou `dark`) et `preview_animations` (`inherit`, `enabled`, `disabled`) pour forcer un thème et simuler l’état des animations dans les aperçus (éditeur, shortcodes dans Gutenberg, etc.). Lorsque le badge « Coup de cœur » est activé dans les réglages et que la note atteint le seuil défini, le bloc met en avant la sélection de la rédaction et affiche la moyenne lecteurs ainsi que le delta.
 * `[jlg_fiche_technique]` - Fiche technique du jeu. Attributs : `post_id` (optionnel, ID d'un test publié à afficher ; sinon l'article courant est utilisé), `champs` (liste de champs séparés par des virgules) et `titre`.
 * `[tagline_notation_jlg]` - Phrase d'accroche bilingue
@@ -120,7 +128,7 @@ Ces points d'extension facilitent la conservation de vos surcharges lors des mis
 1. Téléchargez le plugin et décompressez l'archive
 2. Uploadez le dossier `plugin-notation-jeux` dans `/wp-content/plugins/`
 3. Activez le plugin depuis le menu 'Extensions' de WordPress
-4. Configurez le plugin dans 'Notation - JLG' > 'Réglages'. La section *Contenus* vous permet de choisir les types de publications (articles, CPT publics…) autorisés pour la notation ; si besoin, un développeur peut ajuster cette liste via le filtre PHP `jlg_rated_post_types`.
+4. Configurez le plugin dans 'Notation - JLG' > 'Réglages'. La section *Contenus* vous permet de choisir les types de publications (articles, CPT publics…) autorisés pour la notation ; si besoin, un développeur peut ajuster cette liste via le filtre PHP `jlg_rated_post_types`. Activez au passage la finalisation automatique du statut et définissez le délai (en jours) pour laisser le cron ramener les reviews en « Version finale » après vérification des patchs.
 5. Créez votre premier test avec notation !
 
 == Tests manuels de sécurité CSS ==
@@ -153,7 +161,7 @@ Le plugin est conçu pour être compatible avec tous les thèmes WordPress stand
 
 = Puis-je désactiver certains modules ? =
 
-Oui, vous pouvez activer/désactiver individuellement : notation utilisateurs, badge « Coup de cœur », taglines, animations, schema SEO.
+Oui, vous pouvez activer/désactiver individuellement : notation utilisateurs, badge « Coup de cœur », taglines, animations, schema SEO ainsi que la finalisation automatique du statut de review.
 
 = Comment obtenir une clé API RAWG ? =
 

--- a/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
+++ b/plugin-notation-jeux_V4/assets/css/jlg-shortcode-all-in-one.css
@@ -60,6 +60,151 @@
     padding: 0 clamp(16px, 8vw, 40px);
 }
 
+.jlg-aio-verdict {
+    padding: 24px 30px;
+    background: var(--jlg-aio-verdict-bg, #ffffff);
+    border-bottom: 1px solid var(--jlg-aio-verdict-border, rgba(0, 0, 0, 0.08));
+    display: grid;
+    gap: 18px;
+}
+
+.jlg-aio-verdict__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+    align-items: center;
+    justify-content: space-between;
+    color: var(--jlg-aio-verdict-meta, #4b5563);
+    font-size: 0.875rem;
+}
+
+.jlg-aio-verdict__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border-radius: 9999px;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+}
+
+.jlg-aio-verdict__status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.6);
+}
+
+.jlg-aio-verdict__status-description {
+    font-size: 0.75rem;
+    font-weight: 400;
+    opacity: 0.8;
+}
+
+.jlg-aio-verdict__status--draft {
+    background: rgba(234, 179, 8, 0.14);
+    color: #b45309;
+}
+
+.jlg-aio-verdict__status--in_progress {
+    background: rgba(14, 165, 233, 0.16);
+    color: #0369a1;
+}
+
+.jlg-aio-verdict__status--final {
+    background: rgba(34, 197, 94, 0.16);
+    color: #0f766e;
+}
+
+.jlg-aio-verdict__body {
+    display: grid;
+    gap: 16px;
+    color: var(--jlg-aio-verdict-text, #111827);
+}
+
+.jlg-aio-verdict__heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.jlg-aio-verdict__title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin: 0;
+    color: inherit;
+}
+
+.jlg-aio-verdict__permalink {
+    display: inline-flex;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(17, 24, 39, 0.06);
+    position: relative;
+}
+
+.jlg-aio-verdict__permalink::after {
+    content: '';
+    position: absolute;
+    inset: 10px;
+    border-radius: 50%;
+    border: 2px solid rgba(17, 24, 39, 0.25);
+}
+
+.jlg-aio-verdict__permalink:focus-visible {
+    outline: 2px solid var(--jlg-aio-verdict-accent, currentColor);
+    outline-offset: 3px;
+}
+
+.jlg-aio-verdict__summary p {
+    margin: 0 0 10px;
+    line-height: 1.55;
+}
+
+.jlg-aio-verdict__summary p:last-child {
+    margin-bottom: 0;
+}
+
+.jlg-aio-verdict__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.jlg-aio-verdict__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 12px 18px;
+    font-weight: 600;
+    border-radius: 9999px;
+    background: var(--jlg-aio-verdict-accent, #2563eb);
+    color: #ffffff;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.jlg-aio-verdict__cta:hover,
+.jlg-aio-verdict__cta:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px -12px var(--jlg-aio-verdict-accent, rgba(37, 99, 235, 0.5));
+    outline: none;
+}
+
+.jlg-aio-verdict__cta-label {
+    font-size: 0.95rem;
+}
+
+.jlg-aio-verdict__updated time,
+.jlg-aio-verdict__updated {
+    color: inherit;
+}
+
 .jlg-aio-video {
     padding: 0 30px 30px;
 }
@@ -185,6 +330,15 @@
         position: static;
         margin: 12px auto 0;
         justify-content: center;
+    }
+
+    .jlg-aio-verdict {
+        padding: 20px;
+    }
+
+    .jlg-aio-verdict__heading {
+        flex-direction: column;
+        align-items: flex-start;
     }
 }
 

--- a/plugin-notation-jeux_V4/docs/product-roadmap/2025-10-roadmap.md
+++ b/plugin-notation-jeux_V4/docs/product-roadmap/2025-10-roadmap.md
@@ -17,7 +17,7 @@ Ce document décline les opportunités identifiées dans le benchmark du 5 octob
 | Deliverable | Description | Piliers UX | Estimation | Notes |
 | --- | --- | --- | --- | --- |
 | Sous-bloc Verdict | Encapsule résumé, verdict, CTA vers review complète, statut et date de mise à jour. | Hiérarchie info, crédibilité | 6 j | Inclure toggle Gutenberg + attributs shortcode. |
-| Mode « Review en cours » automatisé | Cron qui vérifie les métadonnées `last_patch_date` et bascule statut → Final après X jours. | Fraîcheur du contenu | 3 j | Ajouter tests unitaires + hook `jlg_review_status_transition`. |
+| Mode « Review en cours » automatisé | Cron qui vérifie les métadonnées `last_patch_date` et bascule statut → Final après X jours. (✅ livré via `jlg_review_status_auto_finalize` + hook `jlg_review_status_transition`) | Fraîcheur du contenu | 3 j | Ajouter tests unitaires + hook `jlg_review_status_transition`. |
 | Comparateur plateformes | Shortcode/bloc `jlg_platform_breakdown` avec colonnes performances, recommandations. | Guidance d'achat | 8 j | Requiert extension metabox plateformes + data structure. |
 
 ## Vague 2 – Monétisation & insights (S+8 à S+16)

--- a/plugin-notation-jeux_V4/docs/responsive-testing.md
+++ b/plugin-notation-jeux_V4/docs/responsive-testing.md
@@ -29,3 +29,12 @@ Pour vérifier l'interaction mobile du Game Explorer (`[jlg_game_explorer]`) :
 3. Cliquez sur le bouton : un panneau coulissant doit apparaître depuis le bas de l'écran, avec un fond semi-transparent masquant l'arrière-plan.
 4. Modifiez un filtre (catégorie, plateforme, studio, éditeur, disponibilité ou recherche) puis validez. Le panneau doit se refermer automatiquement, les résultats se mettre à jour et le focus clavier passer sur le premier élément des résultats.
 5. Testez le bouton « Réinitialiser » : il doit fermer le panneau, remettre les filtres par défaut et replacer le focus sur les résultats.
+
+## Carte verdict du bloc tout-en-un
+
+Pour vérifier le rendu responsive de la carte verdict du shortcode/bloc `[jlg_bloc_complet]` :
+
+1. Créez un test avec les champs **Résumé court**, **Texte du bouton verdict** et **URL du bouton verdict** renseignés, puis sélectionnez un statut « Mise à jour en cours ».
+2. Affichez la page contenant le bloc tout-en-un sur un écran ≤ 768 px. Vérifiez que le statut reste lisible et que la date de mise à jour s’affiche sous forme de phrase.
+3. Réduisez à 320 px : le titre « Verdict de la rédaction » et le bouton doivent passer sur deux lignes sans chevauchement. Le focus clavier sur le bouton doit être visible.
+4. Agrandissez la fenêtre (>1024 px) et contrôlez que le résumé conserve une largeur raisonnable, que le statut ne se déforme pas et que le CTA aligne correctement son ombre portée.

--- a/plugin-notation-jeux_V4/docs/review-status-automation.md
+++ b/plugin-notation-jeux_V4/docs/review-status-automation.md
@@ -1,0 +1,40 @@
+# Automatisation du statut de review
+
+## Objectif
+La feuille de route d’octobre 2025 introduit un mode « Review en cours » automatisé. Ce document décrit le fonctionnement du cron `jlg_review_status_auto_finalize`, la configuration côté rédaction et les points d’extension disponibles pour les développeurs.
+
+## Fonctionnement général
+1. Chaque review peut renseigner la date du **dernier patch vérifié** via la metabox « 📝 Verdict de la rédaction ».
+2. Lorsque l’option **Finalisation auto du statut** est active dans `Notation – JLG > Réglages > Modules`, le plugin planifie un événement quotidien (`jlg_review_status_auto_finalize`).
+3. À chaque exécution, le cron recherche les articles :
+   - dont le statut courant figure parmi les statuts surveillés (par défaut `in_progress`),
+   - dont la métadonnée `_jlg_last_patch_date` est antérieure ou égale au seuil calculé (`today - N jours`).
+4. Les reviews éligibles sont automatiquement basculées vers `final`. Le hook `jlg_review_status_transition` reçoit les paramètres `(post_id, statut_précédent, statut_cible, 'auto_finalize')` pour permettre la journalisation ou des webhooks externes.
+
+## Options disponibles
+- **Finalisation auto du statut** (checkbox) : active le cron et affiche un champ « Dernier patch vérifié » dans la metabox.
+- **Délai avant finalisation (jours)** : entier entre 1 et 60. Définit le nombre de jours à attendre après la date de dernier patch avant de repasser en version finale.
+
+## Hooks & filtres
+| Hook | Description |
+| --- | --- |
+| `jlg_review_status_auto_finalize_threshold_timestamp` | Ajuste le timestamp calculé à partir du délai configuré. |
+| `jlg_review_status_auto_finalize_threshold` | Permet de substituer la date seuil (format `Y-m-d`). |
+| `jlg_review_status_auto_finalize_statuses` | Modifie la liste des statuts surveillés (par défaut `in_progress`). |
+| `jlg_review_status_auto_finalize_target` | Change le statut cible (par défaut `final`). |
+| `jlg_review_status_auto_finalize_batch_size` | Ajuste la taille des lots traités par requête. |
+| `jlg_review_status_auto_finalize_query_args` | Permet de personnaliser l’argumentation `WP_Query`. |
+| `jlg_review_status_transition` | Action déclenchée après chaque bascule automatique ou manuelle du statut. |
+
+## Checklist manuelle
+1. Dans l’admin, cochez **Finalisation auto du statut** et définissez un délai de test (ex. 3 jours).
+2. Sur un article existant, positionnez le statut en « Mise à jour en cours », remplissez le champ « Dernier patch vérifié » avec une date passée et enregistrez.
+3. Exécutez le cron via WP-CLI `wp cron event run jlg_review_status_auto_finalize --allow-root` (ou attendez la prochaine exécution). Vérifiez que :
+   - le statut passe automatiquement à « Version finale »,
+   - la notice d’automatisation apparaît dans les logs si votre thème écoute `jlg_review_status_transition`.
+4. Répétez avec une date future pour confirmer qu’aucune bascule n’a lieu et qu’aucune action n’est déclenchée.
+
+## Points d’attention
+- Le champ « Dernier patch vérifié » est facultatif. Sans valeur, aucun traitement automatique n’est appliqué.
+- Les sites très volumineux peuvent augmenter/diminuer la taille des lots via `jlg_review_status_auto_finalize_batch_size`.
+- Pensez à informer la rédaction que la bascule est automatique pour éviter les modifications contradictoires côté manuel.

--- a/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Metaboxes.php
@@ -179,7 +179,29 @@ class Metaboxes {
 
         // Récupérer les métadonnées
         $meta = array();
-        $keys = array( 'game_title', 'tagline_fr', 'tagline_en', 'points_forts', 'points_faibles', 'developpeur', 'editeur', 'date_sortie', 'version', 'pegi', 'temps_de_jeu', 'plateformes', 'cover_image_url', 'cta_label', 'cta_url', 'review_video_url', 'review_video_provider' );
+        $keys = array(
+            'game_title',
+            'tagline_fr',
+            'tagline_en',
+            'points_forts',
+            'points_faibles',
+            'developpeur',
+            'editeur',
+            'date_sortie',
+            'version',
+            'pegi',
+            'temps_de_jeu',
+            'plateformes',
+            'cover_image_url',
+            'cta_label',
+            'cta_url',
+            'review_video_url',
+            'review_video_provider',
+            'verdict_summary',
+            'verdict_cta_label',
+            'verdict_cta_url',
+            'last_patch_date',
+        );
         foreach ( $keys as $key ) {
             $meta[ $key ] = get_post_meta( $post->ID, '_jlg_' . $key, true );
         }
@@ -200,6 +222,13 @@ class Metaboxes {
         }
         echo '</select>';
         echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Ce statut est affiché sous la note globale pour informer les lecteurs de la fraîcheur de la review.', 'notation-jlg' ) . '</p>';
+        echo '</div>';
+
+        $last_patch_value = isset( $meta['last_patch_date'] ) ? (string) $meta['last_patch_date'] : '';
+        echo '<div style="margin-bottom:20px;">';
+        echo '<label for="jlg_last_patch_date"><strong>' . esc_html__( 'Dernier patch vérifié', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="date" id="jlg_last_patch_date" name="jlg_last_patch_date" value="' . esc_attr( $last_patch_value ) . '" style="width:100%; max-width:260px;">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Utilisé par l’automatisation du statut pour revenir en « Version finale » après le délai configuré.', 'notation-jlg' ) . '</p>';
         echo '</div>';
 
         echo '<div style="margin-bottom:20px;">';
@@ -342,6 +371,27 @@ class Metaboxes {
         echo '</div>';
         echo '</div>';
 
+        echo '<h3>' . esc_html__( '📝 Verdict de la rédaction', 'notation-jlg' ) . '</h3>';
+        echo '<div style="display:grid; grid-template-columns:1fr; gap:15px; margin-bottom:20px;">';
+        echo '<div>';
+        echo '<label for="jlg_verdict_summary"><strong>' . esc_html__( 'Résumé court', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<textarea id="jlg_verdict_summary" name="jlg_verdict_summary" rows="4" style="width:100%;" placeholder="' . esc_attr__( 'Un verdict concis pour guider les lecteurs…', 'notation-jlg' ) . '">' . esc_textarea( $meta['verdict_summary'] ?? '' ) . '</textarea>';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Limitez-vous à 3-4 phrases pour conserver une lecture instantanée.', 'notation-jlg' ) . '</p>';
+        echo '</div>';
+
+        echo '<div style="display:grid; grid-template-columns:1fr 1fr; gap:15px;">';
+        echo '<div>';
+        echo '<label for="jlg_verdict_cta_label"><strong>' . esc_html__( 'Texte du bouton verdict', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="text" id="jlg_verdict_cta_label" name="jlg_verdict_cta_label" value="' . esc_attr( $meta['verdict_cta_label'] ?? '' ) . '" style="width:100%;" placeholder="' . esc_attr__( 'Lire le test complet', 'notation-jlg' ) . '">';
+        echo '</div>';
+        echo '<div>';
+        echo '<label for="jlg_verdict_cta_url"><strong>' . esc_html__( 'URL du bouton verdict', 'notation-jlg' ) . ' :</strong></label><br>';
+        echo '<input type="url" id="jlg_verdict_cta_url" name="jlg_verdict_cta_url" value="' . esc_attr( $meta['verdict_cta_url'] ?? '' ) . '" style="width:100%;" placeholder="https://">';
+        echo '<p class="description" style="margin:5px 0 0;">' . esc_html__( 'Laissez vide pour utiliser automatiquement le permalien de l’article.', 'notation-jlg' ) . '</p>';
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+
         echo '</div>';
     }
 
@@ -429,13 +479,14 @@ class Metaboxes {
 
             // Champs texte simples
             $text_fields = array(
-                'game_title'   => __( 'Nom du jeu', 'notation-jlg' ),
-                'developpeur'  => __( 'Développeur(s)', 'notation-jlg' ),
-                'editeur'      => __( 'Éditeur(s)', 'notation-jlg' ),
-                'date_sortie'  => __( 'Date de sortie', 'notation-jlg' ),
-                'version'      => __( 'Version testée', 'notation-jlg' ),
-                'pegi'         => __( 'PEGI', 'notation-jlg' ),
-                'temps_de_jeu' => __( 'Temps de jeu', 'notation-jlg' ),
+                'game_title'      => __( 'Nom du jeu', 'notation-jlg' ),
+                'developpeur'     => __( 'Développeur(s)', 'notation-jlg' ),
+                'editeur'         => __( 'Éditeur(s)', 'notation-jlg' ),
+                'date_sortie'     => __( 'Date de sortie', 'notation-jlg' ),
+                'version'         => __( 'Version testée', 'notation-jlg' ),
+                'pegi'            => __( 'PEGI', 'notation-jlg' ),
+                'temps_de_jeu'    => __( 'Temps de jeu', 'notation-jlg' ),
+                'last_patch_date' => __( 'Dernier patch vérifié', 'notation-jlg' ),
             );
             foreach ( $text_fields as $field => $label ) {
                 if ( isset( $_POST[ 'jlg_' . $field ] ) ) {
@@ -453,7 +504,7 @@ class Metaboxes {
                         continue;
                     }
 
-                    if ( $field === 'date_sortie' ) {
+                    if ( in_array( $field, array( 'date_sortie', 'last_patch_date' ), true ) ) {
                         $sanitized_date = Validator::sanitize_date( $value );
                         if ( $sanitized_date === null ) {
                             delete_post_meta( $post_id, '_jlg_' . $field );
@@ -520,6 +571,15 @@ class Metaboxes {
                 }
             }
 
+            if ( isset( $_POST['jlg_verdict_summary'] ) ) {
+                $summary_value = wp_kses_post( wp_unslash( $_POST['jlg_verdict_summary'] ) );
+                if ( $summary_value === '' ) {
+                    delete_post_meta( $post_id, '_jlg_verdict_summary' );
+                } else {
+                    update_post_meta( $post_id, '_jlg_verdict_summary', $summary_value );
+                }
+            }
+
             $cta_label = isset( $_POST['jlg_cta_label'] ) ? sanitize_text_field( wp_unslash( $_POST['jlg_cta_label'] ) ) : '';
             $cta_label = is_string( $cta_label ) ? trim( $cta_label ) : '';
             $cta_url   = isset( $_POST['jlg_cta_url'] ) ? esc_url_raw( wp_unslash( $_POST['jlg_cta_url'] ) ) : '';
@@ -542,6 +602,33 @@ class Metaboxes {
                 } else {
                     update_post_meta( $post_id, '_jlg_cta_label', $cta_label );
                     update_post_meta( $post_id, '_jlg_cta_url', esc_url_raw( $cta_url ) );
+                }
+            }
+
+            $verdict_cta_label = isset( $_POST['jlg_verdict_cta_label'] ) ? sanitize_text_field( wp_unslash( $_POST['jlg_verdict_cta_label'] ) ) : '';
+            $verdict_cta_label = is_string( $verdict_cta_label ) ? trim( $verdict_cta_label ) : '';
+            $verdict_cta_url   = isset( $_POST['jlg_verdict_cta_url'] ) ? wp_unslash( $_POST['jlg_verdict_cta_url'] ) : '';
+            $verdict_cta_url   = is_string( $verdict_cta_url ) ? trim( $verdict_cta_url ) : '';
+
+            if ( $verdict_cta_label === '' && $verdict_cta_url === '' ) {
+                delete_post_meta( $post_id, '_jlg_verdict_cta_label' );
+                delete_post_meta( $post_id, '_jlg_verdict_cta_url' );
+            } elseif ( $verdict_cta_label === '' && $verdict_cta_url !== '' ) {
+                delete_post_meta( $post_id, '_jlg_verdict_cta_label' );
+                delete_post_meta( $post_id, '_jlg_verdict_cta_url' );
+                $validation_errors[] = __( 'Bouton verdict : ajoutez un libellé pour le lien de verdict.', 'notation-jlg' );
+            } elseif ( $verdict_cta_label !== '' && $verdict_cta_url === '' ) {
+                delete_post_meta( $post_id, '_jlg_verdict_cta_label' );
+                delete_post_meta( $post_id, '_jlg_verdict_cta_url' );
+                $validation_errors[] = __( 'Bouton verdict : renseignez une URL ou laissez les deux champs vides.', 'notation-jlg' );
+            } else {
+                if ( ! Validator::is_valid_http_url( $verdict_cta_url ) ) {
+                    delete_post_meta( $post_id, '_jlg_verdict_cta_label' );
+                    delete_post_meta( $post_id, '_jlg_verdict_cta_url' );
+                    $validation_errors[] = __( 'Bouton verdict : l’URL doit être absolue et commencer par http ou https.', 'notation-jlg' );
+                } else {
+                    update_post_meta( $post_id, '_jlg_verdict_cta_label', $verdict_cta_label );
+                    update_post_meta( $post_id, '_jlg_verdict_cta_url', esc_url_raw( $verdict_cta_url ) );
                 }
             }
 

--- a/plugin-notation-jeux_V4/includes/Admin/Settings.php
+++ b/plugin-notation-jeux_V4/includes/Admin/Settings.php
@@ -879,13 +879,14 @@ class Settings {
         // Section 7: Modules
         add_settings_section( 'jlg_modules', '7. 🧩 Modules', null, 'notation_jlg_page' );
         $module_fields = array(
-            'user_rating_enabled'    => 'Notation utilisateurs',
-            'rating_badge_enabled'   => 'Badge « Coup de cœur »',
-            'review_status_enabled'  => 'Statut de review',
-            'related_guides_enabled' => 'Guides associés',
-            'tagline_enabled'        => 'Taglines bilingues',
-            'seo_schema_enabled'     => 'Schéma SEO (étoiles Google)',
-            'enable_animations'      => 'Animations des barres',
+            'user_rating_enabled'                 => 'Notation utilisateurs',
+            'rating_badge_enabled'                => 'Badge « Coup de cœur »',
+            'review_status_enabled'               => 'Statut de review',
+            'review_status_auto_finalize_enabled' => __( 'Finalisation auto du statut', 'notation-jlg' ),
+            'related_guides_enabled'              => 'Guides associés',
+            'tagline_enabled'                     => 'Taglines bilingues',
+            'seo_schema_enabled'                  => 'Schéma SEO (étoiles Google)',
+            'enable_animations'                   => 'Animations des barres',
         );
         foreach ( $module_fields as $id => $title ) {
             add_settings_field(
@@ -900,6 +901,23 @@ class Settings {
 				)
             );
         }
+
+        $auto_finalize_days_args = array(
+            'id'   => 'review_status_auto_finalize_days',
+            'type' => 'number',
+            'min'  => 1,
+            'max'  => 60,
+            'desc' => __( 'Nombre de jours à attendre après le dernier patch vérifié avant de repasser en « Version finale ».', 'notation-jlg' ),
+        );
+        add_settings_field(
+            'review_status_auto_finalize_days',
+            __( 'Délai avant finalisation (jours)', 'notation-jlg' ),
+            array( $this, 'render_field' ),
+            'notation_jlg_page',
+            'jlg_modules',
+            $auto_finalize_days_args
+        );
+        $this->store_field_constraints( $auto_finalize_days_args );
 
         $rating_badge_threshold_args = array(
             'id'   => 'rating_badge_threshold',

--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -3186,6 +3186,8 @@ class Frontend {
                 'extra_classes'            => '',
                 'score_layout'             => 'text',
                 'animations_enabled'       => false,
+                'verdict'                  => array(),
+                'display_verdict'          => false,
                 'should_show_rating_badge' => false,
                 'user_rating_average'      => null,
                 'user_rating_delta'        => null,

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -96,6 +96,7 @@ class AllInOne {
 				'afficher_notation'    => 'oui',
 				'afficher_points'      => 'oui',
 				'afficher_tagline'     => 'oui',
+				'afficher_verdict'     => 'oui',
 				'afficher_video'       => 'oui',
 				'titre_points_forts'   => 'Points Forts',
 				'titre_points_faibles' => 'Points Faibles',
@@ -115,6 +116,7 @@ class AllInOne {
         $atts['afficher_notation']    = sanitize_text_field( $atts['afficher_notation'] );
         $atts['afficher_points']      = sanitize_text_field( $atts['afficher_points'] );
         $atts['afficher_tagline']     = sanitize_text_field( $atts['afficher_tagline'] );
+        $atts['afficher_verdict']     = sanitize_text_field( $atts['afficher_verdict'] );
         $atts['afficher_video']       = sanitize_text_field( $atts['afficher_video'] );
         $atts['titre_points_forts']   = sanitize_text_field( $atts['titre_points_forts'] );
         $atts['titre_points_faibles'] = sanitize_text_field( $atts['titre_points_faibles'] );
@@ -266,6 +268,13 @@ class AllInOne {
 
         $score_layout = $options['score_layout'] ?? 'text';
 
+        $verdict_payload     = Helpers::get_review_verdict_for_post( $post_id );
+        $display_verdict     = ( $atts['afficher_verdict'] === 'oui' );
+        $verdict_summary     = isset( $verdict_payload['summary'] ) ? trim( (string) $verdict_payload['summary'] ) : '';
+        $verdict_has_content = $verdict_summary !== ''
+            || ! empty( $verdict_payload['last_updated']['display'] ?? '' );
+        $display_verdict     = $display_verdict && $verdict_has_content;
+
         $css_variables = array(
             '--jlg-aio-bg'                    => $palette['bg_color'] ?? '',
             '--jlg-aio-bg-secondary'          => $palette['bg_color_secondary'] ?? '',
@@ -291,6 +300,11 @@ class AllInOne {
             '--jlg-aio-circle-shadow'         => $this->build_circle_shadow( $accent_color ),
             '--jlg-aio-cta-bg'                => $accent_color,
             '--jlg-aio-cta-text'              => '#ffffff',
+            '--jlg-aio-verdict-bg'            => $palette['bg_color'] ?? '',
+            '--jlg-aio-verdict-border'        => $palette['border_color'] ?? '',
+            '--jlg-aio-verdict-text'          => $palette['text_color'] ?? '',
+            '--jlg-aio-verdict-meta'          => $palette['text_color_secondary'] ?? '',
+            '--jlg-aio-verdict-accent'        => $accent_color,
         );
 
         if ( $score_layout === 'circle' ) {
@@ -448,6 +462,8 @@ class AllInOne {
 				'animations_enabled'       => ! empty( $options['enable_animations'] ),
 				'score_max'                => $score_max_value,
 				'display_mode'             => $display_mode,
+				'verdict'                  => $verdict_payload,
+				'display_verdict'          => $display_verdict,
 			)
         );
     }

--- a/plugin-notation-jeux_V4/languages/notation-jlg.pot
+++ b/plugin-notation-jeux_V4/languages/notation-jlg.pot
@@ -9,20 +9,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-10-19T00:00:00+00:00\n"
+"POT-Creation-Date: 2025-10-07T20:42:10+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: notation-jlg\n"
-
-#. translators: Sort option label for descending popularity (most votes first).
-#: includes/Shortcodes/GameExplorer.php:279 assets/js/blocks/game-explorer.js:48
-msgid "Popularité (plus de votes)"
-msgstr ""
-
-#. translators: Sort option label for ascending popularity (least votes first).
-#: includes/Shortcodes/GameExplorer.php:285 assets/js/blocks/game-explorer.js:49
-msgid "Popularité (moins de votes)"
-msgstr ""
 
 #. Plugin Name of the plugin
 #: plugin-notation-jeux.php
@@ -44,804 +34,2057 @@ msgstr ""
 msgid "Jérôme Le Gousse"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:20
+#: admin/templates/tabs/posts-list.php:34
+msgid "Synthèse des notes"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:38
+#, php-format
+msgid "%d article analysé."
+msgid_plural "%d articles analysés."
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/templates/tabs/posts-list.php:45
+msgid "Score moyen"
+msgstr ""
+
+#. translators: Abbreviation meaning that the user rating is not available.
+#: admin/templates/tabs/posts-list.php:46
+#: admin/templates/tabs/posts-list.php:51
+#: admin/templates/tabs/posts-list.php:96
+#: includes/Admin/Menu.php:177
+#: includes/Assets.php:176
+#: includes/Shortcodes/GameExplorer.php:1763
+#: templates/shortcode-score-insights.php:144
+#: templates/shortcode-score-insights.php:209
+#: templates/shortcode-score-insights.php:210
+#: templates/shortcode-score-insights.php:302
+#: templates/shortcode-score-insights.php:313
+#: templates/shortcode-user-rating.php:154
+#: templates/summary-table-fragment.php:289
+#: templates/summary-table-fragment.php:378
+#: templates/summary-table-fragment.php:422
+msgid "N/A"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:47
+msgid "Moyenne pondérée des notes finales."
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:50
+#: templates/shortcode-score-insights.php:114
+msgid "Médiane"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:52
+msgid "Score central sur l’ensemble des publications."
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:55
+#: templates/shortcode-score-insights.php:247
+msgid "Répartition des notes"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:63
+#, php-format
+msgid "%1$s : %2$d articles, %3$s%% du total"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:81
+msgid "Classement par plateforme"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:82
+msgid "Classement des plateformes les mieux notées"
+msgstr ""
+
+#: admin/templates/tabs/posts-list.php:90
+#, php-format
+msgid "%d jeu noté"
+msgid_plural "%d jeux notés"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/templates/tabs/posts-list.php:102
+msgid "Pas encore de plateforme renseignée."
+msgstr ""
+
+#. translators: %s: Maximum possible rating value.
+#. translators: %s: Maximum rating value displayed with the thumbnail score.
+#: admin/templates/tabs/posts-list.php:146
+#: plugin-notation-jeux.php:529
+#: templates/game-explorer-fragment.php:166
+#: templates/widget-thumbnail-score.php:43
+#, php-format
+msgid "/%s"
+msgstr ""
+
+#: includes/Admin/Ajax.php:55
+msgid "Permissions insuffisantes."
+msgstr ""
+
+#: includes/Admin/Ajax.php:66
+msgid "Terme de recherche vide."
+msgstr ""
+
+#: includes/Admin/Ajax.php:95
+msgid "Recherche simulée. Configurez une vraie clé API RAWG dans les réglages pour des résultats réels."
+msgstr ""
+
+#: includes/Admin/Ajax.php:132
+msgid "Erreur de communication avec RAWG.io. Veuillez réessayer ultérieurement."
+msgstr ""
+
+#. translators: %d: HTTP status code returned by RAWG.io
+#: includes/Admin/Ajax.php:145
+#, php-format
+msgid "La requête RAWG.io a échoué avec le code HTTP %d."
+msgstr ""
+
+#: includes/Admin/Ajax.php:159
+msgid "Réponse RAWG.io invalide : données JSON non valides."
+msgstr ""
+
+#: includes/Admin/Ajax.php:180
+msgid "Résultats récupérés depuis RAWG.io."
+msgstr ""
+
+#: includes/Admin/Menu.php:28
 msgctxt "Admin page title"
 msgid "Notation JLG"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:21
+#: includes/Admin/Menu.php:29
 msgctxt "Admin menu title"
 msgid "Notation - JLG"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:32
+#: includes/Admin/Menu.php:40
 msgid "Accès refusé."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:45
+#: includes/Admin/Menu.php:55
 msgid "⭐ Notation JLG v5.0"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:53
+#: includes/Admin/Menu.php:64
 msgid "⚙️ Réglages"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:54
+#: includes/Admin/Menu.php:65
 msgid "📊 Articles Notés"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:55
+#: includes/Admin/Menu.php:66
 msgid "🎮 Plateformes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:56
+#: includes/Admin/Menu.php:67
 msgid "📝 Shortcodes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:57
+#: includes/Admin/Menu.php:68
 msgid "📚 Tutoriels"
 msgstr ""
 
-#. translators: Abbreviation meaning that the user rating is not available.
-#: includes/admin/class-jlg-admin-menu.php:153
-#: includes/class-jlg-assets.php:117
-#: templates/shortcode-user-rating.php:15
-#: templates/summary-table-fragment.php:97
-#: templates/summary-table-fragment.php:157
-msgid "N/A"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-menu.php:178
+#: includes/Admin/Menu.php:202
 msgid "Page "
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:203
+#: includes/Admin/Menu.php:230
 msgid "🖨️ Imprimer cette liste"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:209
+#: includes/Admin/Menu.php:238
 msgid "Titre"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:210
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:184
+#: includes/Admin/Menu.php:242
+#: includes/Shortcodes/SummaryDisplay.php:356
+#: assets/js/blocks/summary-display.js:38
 msgid "Date"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:211
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:192
+#: includes/Admin/Menu.php:246
+#: includes/Shortcodes/SummaryDisplay.php:364
 msgid "Note"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:249
+#: includes/Admin/Menu.php:289
 msgid "🎮 Gestion des Plateformes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:268
+#: includes/Admin/Menu.php:296
 msgid "La classe de gestion des plateformes n'a pas pu être chargée."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:271
-msgid "Fichier class-jlg-admin-platforms.php introuvable."
-msgstr ""
-
-#: includes/admin/class-jlg-admin-menu.php:283
+#: includes/Admin/Menu.php:312
 msgid "⚡ Démarrage rapide avec le Bloc Complet"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:284
+#: includes/Admin/Menu.php:313
 msgid "La méthode la plus simple pour créer un test professionnel."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:286
-#: includes/admin/class-jlg-admin-menu.php:297
+#: includes/Admin/Menu.php:315
+#: includes/Admin/Menu.php:326
 msgid "Créer un nouvel article"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:287
+#: includes/Admin/Menu.php:316
 msgid "Remplir les notes dans la metabox (colonne droite)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:288
+#: includes/Admin/Menu.php:317
 msgid "Ajouter tagline et points forts/faibles"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:289
+#: includes/Admin/Menu.php:318
 msgid "Insérer [jlg_bloc_complet] dans le contenu"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:290
+#: includes/Admin/Menu.php:319
 msgid "C'est tout ! Publiez votre test"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:294
+#: includes/Admin/Menu.php:323
 msgid "🎮 Créer un test détaillé (méthode classique)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:295
+#: includes/Admin/Menu.php:324
 msgid "Guide pas-à-pas pour un contrôle total."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:298
+#: includes/Admin/Menu.php:327
 msgid "Remplir la metabox \"Notation\" (colonne droite)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:299
+#: includes/Admin/Menu.php:328
 msgid "Ajouter les détails du jeu (metabox principale)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:300
+#: includes/Admin/Menu.php:329
 msgid "Intégrer les shortcodes séparés si besoin"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:301
+#: includes/Admin/Menu.php:330
 msgid "Publier et vérifier l'affichage"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:305
+#: includes/Admin/Menu.php:334
 msgid "🎨 Personnalisation du Bloc Complet"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:306
+#: includes/Admin/Menu.php:335
 msgid "Créez un rendu unique."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:308
+#: includes/Admin/Menu.php:337
 msgid "Choisir le style (moderne/classique/compact)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:309
+#: includes/Admin/Menu.php:338
 msgid "Définir une couleur d'accent personnalisée"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:310
+#: includes/Admin/Menu.php:339
 msgid "Activer/désactiver les sections"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:311
+#: includes/Admin/Menu.php:340
 msgid "Personnaliser les titres des sections"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:312
+#: includes/Admin/Menu.php:341
 msgid "Combiner avec d'autres shortcodes si besoin"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:316
+#: includes/Admin/Menu.php:345
 msgid "🎨 Personnalisation visuelle globale"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:317
+#: includes/Admin/Menu.php:346
 msgid "Ajuster l'apparence générale."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:319
+#: includes/Admin/Menu.php:348
 msgid "Choisir le thème (clair/sombre)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:320
+#: includes/Admin/Menu.php:349
 msgid "Activer les effets Neon/Glow"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:321
+#: includes/Admin/Menu.php:350
 msgid "Configurer la pulsation"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:322
+#: includes/Admin/Menu.php:351
 msgid "Personnaliser les couleurs"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:323
+#: includes/Admin/Menu.php:352
 msgid "Ajouter du CSS personnalisé"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:327
+#: includes/Admin/Menu.php:356
 msgid "📊 Tableau récapitulatif avancé"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:328
+#: includes/Admin/Menu.php:357
 msgid "Maîtriser le shortcode tableau."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:330
+#: includes/Admin/Menu.php:359
 msgid "Choisir entre table et grille"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:331
+#: includes/Admin/Menu.php:360
 msgid "Sélectionner les colonnes à afficher"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:332
+#: includes/Admin/Menu.php:361
+#: templates/shortcode-game-explorer.php:341
+#: templates/shortcode-summary-display.php:121
 msgid "Filtrer par catégorie"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:333
+#: includes/Admin/Menu.php:362
 msgid "Ajuster la pagination"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:334
+#: includes/Admin/Menu.php:363
 msgid "Personnaliser les couleurs dans Réglages"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:338
+#: includes/Admin/Menu.php:367
 msgid "⚡ Optimisations"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:339
+#: includes/Admin/Menu.php:368
 msgid "Améliorer les performances."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:341
+#: includes/Admin/Menu.php:370
 msgid "Utiliser [jlg_bloc_complet] au lieu de 3 shortcodes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:342
+#: includes/Admin/Menu.php:371
 msgid "Activer un plugin de cache"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:343
+#: includes/Admin/Menu.php:372
 msgid "Optimiser les images de couverture"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:344
+#: includes/Admin/Menu.php:373
 msgid "Limiter le nombre d'articles affichés"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:345
+#: includes/Admin/Menu.php:374
 msgid "Désactiver les animations si non nécessaires"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:349
+#: includes/Admin/Menu.php:378
 msgid "🔧 Intégration dans le thème"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:350
+#: includes/Admin/Menu.php:379
 msgid "Pour les développeurs."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:352
+#: includes/Admin/Menu.php:381
 msgid "Ajouter jlg_display_thumbnail_score() dans les templates"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:353
+#: includes/Admin/Menu.php:382
 msgid "Utiliser jlg_get_post_rating() pour récupérer la note"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:354
+#: includes/Admin/Menu.php:383
 msgid "Personnaliser les templates dans /templates/"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:355
+#: includes/Admin/Menu.php:384
 msgid "Créer des hooks personnalisés"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:356
+#: includes/Admin/Menu.php:385
 msgid "Surcharger les styles CSS du plugin"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:360
+#: includes/Admin/Menu.php:389
 msgid "❓ Dépannage"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:361
+#: includes/Admin/Menu.php:390
 msgid "Résoudre les problèmes courants."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:363
+#: includes/Admin/Menu.php:392
 msgid "Vérifier les conflits de plugins"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:364
+#: includes/Admin/Menu.php:393
 msgid "Vider le cache navigateur et site"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:365
+#: includes/Admin/Menu.php:394
 msgid "Vérifier les permissions utilisateur"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:366
+#: includes/Admin/Menu.php:395
 msgid "Consulter les logs d'erreur"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-menu.php:367
+#: includes/Admin/Menu.php:396
 msgid "Réinitialiser les réglages si nécessaire"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:31
+#: includes/Admin/Metaboxes.php:62
 msgid "Notation JLG"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:46
+#: includes/Admin/Metaboxes.php:81
 msgid "⭐ Notation du Jeu Vidéo"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:55
+#: includes/Admin/Metaboxes.php:90
 msgid "🎮 Détails du Test"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:73
-msgid "Gameplay"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:74
-msgid "Graphismes"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:75
-msgid "Bande-son"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:76
-msgid "Durée de vie"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:77
-msgid "Scénario"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:78
-msgid "Originalité"
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:90
-msgid "Entrez les notes sur 10. Laissez vide si non pertinent."
-msgstr ""
-
-#: includes/admin/class-jlg-admin-metaboxes.php:96
-msgctxt "score input suffix"
-msgid "/ 10"
-msgstr ""
-
-#. translators: %s: average score value.
-#: includes/admin/class-jlg-admin-metaboxes.php:104
+#: includes/Admin/Metaboxes.php:121
 #, php-format
-msgid "%s / 10"
+msgid "Entrez les notes sur %s. Laissez vide si non pertinent."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:107
+#. translators: %s: Maximum possible rating value.
+#: includes/Admin/Metaboxes.php:144
+#, php-format
+msgctxt "score input suffix"
+msgid "/ %s"
+msgstr ""
+
+#. translators: 1: Average score value. 2: Maximum possible rating value.
+#. translators: 1: Rating value. 2: Maximum possible rating.
+#. translators: 1: reader score. 2: maximum possible score.
+#. translators: 1: category score. 2: maximum score.
+#. translators: %1$s: category score value. %2$s: maximum rating value.
+#: includes/Admin/Metaboxes.php:155
+#: templates/shortcode-all-in-one.php:350
+#: templates/shortcode-rating-block-empty.php:177
+#: templates/shortcode-rating-block-empty.php:233
+#: templates/shortcode-rating-block.php:170
+#: templates/shortcode-rating-block.php:281
+#: templates/summary-table-fragment.php:428
+#, php-format
+msgid "%1$s / %2$s"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:159
 msgid "Note moyenne :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:132
-#: includes/admin/class-jlg-admin-metaboxes.php:280
+#: includes/Admin/Metaboxes.php:216
+#: templates/shortcode-rating-block-empty.php:197
+#: templates/shortcode-rating-block.php:198
+msgid "Statut du test"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:224
+msgid "Ce statut est affiché sous la note globale pour informer les lecteurs de la fraîcheur de la review."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:229
+#: includes/Admin/Metaboxes.php:489
+msgid "Dernier patch vérifié"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:231
+msgid "Utilisé par l’automatisation du statut pour revenir en « Version finale » après le délai configuré."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:235
+#: includes/Admin/Metaboxes.php:482
 msgid "Nom du jeu"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:134
+#: includes/Admin/Metaboxes.php:237
 msgid "Cette valeur est utilisée dans les tableaux, widgets et données structurées lorsque renseignée."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:138
+#: includes/Admin/Metaboxes.php:241
 msgid "📋 Fiche Technique"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:142
-#: includes/admin/class-jlg-admin-metaboxes.php:281
+#: includes/Admin/Metaboxes.php:245
+#: includes/Admin/Metaboxes.php:483
 msgid "Développeur(s)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:143
-#: includes/admin/class-jlg-admin-metaboxes.php:282
+#: includes/Admin/Metaboxes.php:246
+#: includes/Admin/Metaboxes.php:484
 msgid "Éditeur(s)"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:144
-#: includes/admin/class-jlg-admin-metaboxes.php:283
+#: includes/Admin/Metaboxes.php:247
+#: includes/Admin/Metaboxes.php:485
+#: assets/js/blocks/game-info.js:38
 msgid "Date de sortie"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:145
-#: includes/admin/class-jlg-admin-metaboxes.php:284
+#: includes/Admin/Metaboxes.php:248
+#: includes/Admin/Metaboxes.php:486
 msgid "Version testée"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:146
-#: includes/admin/class-jlg-admin-metaboxes.php:285
+#: includes/Admin/Metaboxes.php:249
+#: includes/Admin/Metaboxes.php:487
+#: assets/js/blocks/game-info.js:40
 msgid "PEGI"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:147
-#: includes/admin/class-jlg-admin-metaboxes.php:286
+#: includes/Admin/Metaboxes.php:250
+#: includes/Admin/Metaboxes.php:488
+#: assets/js/blocks/game-info.js:41
 msgid "Temps de jeu"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:148
+#: includes/Admin/Metaboxes.php:251
 msgid "URL de la jaquette"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:164
+#: includes/Admin/Metaboxes.php:267
 msgid "Plateformes :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:168
+#: includes/Admin/Metaboxes.php:271
 msgid "PC"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:169
+#: includes/Admin/Metaboxes.php:272
 msgid "PlayStation 5"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:170
+#: includes/Admin/Metaboxes.php:273
 msgid "Xbox Series S/X"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:171
+#: includes/Admin/Metaboxes.php:274
 msgid "Nintendo Switch"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:172
+#: includes/Admin/Metaboxes.php:275
 msgid "PlayStation 4"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:173
+#: includes/Admin/Metaboxes.php:276
 msgid "Xbox One"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:201
-msgid "💬 Taglines"
+#: includes/Admin/Metaboxes.php:304
+msgid "💬 Taglines & CTA"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:204
+#: includes/Admin/Metaboxes.php:307
 msgid "Française :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:208
+#: includes/Admin/Metaboxes.php:311
 msgid "Anglaise :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:214
+#: includes/Admin/Metaboxes.php:316
+msgid "Texte du bouton CTA"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:317
+msgid "Découvrir le jeu"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:318
+msgid "Obligatoire si vous renseignez une URL."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:321
+msgid "URL du bouton CTA"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:323
+msgid "Renseignez une URL absolue (https://...)."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:328
+msgid "🎬 Vidéo du test"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:331
+msgid "URL de la vidéo"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:333
+msgid "YouTube et Vimeo sont pris en charge. Le mode sans cookie sera appliqué automatiquement quand possible."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:341
+msgid "Fournisseur"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:343
+msgid "Détection automatique"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:356
+msgid "Sélectionnez le fournisseur si vous devez forcer la détection."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:361
 msgid "⚖️ Points Forts & Faibles"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:215
+#: includes/Admin/Metaboxes.php:362
 msgid "Un point par ligne"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:218
+#: includes/Admin/Metaboxes.php:365
 msgid "Points Forts :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:219
+#: includes/Admin/Metaboxes.php:366
 msgid ""
 "Gameplay addictif\n"
 "Graphismes superbes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:222
+#: includes/Admin/Metaboxes.php:369
 msgid "Points Faibles :"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-metaboxes.php:223
+#: includes/Admin/Metaboxes.php:370
 msgid ""
 "Durée de vie courte\n"
 "Bugs occasionnels"
 msgstr ""
 
+#: includes/Admin/Metaboxes.php:374
+msgid "📝 Verdict de la rédaction"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:377
+msgid "Résumé court"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:378
+msgid "Un verdict concis pour guider les lecteurs…"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:379
+msgid "Limitez-vous à 3-4 phrases pour conserver une lecture instantanée."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:384
+msgid "Texte du bouton verdict"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:385
+#: includes/Helpers.php:1029
+msgid "Lire le test complet"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:388
+msgid "URL du bouton verdict"
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:390
+msgid "Laissez vide pour utiliser automatiquement le permalien de l’article."
+msgstr ""
+
 #. translators: %s is the field label.
-#: includes/admin/class-jlg-admin-metaboxes.php:310
+#: includes/Admin/Metaboxes.php:513
 #, php-format
 msgid "%s : format de date invalide. Utilisez AAAA-MM-JJ."
 msgstr ""
 
 #. translators: %s is a list of allowed PEGI values
-#: includes/admin/class-jlg-admin-metaboxes.php:325
+#: includes/Admin/Metaboxes.php:528
 #, php-format
 msgid "PEGI invalide. Valeurs acceptées : %s."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:199
+#: includes/Admin/Metaboxes.php:595
+msgid "Bouton CTA : le texte et l'URL doivent être renseignés ensemble."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:601
+msgid "Bouton CTA : l'URL doit être absolue et commencer par http ou https."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:619
+msgid "Bouton verdict : ajoutez un libellé pour le lien de verdict."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:623
+msgid "Bouton verdict : renseignez une URL ou laissez les deux champs vides."
+msgstr ""
+
+#: includes/Admin/Metaboxes.php:628
+msgid "Bouton verdict : l’URL doit être absolue et commencer par http ou https."
+msgstr ""
+
+#: includes/Admin/Platforms.php:328
 msgid "Permissions insuffisantes"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:213
+#: includes/Admin/Platforms.php:342
 msgid "Erreur de sécurité"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:257
+#: includes/Admin/Platforms.php:382
 msgid "Plateformes réinitialisées avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:288
+#: includes/Admin/Platforms.php:433
 msgid "Le nom de la plateforme est requis."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:301
+#: includes/Admin/Platforms.php:449
 msgid "Nom de plateforme invalide."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:349
+#: includes/Admin/Platforms.php:498
 #, php-format
 msgid "Plateforme '%s' ajoutée avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:355
+#: includes/Admin/Platforms.php:506
 msgid "Erreur lors de la sauvegarde."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:369
+#: includes/Admin/Platforms.php:523
 msgid "Clé de plateforme manquante."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:378
+#: includes/Admin/Platforms.php:535
 msgid "Plateforme introuvable."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:388
+#: includes/Admin/Platforms.php:546
 #, php-format
 msgid "La plateforme '%s' est une plateforme par défaut et ne peut pas être supprimée."
 msgstr ""
 
 #. translators: %s: platform name.
-#: includes/admin/class-jlg-admin-platforms.php:406
+#: includes/Admin/Platforms.php:564
 #, php-format
 msgid "Plateforme '%s' supprimée avec succès !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:412
+#: includes/Admin/Platforms.php:572
 msgid "Erreur lors de la suppression."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:426
+#: includes/Admin/Platforms.php:589
 msgid "Données d'ordre manquantes."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:435
+#: includes/Admin/Platforms.php:604
 msgid "Ordre soumis invalide."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:457
+#: includes/Admin/Platforms.php:629
 msgid "Aucune plateforme valide reçue."
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:478
+#: includes/Admin/Platforms.php:653
 msgid "Ordre des plateformes mis à jour !"
 msgstr ""
 
-#: includes/admin/class-jlg-admin-platforms.php:481
+#: includes/Admin/Platforms.php:659
 msgid "Erreur lors de la mise à jour."
 msgstr ""
 
-#: includes/class-jlg-assets.php:99
-#: templates/shortcode-user-rating.php:37
+#: includes/Admin/Platforms.php:682
+msgid "Associations de tags mises à jour avec succès !"
+msgstr ""
+
+#: includes/Admin/Platforms.php:688
+msgid "Erreur lors de la mise à jour des tags."
+msgstr ""
+
+#: includes/Admin/Platforms.php:974
+msgid "Utilisez Ctrl/Cmd pour sélectionner plusieurs tags."
+msgstr ""
+
+#: includes/Admin/Platforms.php:982
+msgid "Les associations sauvegardées pourront être exploitées dans vos templates front-office."
+msgstr ""
+
+#: includes/Admin/Settings.php:501
+msgid "Catégories de notation"
+msgstr ""
+
+#: includes/Admin/Settings.php:508
+msgid "Ajoutez, réorganisez ou renommez les catégories utilisées pour vos notes détaillées."
+msgstr ""
+
+#: includes/Admin/Settings.php:517
+msgid "Sélectionnez les types de contenus qui peuvent utiliser les notations du plugin."
+msgstr ""
+
+#: includes/Admin/Settings.php:523
+msgid "Types de contenus autorisés"
+msgstr ""
+
+#: includes/Admin/Settings.php:531
+msgid "Maintenez Ctrl (ou Cmd sur Mac) pour sélectionner plusieurs types."
+msgstr ""
+
+#: includes/Admin/Settings.php:543
+msgid "Définissez la note maximale utilisée pour vos tests (par exemple 10, 20 ou 100)."
+msgstr ""
+
+#: includes/Admin/Settings.php:547
+msgid "Barème maximum"
+msgstr ""
+
+#: includes/Admin/Settings.php:885
+msgid "Finalisation auto du statut"
+msgstr ""
+
+#: includes/Admin/Settings.php:910
+msgid "Nombre de jours à attendre après le dernier patch vérifié avant de repasser en « Version finale »."
+msgstr ""
+
+#: includes/Admin/Settings.php:914
+msgid "Délai avant finalisation (jours)"
+msgstr ""
+
+#: includes/Admin/Settings.php:928
+msgid "Le badge apparaît lorsque la note globale atteint ce seuil. Utilisez le même barème que vos tests (ex. 8 pour un barème sur 10)."
+msgstr ""
+
+#: includes/Admin/Settings.php:932
+msgid "Seuil du badge"
+msgstr ""
+
+#: includes/Admin/Settings.php:946
+msgid "Nombre maximum de guides associés affichés sous la note."
+msgstr ""
+
+#: includes/Admin/Settings.php:950
+msgid "Nombre de guides associés"
+msgstr ""
+
+#: includes/Admin/Settings.php:960
+msgid "Taxonomies ciblées"
+msgstr ""
+
+#: includes/Admin/Settings.php:968
+msgid "Renseignez les slugs de taxonomie séparés par des virgules pour identifier les guides pertinents (ex. guide,astuce)."
+msgstr ""
+
+#: includes/Admin/Settings.php:1049
+msgid "Connexion obligatoire avant le vote"
+msgstr ""
+
+#: includes/Admin/Settings.php:1056
+msgid "Empêche les visiteurs non connectés de voter et leur affiche un lien de connexion."
+msgstr ""
+
+#: includes/Admin/Settings.php:1333
+#: assets/js/blocks/game-explorer.js:178
+msgid "Lettre"
+msgstr ""
+
+#: includes/Admin/Settings.php:1334
+msgid "Catégorie"
+msgstr ""
+
+#: includes/Admin/Settings.php:1335
+msgid "Plateforme"
+msgstr ""
+
+#: includes/Admin/Settings.php:1336
+#: assets/js/blocks/game-explorer.js:42
+msgid "Disponibilité"
+msgstr ""
+
+#: includes/Admin/Settings.php:1337
+#: assets/js/blocks/game-explorer.js:44
+msgid "Recherche"
+msgstr ""
+
+#: includes/Admin/Settings.php:1339
+msgid "Sélectionnez les filtres à afficher dans l’explorateur de jeux."
+msgstr ""
+
+#: includes/Admin/Settings.php:1344
+#: assets/js/blocks/game-explorer.js:59
+msgid "En haut à gauche"
+msgstr ""
+
+#: includes/Admin/Settings.php:1345
+#: assets/js/blocks/game-explorer.js:60
+msgid "En haut à droite"
+msgstr ""
+
+#: includes/Admin/Settings.php:1346
+#: assets/js/blocks/game-explorer.js:61
+msgid "Au centre à gauche"
+msgstr ""
+
+#: includes/Admin/Settings.php:1347
+#: assets/js/blocks/game-explorer.js:62
+msgid "Au centre à droite"
+msgstr ""
+
+#: includes/Admin/Settings.php:1348
+#: assets/js/blocks/game-explorer.js:63
+msgid "En bas à gauche"
+msgstr ""
+
+#: includes/Admin/Settings.php:1349
+#: assets/js/blocks/game-explorer.js:64
+msgid "En bas à droite"
+msgstr ""
+
+#: includes/Admin/Settings.php:1354
+#: assets/js/blocks/game-explorer.js:128
+msgid "Position de la note"
+msgstr ""
+
+#: includes/Admin/Settings.php:1398
+#: includes/Helpers.php:655
+#: includes/Helpers.php:1948
+#, php-format
+msgid "Catégorie %d"
+msgstr ""
+
+#: includes/Admin/Settings.php:1597
+msgid "Monter"
+msgstr ""
+
+#: includes/Admin/Settings.php:1598
+msgid "Descendre"
+msgstr ""
+
+#: includes/Admin/Settings.php:1599
+msgid "Monter la catégorie"
+msgstr ""
+
+#: includes/Admin/Settings.php:1600
+msgid "Descendre la catégorie"
+msgstr ""
+
+#: includes/Admin/Settings.php:1637
+#: includes/Admin/Settings.php:1678
+msgid "Libellé"
+msgstr ""
+
+#: includes/Admin/Settings.php:1641
+#: includes/Admin/Settings.php:1679
+msgid "Identifiant"
+msgstr ""
+
+#: includes/Admin/Settings.php:1643
+#: includes/Admin/Settings.php:1681
+msgid "Utilisé pour la clé méta (_note_identifiant). Lettres minuscules, chiffres, tirets et soulignés uniquement."
+msgstr ""
+
+#: includes/Admin/Settings.php:1646
+#: includes/Admin/Settings.php:1696
+msgid "Pondération"
+msgstr ""
+
+#: includes/Admin/Settings.php:1648
+#: includes/Admin/Settings.php:1698
+msgid "Coefficient utilisé pour la moyenne pondérée."
+msgstr ""
+
+#: includes/Admin/Settings.php:1653
+#: includes/Admin/Settings.php:1680
+msgid "Supprimer"
+msgstr ""
+
+#: includes/Admin/Settings.php:1670
+msgid "Ajouter une catégorie"
+msgstr ""
+
+#: includes/Assets.php:96
+msgid "Êtes-vous sûr de vouloir réinitialiser toutes les plateformes ?"
+msgstr ""
+
+#: includes/Assets.php:97
+#, php-format
+msgid "Êtes-vous sûr de vouloir supprimer la plateforme \"%s\" ?"
+msgstr ""
+
+#: includes/Assets.php:152
+#: templates/shortcode-user-rating.php:184
 msgid "Merci pour votre vote !"
 msgstr ""
 
-#: includes/class-jlg-assets.php:100
+#: includes/Assets.php:153
 msgid "Erreur. Veuillez réessayer."
 msgstr ""
 
-#: includes/class-jlg-assets.php:101
-#: includes/class-jlg-frontend.php:453
-#: assets/js/user-rating.js:12
+#: includes/Assets.php:154
+#: includes/Frontend.php:1368
+#: assets/js/user-rating.js:14
 msgid "Vous avez déjà voté !"
 msgstr ""
 
-#: includes/class-jlg-assets.php:107
+#: includes/Assets.php:155
+#: includes/Frontend.php:1298
+#: templates/shortcode-user-rating.php:18
+msgid "Connectez-vous pour voter."
+msgstr ""
+
+#: includes/Assets.php:156
+#: templates/shortcode-user-rating.php:19
+msgid "Se connecter"
+msgstr ""
+
+#: includes/Assets.php:166
 msgid "Configuration AJAX invalide."
 msgstr ""
 
-#: includes/class-jlg-assets.php:108
+#: includes/Assets.php:167
 msgid "Nonce de sécurité manquant. Actualisez la page."
 msgstr ""
 
-#: includes/class-jlg-assets.php:109
+#: includes/Assets.php:168
 msgid "Veuillez entrer au moins 3 caractères."
 msgstr ""
 
-#: includes/class-jlg-assets.php:110
+#: includes/Assets.php:169
 msgid "Recherche..."
 msgstr ""
 
-#: includes/class-jlg-assets.php:111
+#: includes/Assets.php:170
 msgid "Chargement..."
 msgstr ""
 
-#: includes/class-jlg-assets.php:112
+#: includes/Assets.php:171
 msgid "Rechercher"
 msgstr ""
 
-#: includes/class-jlg-assets.php:113
+#: includes/Assets.php:172
 msgid "Vérification de sécurité échouée. Actualisez la page."
 msgstr ""
 
-#: includes/class-jlg-assets.php:114
+#: includes/Assets.php:173
 msgid "Choisir"
 msgstr ""
 
-#: includes/class-jlg-assets.php:115
+#: includes/Assets.php:174
 msgid "Erreur de communication."
 msgstr ""
 
-#: includes/class-jlg-assets.php:116
+#: includes/Assets.php:175
 msgid "Fiche technique remplie !"
 msgstr ""
 
-#: includes/class-jlg-frontend.php:380
+#: includes/Assets.php:189
+msgid "Chargement des jeux..."
+msgstr ""
+
+#: includes/Assets.php:190
+msgid "Aucun jeu ne correspond à votre sélection."
+msgstr ""
+
+#: includes/Assets.php:191
+msgid "Réinitialiser les filtres"
+msgstr ""
+
+#: includes/Assets.php:192
+msgid "Impossible de charger les jeux pour le moment."
+msgstr ""
+
+#: includes/Assets.php:193
+#, php-format
+msgid "%d jeu"
+msgstr ""
+
+#: includes/Assets.php:194
+#, php-format
+msgid "%d jeux"
+msgstr ""
+
+#: includes/Blocks.php:287
+#: assets/js/blocks/shared.js:30
+msgid "Articles"
+msgstr ""
+
+#. translators: %s: nom de classe de shortcode manquante
+#: includes/Frontend.php:136
+#, php-format
+msgid "Classe de shortcode introuvable : %s"
+msgstr ""
+
+#: includes/Frontend.php:538
 msgid "Une erreur est survenue. Merci de réessayer plus tard."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:401
+#: includes/Frontend.php:1107
+msgid "Jeton invalide."
+msgstr ""
+
+#: includes/Frontend.php:1277
 msgid "Jeton de sécurité manquant ou invalide."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:405
-#: includes/class-jlg-frontend.php:707
+#: includes/Frontend.php:1281
+#: includes/Frontend.php:2060
+#: includes/Frontend.php:2172
 msgid "La vérification de sécurité a échoué."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:412
+#: includes/Frontend.php:1289
 msgid "La notation des lecteurs est désactivée."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:419
-#: includes/class-jlg-frontend.php:441
+#: includes/Frontend.php:1308
+#: includes/Frontend.php:1330
 msgid "Données invalides."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:425
+#: includes/Frontend.php:1314
 msgid "Article introuvable ou non disponible pour la notation."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:435
+#: includes/Frontend.php:1324
 msgid "La notation des lecteurs est désactivée pour ce contenu."
 msgstr ""
 
-#: includes/class-jlg-frontend.php:711
+#: includes/Frontend.php:1358
+msgid "Ce jeton a été bloqué par la rédaction."
+msgstr ""
+
+#: includes/Frontend.php:1376
+msgid "Un vote depuis cette adresse IP a déjà été enregistré."
+msgstr ""
+
+#: includes/Frontend.php:1387
+msgid "Veuillez patienter avant de voter à nouveau."
+msgstr ""
+
+#: includes/Frontend.php:2064
+#: includes/Frontend.php:2176
 msgid "Le shortcode requis est indisponible."
 msgstr ""
 
-#: includes/class-jlg-widget.php:9
+#: includes/Frontend.php:2475
+msgid "Editorial Score"
+msgstr ""
+
+#: includes/Frontend.php:2487
+msgid "Editorial Score (100 scale)"
+msgstr ""
+
+#: includes/Frontend.php:2521
+msgid "User Rating"
+msgstr ""
+
+#: includes/Frontend.php:2536
+msgid "User Rating (review scale)"
+msgstr ""
+
+#: includes/Frontend.php:2550
+msgid "User Rating (100 scale)"
+msgstr ""
+
+#: includes/Frontend.php:2570
+#, php-format
+msgid "Rating %s"
+msgstr ""
+
+#: includes/Frontend.php:2579
+msgid "User rating distribution"
+msgstr ""
+
+#: includes/Frontend.php:2602
+msgid "User rating trend"
+msgstr ""
+
+#: includes/Frontend.php:3062
+#, php-format
+msgid "%s – Review"
+msgstr ""
+
+#: includes/Frontend.php:3062
+msgid "Game review video"
+msgstr ""
+
+#: includes/Helpers.php:81
+#: includes/Helpers.php:177
+msgid "Impossible de préparer le lecteur vidéo pour cette URL."
+msgstr ""
+
+#: includes/Helpers.php:90
+msgid "Impossible d’identifier le fournisseur vidéo pour cette URL."
+msgstr ""
+
+#. translators: %s: video provider name.
+#: includes/Helpers.php:156
+#, php-format
+msgid "Lecteur vidéo %s"
+msgstr ""
+
+#. translators: %s: video provider name.
+#: includes/Helpers.php:182
+#, php-format
+msgid "Impossible de préparer le lecteur vidéo pour %s."
+msgstr ""
+
+#: includes/Helpers.php:882
+msgctxt "Review status label"
+msgid "Brouillon éditorial"
+msgstr ""
+
+#: includes/Helpers.php:883
+msgctxt "Review status description"
+msgid "Le test est en cours de rédaction et peut encore évoluer."
+msgstr ""
+
+#: includes/Helpers.php:886
+msgctxt "Review status label"
+msgid "Mise à jour en cours"
+msgstr ""
+
+#: includes/Helpers.php:887
+msgctxt "Review status description"
+msgid "La rédaction vérifie les derniers patchs ou ajoute des compléments."
+msgstr ""
+
+#: includes/Helpers.php:890
+msgctxt "Review status label"
+msgid "Version finale"
+msgstr ""
+
+#: includes/Helpers.php:891
+msgctxt "Review status description"
+msgid "La review est validée et reflète l’avis définitif de la rédaction."
+msgstr ""
+
+#: includes/Helpers.php:1480
+#: templates/shortcode-rating-block.php:330
+#, php-format
+msgid "Guide #%d"
+msgstr ""
+
+#: includes/Helpers.php:2962
+#: includes/Shortcodes/ScoreInsights.php:67
+msgctxt "Fallback platform label"
+msgid "Sans plateforme"
+msgstr ""
+
+#. translators: 1: start of the score range, 2: end of the score range.
+#: includes/Helpers.php:3201
+#, php-format
+msgctxt "Score range label"
+msgid "%1$s – %2$s"
+msgstr ""
+
+#: includes/LatestReviewsWidget.php:19
 msgid "Notation JLG : Derniers Tests"
 msgstr ""
 
-#: includes/class-jlg-widget.php:10
+#: includes/LatestReviewsWidget.php:20
 msgid "Affiche les derniers articles ayant reçu une note."
 msgstr ""
 
-#: includes/class-jlg-widget.php:15
-#: includes/class-jlg-widget.php:50
+#: includes/LatestReviewsWidget.php:25
+#: includes/LatestReviewsWidget.php:63
 msgid "Derniers Tests"
 msgstr ""
 
-#: includes/class-jlg-widget.php:25
-#: templates/widget-latest-reviews.php:20
+#: includes/LatestReviewsWidget.php:35
+#: templates/widget-latest-reviews.php:22
 msgid "Aucun test trouvé."
 msgstr ""
 
-#: includes/class-jlg-widget.php:54
+#: includes/LatestReviewsWidget.php:67
 msgid "Titre :"
 msgstr ""
 
-#: includes/class-jlg-widget.php:60
+#: includes/LatestReviewsWidget.php:73
 msgid "Nombre d'articles à afficher :"
 msgstr ""
 
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:103
+#: includes/Shortcodes/GameExplorer.php:278
+#: assets/js/blocks/game-explorer.js:48
+msgid "Plus récents"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:284
+#: assets/js/blocks/game-explorer.js:49
+msgid "Plus anciens"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:290
+#: assets/js/blocks/game-explorer.js:50
+msgid "Meilleures notes"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:296
+#: assets/js/blocks/game-explorer.js:51
+msgid "Notes les plus basses"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:302
+#: assets/js/blocks/game-explorer.js:52
+msgid "Popularité (plus de votes)"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:308
+#: assets/js/blocks/game-explorer.js:53
+msgid "Popularité (moins de votes)"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:314
+#: assets/js/blocks/game-explorer.js:54
+msgid "Titre (A-Z)"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:320
+#: assets/js/blocks/game-explorer.js:55
+msgid "Titre (Z-A)"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:705
+#: includes/Shortcodes/GameExplorer.php:730
+#: includes/Shortcodes/GameExplorer.php:738
+#: includes/Shortcodes/GameExplorer.php:1529
+msgid "À confirmer"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:745
+#: includes/Shortcodes/GameExplorer.php:1528
+msgid "À venir"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:751
+#: includes/Shortcodes/GameExplorer.php:1527
+msgid "Disponible"
+msgstr ""
+
+#: includes/Shortcodes/GameExplorer.php:1444
+msgid "Aucun test noté n'est disponible pour le moment."
+msgstr ""
+
+#. translators: 1: Release year, 2: Number of games.
+#: includes/Shortcodes/GameExplorer.php:1575
+#, php-format
+msgid "%1$s – %2$d jeu"
+msgid_plural "%1$s – %2$d jeux"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/Shortcodes/GameExplorer.php:1745
+msgid "Aucun jeu ne correspond à vos filtres actuels."
+msgstr ""
+
+#: includes/Shortcodes/RatingBlock.php:307
+#: templates/shortcode-rating-block-empty.php:252
+msgid "Guide stratégique"
+msgstr ""
+
+#: includes/Shortcodes/RatingBlock.php:312
+msgid "Astuces progression"
+msgstr ""
+
+#: includes/Shortcodes/RatingBlock.php:317
+msgid "Build recommandé"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:144
+#: includes/Shortcodes/ScoreInsights.php:171
+msgctxt "Score insights time range"
+msgid "Depuis toujours"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:148
+msgctxt "Score insights time range"
+msgid "30 derniers jours"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:152
+msgctxt "Score insights time range"
+msgid "90 derniers jours"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:156
+msgctxt "Score insights time range"
+msgid "12 derniers mois"
+msgstr ""
+
+#. translators: %s: Human readable time range label.
+#: includes/Shortcodes/ScoreInsights.php:435
+#, php-format
+msgid "Période précédente (%s)"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:436
+msgid "Période glissante"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:497
+msgid "Tendance en hausse"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:499
+msgid "Tendance en baisse"
+msgstr ""
+
+#: includes/Shortcodes/ScoreInsights.php:501
+#: templates/shortcode-score-insights.php:143
+msgid "Tendance stable"
+msgstr ""
+
+#: includes/Shortcodes/SummaryDisplay.php:173
 msgid "Aucun article noté trouvé."
 msgstr ""
 
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:175
+#: includes/Shortcodes/SummaryDisplay.php:347
+#: assets/js/blocks/summary-display.js:37
 msgid "Titre du jeu"
 msgstr ""
 
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:202
+#: includes/Shortcodes/SummaryDisplay.php:374
+#: templates/game-explorer-fragment.php:191
+#: assets/js/blocks/game-info.js:36
+#: assets/js/blocks/summary-display.js:40
 msgid "Développeur"
 msgstr ""
 
-#: includes/shortcodes/class-jlg-shortcode-summary-display.php:213
+#: includes/Shortcodes/SummaryDisplay.php:385
+#: templates/game-explorer-fragment.php:197
+#: assets/js/blocks/game-info.js:37
+#: assets/js/blocks/summary-display.js:41
 msgid "Éditeur"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:23
-#: templates/shortcode-tagline.php:12
+#: includes/Utils/Validator.php:315
+msgid "URL de vidéo invalide. Utilisez un lien complet commençant par http ou https."
+msgstr ""
+
+#: includes/Utils/Validator.php:325
+msgid "Le fournisseur sélectionné ne correspond pas à l'URL fournie."
+msgstr ""
+
+#. translators: %s: list of allowed video providers.
+#: includes/Utils/Validator.php:347
+#, php-format
+msgid "Fournisseur vidéo non reconnu. Fournisseurs acceptés : %s."
+msgstr ""
+
+#: templates/game-explorer-fragment.php:157
+msgid "Visuel indisponible"
+msgstr ""
+
+#: templates/game-explorer-fragment.php:185
+msgid "Sortie"
+msgstr ""
+
+#: templates/game-explorer-fragment.php:208
+#, php-format
+msgid "+%d"
+msgstr ""
+
+#. translators: %d: number of additional platforms.
+#: templates/game-explorer-fragment.php:211
+#, php-format
+msgid "+%d plateforme"
+msgid_plural "+%d plateformes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/game-explorer-fragment.php:242
+msgid "Navigation des pages du Game Explorer"
+msgstr ""
+
+#: templates/game-explorer-fragment.php:256
+msgid "Précédent"
+msgstr ""
+
+#: templates/game-explorer-fragment.php:285
+msgid "Suivant"
+msgstr ""
+
+#. translators: %s is the video provider label.
+#: templates/shortcode-all-in-one.php:57
+#, php-format
+msgid "Vidéo de test hébergée par %s"
+msgstr ""
+
+#. translators: %s is the video provider label.
+#: templates/shortcode-all-in-one.php:58
+msgid "Vidéo de test"
+msgstr ""
+
+#. translators: %s: Global score percentage.
+#: templates/shortcode-all-in-one.php:89
+#: templates/shortcode-rating-block-empty.php:130
+#: templates/shortcode-rating-block.php:103
+#, php-format
+msgctxt "global percentage score"
+msgid "%s %%"
+msgstr ""
+
+#. translators: 1: Global score percentage. 2: Global score value. 3: Maximum score.
+#: templates/shortcode-all-in-one.php:94
+#: templates/shortcode-rating-block.php:108
+#, php-format
+msgid "Note globale : %1$s %%, soit %2$s sur %3$s"
+msgstr ""
+
+#. translators: 1: Global score value. 2: Maximum score.
+#. translators: 1: Rating value. 2: Maximum possible rating.
+#: templates/shortcode-all-in-one.php:101
+#: templates/shortcode-all-in-one.php:340
+#: templates/shortcode-rating-block.php:115
+#: templates/shortcode-rating-block.php:271
+#, php-format
+msgid "Équivalent à %1$s sur %2$s"
+msgstr ""
+
+#. translators: 1: Global score value. 2: Maximum score.
+#: templates/shortcode-all-in-one.php:112
+#: templates/shortcode-rating-block.php:125
+#, php-format
+msgid "Note globale : %1$s sur %2$s"
+msgstr ""
+
+#. translators: %s: Global score percentage.
+#. translators: %s: Rating percentage for a category.
+#: templates/shortcode-all-in-one.php:122
+#: templates/shortcode-all-in-one.php:367
+#: templates/shortcode-rating-block.php:134
+#: templates/shortcode-rating-block.php:298
+#, php-format
+msgid "Correspond à %s %%"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:145
+#: templates/shortcode-all-in-one.php:148
+#: templates/shortcode-tagline.php:20
 msgid "Français"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:27
-#: templates/shortcode-tagline.php:13
+#: templates/shortcode-all-in-one.php:155
+#: templates/shortcode-all-in-one.php:158
+#: templates/shortcode-tagline.php:30
 msgid "English"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:51 templates/shortcode-all-in-one.php:55
-#: templates/shortcode-rating-block.php:22 templates/shortcode-rating-block.php:27
-#: templates/shortcode-rating-block-empty.php:140
-#: templates/shortcode-rating-block-empty.php:145
+#. translators: %s: formatted update date.
+#: templates/shortcode-all-in-one.php:202
+#, php-format
+msgid "Mise à jour le %s"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:217
+msgid "Verdict de la rédaction"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:220
+msgid "Voir le test complet"
+msgstr ""
+
+#: templates/shortcode-all-in-one.php:272
+#: templates/shortcode-all-in-one.php:276
+#: templates/shortcode-rating-block-empty.php:158
+#: templates/shortcode-rating-block-empty.php:163
+#: templates/shortcode-rating-block.php:149
+#: templates/shortcode-rating-block.php:154
 msgid "Note Globale"
 msgstr ""
 
-#: templates/shortcode-rating-block.php:142
-#: templates/shortcode-rating-block-empty.php:150
-msgid "Sélection de la rédaction"
-msgstr ""
-
-#: templates/shortcode-rating-block.php:148
-#: templates/shortcode-rating-block-empty.php:153
-msgid "Note des lecteurs"
-msgstr ""
-
-#. translators: %s: difference between reader and editorial scores.
-#: templates/shortcode-rating-block.php:170
-#: templates/shortcode-rating-block-empty.php:170
+#. translators: %s: weight multiplier for a rating category.
+#: templates/shortcode-all-in-one.php:313
+#: templates/shortcode-rating-block.php:243
+#: templates/summary-table-fragment.php:112
 #, php-format
-msgid "Δ vs rédaction : %s"
+msgctxt "category weight multiplier"
+msgid "×%s"
 msgstr ""
 
-#: templates/shortcode-rating-block-empty.php:134
-msgid "Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes."
+#. translators: %s: Rating percentage for a category.
+#: templates/shortcode-all-in-one.php:327
+#: templates/shortcode-rating-block.php:258
+#, php-format
+msgctxt "category percentage score"
+msgid "%s %%"
+msgstr ""
+
+#. translators: 1: Rating category label. 2: Rating percentage. 3: Rating value. 4: Maximum possible rating.
+#: templates/shortcode-all-in-one.php:332
+#: templates/shortcode-rating-block.php:263
+#, php-format
+msgid "%1$s : %2$s %%, soit %3$s sur %4$s"
+msgstr ""
+
+#. translators: 1: Rating category label. 2: Rating value. 3: Maximum possible rating.
+#: templates/shortcode-all-in-one.php:356
+#: templates/shortcode-rating-block.php:287
+#, php-format
+msgid "%1$s : %2$s sur %3$s"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:152
+#: templates/shortcode-summary-display.php:80
+msgid "Filtrer par lettre"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:179
+#: templates/shortcode-summary-display.php:91
+msgid "Tous"
+msgstr ""
+
+#. translators: %s: Letter without available games.
+#: templates/shortcode-game-explorer.php:215
+#, php-format
+msgid "Aucun jeu disponible pour %s."
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:218
+msgid "Aucun jeu disponible pour cette lettre."
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:260
+msgid "Trier par"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:280
+msgid "Appliquer"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:289
+#, php-format
+msgid "%s jeu"
+msgid_plural "%s jeux"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/shortcode-game-explorer.php:312
+msgid "Filtres"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:349
+#: templates/shortcode-summary-display.php:126
+msgid "Toutes les catégories"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:365
+msgid "Filtrer par plateforme"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:373
+#: templates/shortcode-score-insights.php:66
+msgid "Toutes les plateformes"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:389
+msgid "Filtrer par développeur"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:397
+msgid "Tous les studios"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:413
+msgid "Filtrer par éditeur"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:421
+msgid "Tous les éditeurs"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:437
+msgid "Filtrer par disponibilité"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:445
+msgid "Toutes les sorties"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:458
+msgid "Filtrer par année de sortie"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:467
+msgid "Toutes les années"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:483
+#, php-format
+msgid "Période couverte : %1$d – %2$d"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:491
+msgid "Sélectionnez une année pour filtrer les résultats."
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:500
+msgid "Rechercher un jeu"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:508
+msgid "Rechercher…"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:515
+msgid "Appliquer les filtres"
+msgstr ""
+
+#: templates/shortcode-game-explorer.php:518
+msgid "Réinitialiser"
+msgstr ""
+
+#. translators: Loading overlay message displayed while the Game Explorer refreshes via AJAX.
+#: templates/shortcode-game-explorer.php:531
+#: assets/js/blocks/shared.js:198
+msgid "Chargement…"
 msgstr ""
 
 #. translators: Section title for the list of advantages in the pros and cons block.
-#: templates/shortcode-pros-cons.php:10
+#: templates/shortcode-pros-cons.php:13
 msgid "Points Forts"
 msgstr ""
 
 #. translators: Section title for the list of drawbacks in the pros and cons block.
-#: templates/shortcode-pros-cons.php:19
+#: templates/shortcode-pros-cons.php:29
 msgid "Points Faibles"
 msgstr ""
 
-#. translators: 1: Rating value for a specific category. 2: Maximum possible rating.
-#: templates/shortcode-rating-block.php:46
-#: templates/shortcode-rating-block-empty.php:159
-#: templates/shortcode-rating-block-empty.php:205
+#: templates/shortcode-rating-block-empty.php:114
+msgid "Mise à jour en cours"
+msgstr ""
+
+#: templates/shortcode-rating-block-empty.php:137
+msgid "Prévisualisation des notes avec des valeurs fictives. Renseignez la metabox « Notation JLG » pour publier vos notes."
+msgstr ""
+
+#: templates/shortcode-rating-block-empty.php:168
+#: templates/shortcode-rating-block.php:159
+msgid "Sélection de la rédaction"
+msgstr ""
+
+#: templates/shortcode-rating-block-empty.php:172
+#: templates/shortcode-rating-block.php:165
+msgid "Note des lecteurs"
+msgstr ""
+
+#. translators: %s: difference between reader and editorial scores.
+#: templates/shortcode-rating-block-empty.php:188
+#: templates/shortcode-rating-block.php:187
 #, php-format
-msgid "%1$s / %2$s"
+msgid "Δ vs rédaction : %s"
 msgstr ""
 
-#: templates/shortcode-summary-display.php:47
-msgid "Toutes les catégories"
+#: templates/shortcode-rating-block-empty.php:249
+#: templates/shortcode-rating-block.php:324
+msgid "Guides associés"
 msgstr ""
 
-#: templates/shortcode-summary-display.php:56
+#. translators: %s: platform name
+#: templates/shortcode-score-insights.php:62
+#, php-format
+msgid "Plateforme : %s"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:80
+#: assets/js/blocks/score-insights.js:110
+#: assets/js/blocks/score-insights.js:125
+msgid "Score Insights"
+msgstr ""
+
+#. translators: 1: summary (time range/platform), 2: total number of reviews.
+#: templates/shortcode-score-insights.php:87
+#, php-format
+msgid "%1$s — %2$s tests analysés"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:88
+#: assets/js/blocks/score-insights.js:36
+msgid "Toutes les périodes"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:98
+msgid "Aucune note disponible pour ces critères. Ajustez la période ou la plateforme sélectionnée."
+msgstr ""
+
+#: templates/shortcode-score-insights.php:104
+msgid "Tendance centrale"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:108
+msgid "Moyenne"
+msgstr ""
+
+#. translators: 1: textual direction (up/down/stable), 2: previous mean, 3: number of reviews.
+#: templates/shortcode-score-insights.php:142
+#, php-format
+msgid "%1$s — moyenne précédente %2$s sur %3$s tests."
+msgstr ""
+
+#: templates/shortcode-score-insights.php:157
+msgid "Focus rédaction vs lecteurs"
+msgstr ""
+
+#. translators: %s: minimal absolute delta to display a badge.
+#: templates/shortcode-score-insights.php:164
+#, php-format
+msgid "Écarts supérieurs à %s point(s)."
+msgstr ""
+
+#. translators: %s: formatted score delta
+#: templates/shortcode-score-insights.php:187
+#, php-format
+msgid "Lecteurs +%s vs rédaction"
+msgstr ""
+
+#. translators: %s: formatted score delta
+#: templates/shortcode-score-insights.php:193
+#, php-format
+msgid "Lecteurs -%s vs rédaction"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:197
+msgid "Lecteurs au même niveau que la rédaction"
+msgstr ""
+
+#. translators: %s: number of reader votes
+#: templates/shortcode-score-insights.php:202
+#, php-format
+msgid "%s vote lecteur"
+msgid_plural "%s votes lecteurs"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: editorial score, 2: user score, 3: reader votes label
+#: templates/shortcode-score-insights.php:208
+#, php-format
+msgid "Rédaction %1$s · Lecteurs %2$s (%3$s)"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:228
+#: templates/shortcode-score-insights.php:232
+#, php-format
+msgid "Test #%d"
+msgstr ""
+
+#. translators: 1: score range label, 2: number of reviews, 3: percentage
+#: templates/shortcode-score-insights.php:257
+#, php-format
+msgid "%1$s : %2$s tests, %3$s%% des notes"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:274
+#, php-format
+msgctxt "Bucket percentage and count"
+msgid "%1$s%% · %2$s tests"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:283
+msgid "Top plateformes"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:287
+msgid "Aucune plateforme ne se détache encore sur cette période."
+msgstr ""
+
+#. translators: 1: ranking position, 2: platform name, 3: average score, 4: number of reviews
+#: templates/shortcode-score-insights.php:299
+#, php-format
+msgid "%1$s. %2$s — moyenne %3$s sur %4$s tests"
+msgstr ""
+
+#: templates/shortcode-score-insights.php:316
+#, php-format
+msgid "%s test"
+msgid_plural "%s tests"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/shortcode-summary-display.php:115
+#: templates/summary-table-fragment.php:61
+msgid "0-9"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:139
+msgid "Filtrer par genre"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:142
+msgid "Tous les genres"
+msgstr ""
+
+#: templates/shortcode-summary-display.php:152
 msgid "Filtrer"
 msgstr ""
 
-#: templates/shortcode-user-rating.php:6
+#: templates/shortcode-user-rating.php:51
+#: templates/shortcode-user-rating.php:124
+#, php-format
+msgid "%s vote"
+msgid_plural "%s votes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/shortcode-user-rating.php:52
+#, php-format
+msgid "%s votes"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:53
+#, php-format
+msgid "%1$s : %2$s (%3$s%%)"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:78
 msgid "Votre avis nous intéresse !"
 msgstr ""
 
-#. translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes.
-#: templates/shortcode-user-rating.php:18
-#, php-format
-msgid "Note moyenne : <strong class=\"jlg-user-rating-avg-value\">%1$s</strong> sur %2$s (<span class=\"jlg-user-rating-count-value\">%3$s</span> votes)"
+#: templates/shortcode-user-rating.php:83
+msgid "Choisissez une note"
 msgstr ""
 
-#: templates/summary-table-fragment.php:20
+#. translators: 1: Selected rating value. 2: Maximum possible rating.
+#: templates/shortcode-user-rating.php:101
+#, php-format
+msgid "Attribuer %1$s sur %2$s"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:111
+msgid "Répartition des votes"
+msgstr ""
+
+#: templates/shortcode-user-rating.php:123
+#, php-format
+msgid "%s étoile"
+msgid_plural "%s étoiles"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: Average user rating value. 2: Maximum possible rating. 3: Number of user votes.
+#: templates/shortcode-user-rating.php:157
+#, php-format
+msgid "Note moyenne : <strong class=\"jlg-user-rating-avg-value\" aria-live=\"polite\" aria-atomic=\"true\">%1$s</strong> sur %2$s (<span class=\"jlg-user-rating-count-value\">%3$s</span> votes)"
+msgstr ""
+
+#: templates/summary-table-fragment.php:27
 msgid "Aucun article trouvé pour cette sélection."
 msgstr ""
 
-#: templates/summary-table-fragment.php:67
+#. translators: %s is the category name.
+#: templates/summary-table-fragment.php:53
+#, php-format
+msgid "Catégorie : %s"
+msgstr ""
+
+#. translators: %s is the first letter used to filter results.
+#: templates/summary-table-fragment.php:66
+#, php-format
+msgid "Lettre : %s"
+msgstr ""
+
+#. translators: %s is the selected genre.
+#: templates/summary-table-fragment.php:84
+#, php-format
+msgid "Genre : %s"
+msgstr ""
+
+#. translators: %s is the list of active filters.
+#: templates/summary-table-fragment.php:93
+#, php-format
+msgid "Aucun article ne correspond aux filtres : %s."
+msgstr ""
+
+#: templates/summary-table-fragment.php:198
 msgid " ▲"
 msgstr ""
 
-#: templates/summary-table-fragment.php:68
+#: templates/summary-table-fragment.php:199
 msgid " ▼"
 msgstr ""
 
+#: templates/summary-table-fragment.php:209
+#: templates/summary-table-fragment.php:213
+msgid "ordre croissant"
+msgstr ""
+
+#: templates/summary-table-fragment.php:210
+#: templates/summary-table-fragment.php:214
+msgid "ordre décroissant"
+msgstr ""
+
+#. translators: %1$s: column label, %2$s: current direction, %3$s: next direction.
+#: templates/summary-table-fragment.php:220
+#, php-format
+msgid "%1$s, actuellement trié en %2$s. Activer pour trier en %3$s"
+msgstr ""
+
+#. translators: %1$s: column label, %2$s: sorting direction.
+#: templates/summary-table-fragment.php:228
+#, php-format
+msgid "Trier par %1$s en %2$s"
+msgstr ""
+
 #. translators: %s: Maximum possible rating value.
-#: templates/summary-table-fragment.php:162
+#: templates/summary-table-fragment.php:383
 #, php-format
 msgid "/ %s"
 msgstr ""
 
-#: templates/summary-table-fragment.php:167
-#: templates/summary-table-fragment.php:171
+#: templates/summary-table-fragment.php:388
+#: templates/summary-table-fragment.php:392
 msgid "-"
 msgstr ""
 
-#: templates/summary-table-fragment.php:208
+#: templates/summary-table-fragment.php:474
 msgid "« Précédent"
 msgstr ""
 
-#: templates/summary-table-fragment.php:209
+#: templates/summary-table-fragment.php:475
 msgid "Suivant »"
 msgstr ""
 
-#. translators: %s: Maximum rating value displayed with the thumbnail score.
-#: templates/widget-thumbnail-score.php:35
-#, php-format
-msgid "/%s"
+#: assets/js/blocks/all-in-one.js:46
+#: assets/js/blocks/rating-block.js:42
+msgid "Couleurs"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:53
+#: assets/js/blocks/all-in-one.js:59
+#: assets/js/blocks/rating-block.js:49
+#: assets/js/blocks/rating-block.js:57
+msgid "Couleur d'accent"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:78
+#: assets/js/blocks/rating-block.js:84
+msgid "Source et affichage"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:86
+msgid "Style visuel"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:89
+msgid "Moderne"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:90
+msgid "Classique"
+msgstr ""
+
+#: assets/js/blocks/all-in-one.js:91
+msgid "Compact"
 msgstr ""
 
 #: assets/js/blocks/all-in-one.js:98
@@ -850,122 +2093,347 @@ msgid "Affichage du score"
 msgstr ""
 
 #: assets/js/blocks/all-in-one.js:101
-#: assets/js/blocks/rating-block.js:107
+#: assets/js/blocks/rating-block.js:106
 msgid "Valeur absolue"
 msgstr ""
 
 #: assets/js/blocks/all-in-one.js:102
-#: assets/js/blocks/rating-block.js:108
+#: assets/js/blocks/rating-block.js:107
 msgid "Pourcentage"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:36
-#: templates/shortcode-rating-block.php:63
-#: templates/shortcode-rating-block-empty.php:124
-msgctxt "global percentage score"
-msgid "%s %%"
+#: assets/js/blocks/all-in-one.js:109
+msgid "Afficher la notation"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:41
-#: templates/shortcode-rating-block.php:68
-msgid "Note globale : %1$s %%, soit %2$s sur %3$s"
+#: assets/js/blocks/all-in-one.js:116
+msgid "Afficher les points forts/faibles"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:47
-#: templates/shortcode-rating-block.php:74
-msgid "Équivalent à %1$s sur %2$s"
+#: assets/js/blocks/all-in-one.js:123
+msgid "Afficher la tagline"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:57
-#: templates/shortcode-rating-block.php:89
-msgid "Note globale : %1$s sur %2$s"
+#: assets/js/blocks/all-in-one.js:130
+msgid "Afficher la vidéo de test"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:63
-#: templates/shortcode-all-in-one.php:147
-#: templates/shortcode-rating-block.php:95
-#: templates/shortcode-rating-block.php:152
-msgid "Correspond à %s %%"
+#: assets/js/blocks/all-in-one.js:140
+msgid "Titres personnalisés"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:133
-#: templates/shortcode-rating-block.php:137
-msgctxt "category percentage score"
-msgid "%s %%"
+#: assets/js/blocks/all-in-one.js:142
+msgid "Titre Points forts"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:138
-#: templates/shortcode-rating-block.php:142
-msgid "%1$s : %2$s %%, soit %3$s sur %4$s"
+#: assets/js/blocks/all-in-one.js:149
+msgid "Titre Points faibles"
 msgstr ""
 
-#: templates/shortcode-all-in-one.php:147
-#: templates/shortcode-rating-block.php:152
-msgid "%1$s : %2$s sur %3$s"
-msgstr ""
-#. translators: Review status label.
-#: includes/Helpers.php:879
-msgctxt "Review status label"
-msgid "Brouillon éditorial"
+#: assets/js/blocks/all-in-one.js:158
+msgid "Bouton d'action"
 msgstr ""
 
-#. translators: Review status description.
-#: includes/Helpers.php:880
-msgctxt "Review status description"
-msgid "Le test est en cours de rédaction et peut encore évoluer."
+#: assets/js/blocks/all-in-one.js:160
+msgid "Texte du bouton"
 msgstr ""
 
-#. translators: Review status label.
-#: includes/Helpers.php:883
-msgctxt "Review status label"
-msgid "Mise à jour en cours"
+#: assets/js/blocks/all-in-one.js:165
+msgid "Laissez vide pour utiliser le texte défini dans la métabox."
 msgstr ""
 
-#. translators: Review status description.
-#: includes/Helpers.php:884
-msgctxt "Review status description"
-msgid "La rédaction vérifie les derniers patchs ou ajoute des compléments."
+#: assets/js/blocks/all-in-one.js:168
+msgid "URL du bouton"
 msgstr ""
 
-#. translators: Review status label.
-#: includes/Helpers.php:887
-msgctxt "Review status label"
-msgid "Version finale"
+#: assets/js/blocks/all-in-one.js:174
+msgid "Utilisez une URL absolue (https://...) ou laissez vide pour utiliser la métabox."
 msgstr ""
 
-#. translators: Review status description.
-#: includes/Helpers.php:888
-msgctxt "Review status description"
-msgid "La review est validée et reflète l’avis définitif de la rédaction."
+#: assets/js/blocks/all-in-one.js:177
+msgid "Attribut role"
 msgstr ""
 
-#: includes/Admin/Settings.php:884
-msgid "Statut de review"
+#: assets/js/blocks/all-in-one.js:182
+msgid "Par défaut : button"
 msgstr ""
 
-#: includes/Admin/Settings.php:885 templates/shortcode-rating-block.php:324 templates/shortcode-rating-block-empty.php:249
-msgid "Guides associés"
+#: assets/js/blocks/all-in-one.js:185
+msgid "Attribut rel"
 msgstr ""
 
-#: includes/Admin/Settings.php:922
-msgid "Nombre maximum de guides associés affichés sous la note."
+#: assets/js/blocks/all-in-one.js:190
+msgid "Par défaut : nofollow sponsored"
 msgstr ""
 
-#: includes/Admin/Settings.php:931
-msgid "Nombre de guides associés"
+#: assets/js/blocks/all-in-one.js:215
+msgid "Bloc tout-en-un"
 msgstr ""
 
-#: includes/Admin/Settings.php:941
-msgid "Taxonomies ciblées"
+#: assets/js/blocks/game-explorer.js:37
+#: assets/js/blocks/summary-display.js:134
+msgid "Filtre lettre"
 msgstr ""
 
-#: includes/Admin/Settings.php:947
-msgid "Renseignez les slugs de taxonomie séparés par des virgules pour identifier les guides pertinents (ex. guide,astuce)."
+#: assets/js/blocks/game-explorer.js:38
+msgid "Filtre catégorie"
 msgstr ""
 
-#: includes/Admin/Metaboxes.php:194 templates/shortcode-rating-block.php:198 templates/shortcode-rating-block-empty.php:197
-msgid "Statut du test"
+#: assets/js/blocks/game-explorer.js:39
+msgid "Filtre plateforme"
 msgstr ""
-#: includes/Admin/Metaboxes.php:202
-msgid "Ce statut est affiché sous la note globale pour informer les lecteurs de la fraîcheur de la review."
+
+#: assets/js/blocks/game-explorer.js:40
+msgid "Filtre développeur"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:41
+msgid "Filtre éditeur"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:43
+msgid "Filtre année de sortie"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:100
+msgid "Configuration du listing"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:102
+#: assets/js/blocks/summary-display.js:84
+msgid "Nombre d'éléments par page"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:115
+msgid "Colonnes"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:137
+msgid "Tri par défaut"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:147
+msgid "Filtres disponibles"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:162
+msgid "Pré-filtrage"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:164
+#: assets/js/blocks/summary-display.js:127
+msgid "Catégorie (slug)"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:171
+msgid "Plateforme (slug)"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:185
+msgid "Développeur (nom exact)"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:192
+msgid "Éditeur (nom exact)"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:199
+msgid "Année de sortie"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:207
+msgid "Recherche (mot-clé)"
+msgstr ""
+
+#: assets/js/blocks/game-explorer.js:234
+msgid "Game Explorer"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:39
+msgid "Version"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:42
+msgid "Plateformes"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:90
+msgid "Source des données"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:98
+#: assets/js/blocks/score-insights.js:105
+msgid "Titre personnalisé"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:107
+msgid "Champs affichés"
+msgstr ""
+
+#: assets/js/blocks/game-info.js:122
+msgid "Décochez les éléments que vous ne souhaitez pas afficher."
+msgstr ""
+
+#: assets/js/blocks/game-info.js:136
+msgid "Fiche technique"
+msgstr ""
+
+#: assets/js/blocks/pros-cons.js:38
+msgid "Points forts / faibles"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:92
+msgid "Disposition du score"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:95
+msgid "Texte"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:96
+msgid "Cercle"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:114
+msgid "Thème de prévisualisation"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:117
+msgid "Selon les réglages du site"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:118
+msgid "Forcer le thème sombre"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:119
+msgid "Forcer le thème clair"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:126
+msgid "Animations (aperçu)"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:129
+msgid "Suivre la configuration globale"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:130
+msgid "Toujours activer"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:131
+msgid "Toujours désactiver"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:138
+msgid "Afficher les animations"
+msgstr ""
+
+#: assets/js/blocks/rating-block.js:161
+msgid "Bloc de notation"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:37
+msgid "30 derniers jours"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:38
+msgid "90 derniers jours"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:39
+msgid "12 derniers mois"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:64
+msgid "Données affichées"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:66
+msgid "Période analysée"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:74
+msgid "Filtrer par plateforme (slug)"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:79
+msgid "Laissez vide pour toutes les plateformes ou utilisez le slug enregistré dans Notation → Plateformes."
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:82
+msgid "Nombre de plateformes affichées"
+msgstr ""
+
+#: assets/js/blocks/score-insights.js:103
+msgid "Présentation"
+msgstr ""
+
+#: assets/js/blocks/shared.js:41
+msgid "Article cible"
+msgstr ""
+
+#: assets/js/blocks/shared.js:200
+msgid "Aucun élément trouvé."
+msgstr ""
+
+#: assets/js/blocks/shared.js:208
+msgid "Type de contenu"
+msgstr ""
+
+#: assets/js/blocks/shared.js:270
+msgid "Prévisualisation du bloc"
+msgstr ""
+
+#: assets/js/blocks/shared.js:277
+msgid "La prévisualisation n'est pas disponible dans cet environnement."
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:39
+msgid "Note moyenne"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:82
+msgid "Pagination et mise en page"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:97
+msgid "Disposition"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:100
+msgid "Tableau"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:101
+msgid "Grille"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:110
+msgid "Colonnes affichées"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:125
+msgid "Filtres initiaux"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:139
+msgid "Utilisez une lettre ou le symbole # pour regrouper chiffres et symboles."
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:142
+msgid "Filtre genre"
+msgstr ""
+
+#: assets/js/blocks/summary-display.js:163
+msgid "Tableau récapitulatif"
+msgstr ""
+
+#: assets/js/blocks/tagline.js:38
+msgid "Tagline bilingue"
+msgstr ""
+
+#: assets/js/blocks/user-rating.js:38
+msgid "Notation utilisateurs"
 msgstr ""

--- a/plugin-notation-jeux_V4/plugin-notation-jeux.php
+++ b/plugin-notation-jeux_V4/plugin-notation-jeux.php
@@ -119,6 +119,8 @@ final class JLG_Plugin_De_Notation_Main {
         $this->load_dependencies();
         if ( class_exists( \JLG\Notation\Helpers::class ) ) {
             \JLG\Notation\Helpers::migrate_legacy_rating_configuration();
+            add_action( \JLG\Notation\Helpers::REVIEW_STATUS_CRON_HOOK, array( \JLG\Notation\Helpers::class, 'run_review_status_automation' ) );
+            add_action( 'init', array( \JLG\Notation\Helpers::class, 'maybe_schedule_review_status_automation' ) );
         }
         $this->init_components();
         add_action( 'jlg_process_v5_migration', array( $this, 'process_migration_batch' ) );
@@ -206,6 +208,11 @@ final class JLG_Plugin_De_Notation_Main {
         }
 
         update_option( 'jlg_notation_version', JLG_NOTATION_VERSION );
+
+        if ( class_exists( \JLG\Notation\Helpers::class ) ) {
+            \JLG\Notation\Helpers::activate_review_status_automation();
+        }
+
         flush_rewrite_rules();
     }
 
@@ -213,6 +220,10 @@ final class JLG_Plugin_De_Notation_Main {
         if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
             wp_clear_scheduled_hook( 'jlg_process_v5_migration' );
             wp_clear_scheduled_hook( \JLG\Notation\Helpers::SCORE_SCALE_EVENT_HOOK );
+        }
+
+        if ( class_exists( \JLG\Notation\Helpers::class ) ) {
+            \JLG\Notation\Helpers::deactivate_review_status_automation();
         }
 
         delete_option( 'jlg_migration_v5_queue' );

--- a/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
+++ b/plugin-notation-jeux_V4/templates/shortcode-all-in-one.php
@@ -58,6 +58,30 @@ $video_region_label  = $video_provider_name !== ''
     : __( 'Vidéo de test', 'notation-jlg' );
 $video_region_id     = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'jlg-aio-video-label-' ) : 'jlg-aio-video-label-' . uniqid();
 
+$verdict_data         = isset( $verdict ) && is_array( $verdict ) ? $verdict : array();
+$display_verdict      = ! empty( $display_verdict );
+$verdict_summary_raw  = isset( $verdict_data['summary'] ) ? trim( (string) $verdict_data['summary'] ) : '';
+$verdict_summary_html = '';
+if ( $verdict_summary_raw !== '' ) {
+    if ( strpos( $verdict_summary_raw, '<' ) === false ) {
+        $verdict_summary_html = '<p>' . str_replace( array( "\r\n", "\r", "\n" ), '</p><p>', esc_html( $verdict_summary_raw ) ) . '</p>';
+    } else {
+        $verdict_summary_html = wp_kses_post( $verdict_summary_raw );
+    }
+}
+$verdict_status             = isset( $verdict_data['status'] ) && is_array( $verdict_data['status'] ) ? $verdict_data['status'] : array();
+$verdict_status_slug        = isset( $verdict_status['slug'] ) ? sanitize_html_class( (string) $verdict_status['slug'] ) : '';
+$verdict_status_label       = isset( $verdict_status['label'] ) ? (string) $verdict_status['label'] : '';
+$verdict_status_description = isset( $verdict_status['description'] ) ? (string) $verdict_status['description'] : '';
+$verdict_cta_label          = isset( $verdict_data['cta_label'] ) ? (string) $verdict_data['cta_label'] : '';
+$verdict_cta_url            = isset( $verdict_data['cta_url'] ) ? (string) $verdict_data['cta_url'] : '';
+$verdict_cta_rel            = isset( $verdict_data['cta_rel'] ) ? (string) $verdict_data['cta_rel'] : 'bookmark';
+$verdict_permalink          = isset( $verdict_data['permalink'] ) ? (string) $verdict_data['permalink'] : '';
+$verdict_timestamp          = isset( $verdict_data['last_updated']['timestamp'] ) ? $verdict_data['last_updated']['timestamp'] : null;
+$verdict_iso_date           = isset( $verdict_data['last_updated']['iso'] ) ? (string) $verdict_data['last_updated']['iso'] : '';
+$verdict_date_label         = isset( $verdict_data['last_updated']['display'] ) ? (string) $verdict_data['last_updated']['display'] : '';
+$verdict_section_id         = function_exists( 'wp_unique_id' ) ? wp_unique_id( 'jlg-aio-verdict-' ) : 'jlg-aio-verdict-' . uniqid();
+
 if ( $average_score_display !== '' ) {
     if ( $display_mode === 'percent' && $average_percentage_display !== '' ) {
         $visible_value = sprintf(
@@ -148,6 +172,71 @@ if ( $average_score_display !== '' ) {
         </div>
         <?php endif; ?>
     </div>
+    <?php endif; ?>
+
+    <?php if ( $display_verdict ) : ?>
+    <section class="jlg-aio-verdict" aria-labelledby="<?php echo esc_attr( $verdict_section_id ); ?>">
+        <div class="jlg-aio-verdict__meta">
+            <?php if ( $verdict_status_label !== '' ) : ?>
+				<?php
+				$status_classes = array( 'jlg-aio-verdict__status' );
+				if ( $verdict_status_slug !== '' ) {
+					$status_classes[] = 'jlg-aio-verdict__status--' . $verdict_status_slug;
+				}
+				$status_class_attr = implode( ' ', array_map( 'sanitize_html_class', $status_classes ) );
+				?>
+            <span class="<?php echo esc_attr( $status_class_attr ); ?>">
+                <span class="jlg-aio-verdict__status-indicator" aria-hidden="true"></span>
+                <span class="jlg-aio-verdict__status-label"><?php echo esc_html( $verdict_status_label ); ?></span>
+                <?php if ( $verdict_status_description !== '' ) : ?>
+                <span class="jlg-aio-verdict__status-description"><?php echo esc_html( $verdict_status_description ); ?></span>
+                <?php endif; ?>
+            </span>
+            <?php endif; ?>
+
+            <?php if ( $verdict_date_label !== '' ) : ?>
+            <span class="jlg-aio-verdict__updated">
+                <?php
+                $formatted_update = sprintf(
+                    /* translators: %s: formatted update date. */
+                    esc_html__( 'Mise à jour le %s', 'notation-jlg' ),
+                    $verdict_date_label
+                );
+                ?>
+                <?php if ( $verdict_iso_date !== '' ) : ?>
+                    <time datetime="<?php echo esc_attr( $verdict_iso_date ); ?>"><?php echo $formatted_update; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></time>
+                <?php else : ?>
+                    <?php echo $formatted_update; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                <?php endif; ?>
+            </span>
+            <?php endif; ?>
+        </div>
+
+        <div class="jlg-aio-verdict__body">
+            <div class="jlg-aio-verdict__heading">
+                <h3 id="<?php echo esc_attr( $verdict_section_id ); ?>" class="jlg-aio-verdict__title"><?php echo esc_html__( 'Verdict de la rédaction', 'notation-jlg' ); ?></h3>
+                <?php if ( $verdict_permalink !== '' ) : ?>
+                <a class="jlg-aio-verdict__permalink" href="<?php echo esc_url( $verdict_permalink ); ?>">
+                    <span class="screen-reader-text"><?php esc_html_e( 'Voir le test complet', 'notation-jlg' ); ?></span>
+                </a>
+                <?php endif; ?>
+            </div>
+
+            <?php if ( $verdict_summary_html !== '' ) : ?>
+            <div class="jlg-aio-verdict__summary">
+                <?php echo $verdict_summary_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </div>
+            <?php endif; ?>
+
+            <?php if ( $verdict_cta_url !== '' && $verdict_cta_label !== '' ) : ?>
+            <div class="jlg-aio-verdict__actions">
+                <a class="jlg-aio-verdict__cta" href="<?php echo esc_url( $verdict_cta_url ); ?>"<?php echo $verdict_cta_rel !== '' ? ' rel="' . esc_attr( $verdict_cta_rel ) . '"' : ''; ?>>
+                    <span class="jlg-aio-verdict__cta-label"><?php echo esc_html( $verdict_cta_label ); ?></span>
+                </a>
+            </div>
+            <?php endif; ?>
+        </div>
+    </section>
     <?php endif; ?>
 
     <?php if ( $video_should_render ) : ?>

--- a/plugin-notation-jeux_V4/tests/HelpersReviewStatusAutomationTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersReviewStatusAutomationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersReviewStatusAutomationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+        $GLOBALS['jlg_test_scheduled_events'] = [];
+        $GLOBALS['jlg_test_actions']          = [];
+        $GLOBALS['jlg_test_meta_updates']     = [];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset(
+            $GLOBALS['jlg_test_scheduled_events'],
+            $GLOBALS['jlg_test_actions'],
+            $GLOBALS['jlg_test_meta_updates'],
+            $GLOBALS['jlg_test_meta'],
+            $GLOBALS['jlg_test_posts'],
+            $GLOBALS['jlg_test_options']
+        );
+
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+    }
+
+    private function enableAutomation(array $overrides = []): void
+    {
+        $defaults = \JLG\Notation\Helpers::get_default_settings();
+        $options  = array_merge(
+            $defaults,
+            [
+                'review_status_enabled'               => 1,
+                'review_status_auto_finalize_enabled' => 1,
+                'review_status_auto_finalize_days'    => 7,
+            ],
+            $overrides
+        );
+
+        $GLOBALS['jlg_test_options']['notation_jlg_settings'] = $options;
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+    }
+
+    public function test_maybe_schedule_review_status_automation_schedules_event_when_enabled(): void
+    {
+        $this->enableAutomation();
+
+        $scheduled = \JLG\Notation\Helpers::maybe_schedule_review_status_automation(true);
+
+        $this->assertTrue($scheduled);
+        $this->assertNotEmpty($GLOBALS['jlg_test_scheduled_events']);
+
+        $event = $GLOBALS['jlg_test_scheduled_events'][0];
+
+        $this->assertSame(\JLG\Notation\Helpers::REVIEW_STATUS_CRON_HOOK, $event['hook']);
+        $this->assertSame('daily', $event['recurrence']);
+        $this->assertGreaterThan(time(), $event['timestamp']);
+    }
+
+    public function test_run_review_status_automation_updates_posts_and_triggers_action(): void
+    {
+        $this->enableAutomation(['allowed_post_types' => ['post']]);
+
+        $now       = (int) current_time('timestamp');
+        $oldDate   = gmdate('Y-m-d', $now - (10 * 86400));
+        $recent    = gmdate('Y-m-d', $now - (2 * 86400));
+
+        $GLOBALS['jlg_test_posts'] = [
+            101 => new WP_Post([
+                'ID'         => 101,
+                'post_type'  => 'post',
+                'post_status'=> 'publish',
+                'post_date'  => '2025-01-01 10:00:00',
+            ]),
+            202 => new WP_Post([
+                'ID'         => 202,
+                'post_type'  => 'post',
+                'post_status'=> 'publish',
+                'post_date'  => '2025-01-05 10:00:00',
+            ]),
+        ];
+
+        $GLOBALS['jlg_test_meta'] = [
+            101 => [
+                \JLG\Notation\Helpers::REVIEW_STATUS_META_KEY            => 'in_progress',
+                \JLG\Notation\Helpers::REVIEW_STATUS_LAST_PATCH_META_KEY => $oldDate,
+            ],
+            202 => [
+                \JLG\Notation\Helpers::REVIEW_STATUS_META_KEY            => 'in_progress',
+                \JLG\Notation\Helpers::REVIEW_STATUS_LAST_PATCH_META_KEY => $recent,
+            ],
+        ];
+
+        $updated = \JLG\Notation\Helpers::run_review_status_automation();
+
+        $this->assertSame(1, $updated);
+        $this->assertSame('final', $GLOBALS['jlg_test_meta'][101][\JLG\Notation\Helpers::REVIEW_STATUS_META_KEY]);
+        $this->assertSame('in_progress', $GLOBALS['jlg_test_meta'][202][\JLG\Notation\Helpers::REVIEW_STATUS_META_KEY]);
+
+        $this->assertNotEmpty($GLOBALS['jlg_test_meta_updates']);
+        $lastUpdate = end($GLOBALS['jlg_test_meta_updates']);
+        $this->assertSame(101, $lastUpdate['post_id']);
+        $this->assertSame(\JLG\Notation\Helpers::REVIEW_STATUS_META_KEY, $lastUpdate['key']);
+        $this->assertSame('final', $lastUpdate['value']);
+
+        $this->assertNotEmpty($GLOBALS['jlg_test_actions']);
+        $lastAction = end($GLOBALS['jlg_test_actions']);
+        $this->assertSame('jlg_review_status_transition', $lastAction[0]);
+        $this->assertSame([101, 'in_progress', 'final', 'auto_finalize'], $lastAction[1]);
+    }
+
+    public function test_run_review_status_automation_exits_when_disabled(): void
+    {
+        $this->enableAutomation(['review_status_auto_finalize_enabled' => 0]);
+
+        $result = \JLG\Notation\Helpers::run_review_status_automation();
+
+        $this->assertSame(0, $result);
+        $this->assertEmpty($GLOBALS['jlg_test_actions']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/HelpersReviewVerdictTest.php
+++ b/plugin-notation-jeux_V4/tests/HelpersReviewVerdictTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/Helpers.php';
+
+class HelpersReviewVerdictTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['jlg_test_posts'] = [];
+        $GLOBALS['jlg_test_meta']  = [];
+        $GLOBALS['jlg_test_options'] = [];
+        \JLG\Notation\Helpers::flush_plugin_options_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset(
+            $GLOBALS['jlg_test_posts'],
+            $GLOBALS['jlg_test_meta'],
+            $GLOBALS['jlg_test_options']
+        );
+    }
+
+    public function test_payload_defaults_to_permalink_and_status(): void
+    {
+        $post_id = 321;
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'                => $post_id,
+            'post_type'         => 'post',
+            'post_status'       => 'publish',
+            'post_modified'     => '2025-10-05 18:00:00',
+            'post_modified_gmt' => '2025-10-05 16:00:00',
+        ]);
+
+        $payload = \JLG\Notation\Helpers::get_review_verdict_for_post($post_id);
+
+        $this->assertSame('final', $payload['status']['slug']);
+        $this->assertSame('https://example.com/?p=321', $payload['cta_url']);
+        $this->assertSame('Lire le test complet', $payload['cta_label']);
+        $this->assertNotEmpty($payload['last_updated']['display']);
+        $this->assertNotEmpty($payload['last_updated']['iso']);
+    }
+
+    public function test_payload_uses_custom_summary_and_cta(): void
+    {
+        $post_id = 654;
+        $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
+            'ID'                => $post_id,
+            'post_type'         => 'post',
+            'post_status'       => 'publish',
+            'post_modified'     => '2025-10-07 09:15:00',
+            'post_modified_gmt' => '2025-10-07 07:15:00',
+        ]);
+
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_summary']   = '<strong>Chef-d\'oeuvre</strong> tactique.';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_cta_label'] = 'Consulter l\'analyse';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_cta_url']   = 'https://example.com/full-review';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_review_status']     = 'draft';
+
+        $payload = \JLG\Notation\Helpers::get_review_verdict_for_post($post_id);
+
+        $this->assertSame('draft', $payload['status']['slug']);
+        $this->assertSame('Consulter l\'analyse', $payload['cta_label']);
+        $this->assertSame('https://example.com/full-review', $payload['cta_url']);
+        $this->assertSame('<strong>Chef-d\'oeuvre</strong> tactique.', $payload['summary']);
+        $this->assertArrayHasKey('iso', $payload['last_updated']);
+    }
+}

--- a/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
+++ b/plugin-notation-jeux_V4/tests/ShortcodeAllInOneRenderTest.php
@@ -216,12 +216,47 @@ class ShortcodeAllInOneRenderTest extends TestCase
         $this->assertStringContainsString('Vidéo de test hébergée par YouTube', $output);
     }
 
+    public function test_render_outputs_verdict_section_when_summary_provided(): void
+    {
+        $post_id = 2006;
+        $this->seedPost($post_id);
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_summary']    = 'Une aventure magistrale qui culmine avec un final mémorable.';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_cta_label']  = 'Lire notre verdict complet';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_verdict_cta_url']    = 'https://example.com/review';
+        $GLOBALS['jlg_test_meta'][$post_id]['_jlg_review_status']      = 'in_progress';
+
+        $this->setPluginOptions([
+            'score_layout'      => 'text',
+            'visual_theme'      => 'dark',
+            'score_gradient_1'  => '#336699',
+            'score_gradient_2'  => '#9933cc',
+            'color_high'        => '#22c55e',
+            'color_low'         => '#ef4444',
+            'tagline_font_size' => 18,
+            'enable_animations' => 0,
+        ]);
+
+        $shortcode = new \JLG\Notation\Shortcodes\AllInOne();
+        $output    = $shortcode->render([
+            'post_id'          => (string) $post_id,
+            'afficher_verdict' => 'oui',
+        ]);
+
+        $this->assertNotSame('', $output);
+        $this->assertMatchesRegularExpression('/class="jlg-aio-verdict"/', $output);
+        $this->assertStringContainsString('Lire notre verdict complet', $output);
+        $this->assertMatchesRegularExpression('/jlg-aio-verdict__status--in_progress/', $output);
+        $this->assertMatchesRegularExpression('/Mise à jour le/', $output);
+    }
+
     private function seedPost(int $post_id, string $post_type = 'post'): void
     {
         $GLOBALS['jlg_test_posts'][$post_id] = new WP_Post([
             'ID'          => $post_id,
             'post_type'   => $post_type,
             'post_status' => 'publish',
+            'post_modified' => '2025-10-05 12:34:00',
+            'post_modified_gmt' => '2025-10-05 10:34:00',
         ]);
 
         $GLOBALS['jlg_test_meta'][$post_id] = [

--- a/plugin-notation-jeux_V4/tests/bootstrap.php
+++ b/plugin-notation-jeux_V4/tests/bootstrap.php
@@ -187,6 +187,26 @@ if (!function_exists('wp_next_scheduled')) {
     }
 }
 
+if (!function_exists('wp_schedule_event')) {
+    /**
+     * Capture recurring cron events so tests can assert scheduling logic.
+     */
+    function wp_schedule_event($timestamp, $recurrence, $hook, $args = []) {
+        if (!isset($GLOBALS['jlg_test_scheduled_events'])) {
+            $GLOBALS['jlg_test_scheduled_events'] = [];
+        }
+
+        $GLOBALS['jlg_test_scheduled_events'][] = [
+            'timestamp'  => (int) $timestamp,
+            'hook'       => (string) $hook,
+            'recurrence' => (string) $recurrence,
+            'args'       => is_array($args) ? $args : [$args],
+        ];
+
+        return true;
+    }
+}
+
 if (!function_exists('wp_schedule_single_event')) {
     /**
      * Capture single-event schedules so tests can validate cron behaviour.
@@ -706,6 +726,37 @@ if (!function_exists('wp_timezone')) {
         } catch (Exception $exception) {
             return new DateTimeZone('UTC');
         }
+    }
+}
+
+if (!function_exists('wp_date')) {
+    function wp_date($format, $timestamp, $timezone = null) {
+        if (!is_int($timestamp)) {
+            $timestamp = is_numeric($timestamp) ? (int) $timestamp : strtotime((string) $timestamp);
+        }
+
+        if (!is_int($timestamp)) {
+            return '';
+        }
+
+        if (!($timezone instanceof DateTimeZone)) {
+            try {
+                $timezone = wp_timezone();
+            } catch (Exception $exception) {
+                $timezone = new DateTimeZone('UTC');
+            }
+        }
+
+        try {
+            $date = new DateTimeImmutable('@' . $timestamp);
+            $date = $date->setTimezone($timezone);
+        } catch (Exception $exception) {
+            return '';
+        }
+
+        $format = is_string($format) && $format !== '' ? $format : 'Y-m-d H:i:s';
+
+        return $date->format($format);
     }
 }
 
@@ -1938,6 +1989,43 @@ if (!function_exists('get_post_meta')) {
         }
 
         return [$value];
+    }
+}
+
+if (!function_exists('get_post_modified_time')) {
+    function get_post_modified_time($d = 'U', $gmt = false, $post = null, $translate = true)
+    {
+        unset($translate);
+
+        if ($post === null) {
+            $post = get_post();
+        }
+
+        if (!$post instanceof WP_Post) {
+            return false;
+        }
+
+        $field = $gmt ? 'post_modified_gmt' : 'post_modified';
+        $value = isset($post->$field) ? (string) $post->$field : '';
+
+        if ($value === '') {
+            return false;
+        }
+
+        try {
+            $timezone = $gmt ? new DateTimeZone('UTC') : wp_timezone();
+            $date     = new DateTimeImmutable($value, $timezone);
+        } catch (Exception $exception) {
+            return false;
+        }
+
+        if ($d === 'U' || $d === 'G') {
+            return $date->getTimestamp();
+        }
+
+        $format = is_string($d) && $d !== '' ? $d : 'Y-m-d H:i:s';
+
+        return $date->format($format);
     }
 }
 


### PR DESCRIPTION
## Summary
- add metabox support for tracking the last patch date and persist it alongside review metadata
- introduce review status auto-finalization helpers, cron scheduling, settings toggles, documentation, and translations
- cover the automation with PHPUnit scenarios and note the roadmap milestone for the delivered feature

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e5761f1798832e9c7da04cbd2e4ade