### PR TITLE
Add review verdict helper payload and automation cron

### DIFF
--- a/plugin-notation-jeux_V4/includes/Frontend.php
+++ b/plugin-notation-jeux_V4/includes/Frontend.php
@@ -3196,7 +3196,6 @@ class Frontend {
                 'review_status'            => array(),
                 'related_guides_enabled'   => false,
                 'related_guides'           => array(),
-                'verdict'                  => array(),
                 'paged'                    => 1,
                 'orderby'                  => '',
                 'order'                    => '',

--- a/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
+++ b/plugin-notation-jeux_V4/includes/Shortcodes/AllInOne.php
@@ -275,7 +275,18 @@ class AllInOne {
 
         $score_layout = $options['score_layout'] ?? 'text';
 
-        $verdict_payload     = Helpers::get_review_verdict_for_post( $post_id );
+        $verdict_overrides = array();
+        if ( $atts['verdict_summary'] !== '' ) {
+            $verdict_overrides['summary'] = $atts['verdict_summary'];
+        }
+        if ( $atts['verdict_cta_label'] !== '' ) {
+            $verdict_overrides['cta_label'] = $atts['verdict_cta_label'];
+        }
+        if ( $atts['verdict_cta_url'] !== '' ) {
+            $verdict_overrides['cta_url'] = $atts['verdict_cta_url'];
+        }
+
+        $verdict_payload     = Helpers::get_review_verdict_for_post( $post_id, $verdict_overrides );
         $display_verdict     = ( $atts['afficher_verdict'] === 'oui' );
         $verdict_summary     = isset( $verdict_payload['summary'] ) ? trim( (string) $verdict_payload['summary'] ) : '';
         $verdict_has_content = $verdict_summary !== ''
@@ -313,6 +324,16 @@ class AllInOne {
             '--jlg-aio-verdict-meta'          => $palette['text_color_secondary'] ?? '',
             '--jlg-aio-verdict-accent'        => $accent_color,
         );
+
+        if ( ! $display_verdict ) {
+            unset(
+                $css_variables['--jlg-aio-verdict-bg'],
+                $css_variables['--jlg-aio-verdict-border'],
+                $css_variables['--jlg-aio-verdict-text'],
+                $css_variables['--jlg-aio-verdict-meta'],
+                $css_variables['--jlg-aio-verdict-accent']
+            );
+        }
 
         if ( $score_layout === 'circle' ) {
             $css_variables['--jlg-aio-circle-bg']     = $this->build_circle_background( $options, $accent_color, $average_score, $score_gradient_2 ?: $score_gradient_1 );
@@ -440,21 +461,16 @@ class AllInOne {
             }
         }
 
-        $verdict_overrides = array( 'context' => 'all-in-one' );
+        $verdict_overrides['context'] = 'all-in-one';
 
-        if ( $atts['verdict_summary'] !== '' ) {
-            $verdict_overrides['summary'] = $atts['verdict_summary'];
+        $verdict_data = Helpers::get_verdict_data_for_post( $post_id, $options, $verdict_overrides );
+
+        if ( isset( $verdict_data['cta'] ) && is_array( $verdict_data['cta'] ) ) {
+            $verdict_data['cta_label'] = isset( $verdict_data['cta']['label'] ) ? (string) $verdict_data['cta']['label'] : '';
+            $verdict_data['cta_url']   = isset( $verdict_data['cta']['url'] ) ? (string) $verdict_data['cta']['url'] : '';
+            $verdict_data['cta_rel']   = isset( $verdict_data['cta']['rel'] ) ? (string) $verdict_data['cta']['rel'] : '';
         }
 
-        if ( $atts['verdict_cta_label'] !== '' ) {
-            $verdict_overrides['cta_label'] = $atts['verdict_cta_label'];
-        }
-
-        if ( $atts['verdict_cta_url'] !== '' ) {
-            $verdict_overrides['cta_url'] = $atts['verdict_cta_url'];
-        }
-
-        $verdict_data            = Helpers::get_verdict_data_for_post( $post_id, $options, $verdict_overrides );
         $raw_show_verdict        = strtolower( $atts['afficher_verdict'] );
         $should_show_verdict     = ! in_array( $raw_show_verdict, array( 'non', 'no', 'false', '0', 'off' ), true );
         $verdict_data['enabled'] = ! empty( $verdict_data['enabled'] ) && $should_show_verdict;


### PR DESCRIPTION
## Summary
- add helper APIs to schedule and run the review status auto-finalisation cron, including query safeguards and transition hooks
- expose a simplified verdict payload helper with richer summary/cta data for shortcodes and fill in missing metadata fallbacks
- wire the all-in-one shortcode to pass verdict overrides, mirror CTA fields, and drop verdict CSS variables when the card is hidden, and remove a duplicate default from the frontend template loader

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e58878c0d4832e862b2dd9d188efce