### PR TITLE
Optimise le widget Derniers Tests et documente la revue

### DIFF
--- a/plugin-notation-jeux_V4/README.md
+++ b/plugin-notation-jeux_V4/README.md
@@ -120,6 +120,7 @@ etc., avant de revenir au fichier interne. Deux filtres sont disponibles pour al
 
 - `jlg_frontend_template_candidates` pour modifier la liste des chemins passés à `locate_template()` ;
 - `jlg_frontend_template_path` pour ajuster le chemin final utilisé.
+- `jlg_latest_reviews_widget_query_args` pour enrichir ou restreindre la requête du widget « Derniers Tests » (filtrage par taxonomie, tri personnalisé, etc.).
 
 Ces mécanismes vous permettent de conserver vos surcharges lors des mises à jour tout en offrant des points d'ancrage
 programmatiques pour les intégrations avancées.

--- a/plugin-notation-jeux_V4/README.txt
+++ b/plugin-notation-jeux_V4/README.txt
@@ -116,6 +116,7 @@ version interne. Deux filtres permettent des personnalisations supplémentaires 
 
 * `jlg_frontend_template_candidates` pour ajuster la liste des chemins passés à `locate_template()` ;
 * `jlg_frontend_template_path` pour modifier le chemin final inclus.
+* `jlg_latest_reviews_widget_query_args` pour personnaliser la requête `WP_Query` du widget « Derniers Tests » (filtrage, tri, pagination avancée).
 
 Ces points d'extension facilitent la conservation de vos surcharges lors des mises à jour du plugin.
 

--- a/plugin-notation-jeux_V4/docs/code-review-2025-10-08.md
+++ b/plugin-notation-jeux_V4/docs/code-review-2025-10-08.md
@@ -1,0 +1,33 @@
+# Revue de code – 8 octobre 2025
+
+## Objectifs
+- Cartographier les points de vigilance du widget « Derniers Tests » et des helpers associés.
+- Identifier les optimisations rapides à forte valeur (performance, extensibilité, tests).
+- Préparer les évolutions nécessaires pour fiabiliser le socle côté widgets et templates.
+
+## Constats principaux
+### Forces
+- Les helpers centralisent correctement la logique métier (récupération des IDs notés, options autorisées).
+- Les templates peuvent déjà être surchargés via le dossier `notation-jlg/`, ce qui limite les risques lors des mises à jour.
+- Une batterie de tests unitaires couvre la majorité des modules critiques (helpers, shortcodes, blocs, désinstallation).
+
+### Risques / dettes
+- Le widget « Derniers Tests » recalculait la configuration à chaque appel sans normalisation ni garde-fou sur le nombre de posts.
+- La requête `WP_Query` n’activait pas les optimisations classiques (`no_found_rows`, caches méta/term), augmentant la charge sur les listes volumineuses.
+- Aucun point d’extension ne permettait d’ajuster le filtrage du widget côté intégrateurs (taxonomies, statuts personnalisés).
+- Les tests unitaires ne validaient pas les garde-fous du widget (fallback, clamp du nombre d’articles, options de requête).
+
+## Actions menées
+- Normalisation centralisée des paramètres du widget (titre, nombre d’éléments, typage) avec valeur par défaut robuste.
+- Ajout d’un filtre `jlg_latest_reviews_widget_query_args` pour ouvrir la personnalisation de la requête (taxonomie, tri, statuts).
+- Optimisation de la requête (`no_found_rows`, désactivation des caches méta/term inutiles, limitation du `post__in`).
+- Mutualisation de l’affichage vide et ajout d’un garde-fou lorsque les types de contenus autorisés sont vides.
+- Extension de `LatestReviewsWidgetTest` pour couvrir la normalisation des paramètres et la construction d’arguments `WP_Query` optimisés.
+
+## Recommandations à court terme
+1. **Widget** : ajouter un système de cache court (transient) pour les rendus HTML des widgets afin de limiter les hits répétés lorsque plusieurs widgets affichent la même configuration.
+2. **Helpers** : documenter les points d’invalidation du cache des IDs notés et prévoir un hook dédié pour les purges manuelles dans les scripts d’import.
+3. **Tests** : intégrer un test d’intégration léger (avec doubles WP_Query) pour valider que le widget respecte bien l’ordre chronologique et qu’il se réinitialise correctement après `wp_reset_postdata()`.
+4. **Docs** : compléter le guide front (`docs/responsive-testing.md`) avec un scénario widget + sidebar (desktop/mobile) pour vérifier l’accessibilité clavier.
+
+Ces éléments servent de base pour prioriser les prochains chantiers autour des widgets et garantir une expérience performante, extensible et testée.

--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -8,80 +8,188 @@ use WP_Query;
 use WP_Widget;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class LatestReviewsWidget extends WP_Widget {
+
+    private const DEFAULT_POST_COUNT = 5;
 
     public function __construct() {
         parent::__construct(
             'jlg_latest_reviews_widget',
             __( 'Notation JLG : Derniers Tests', 'notation-jlg' ),
-            array( 'description' => __( 'Affiche les derniers articles ayant reçu une note.', 'notation-jlg' ) )
+            array(
+                'description' => __( 'Affiche les derniers articles ayant reçu une note.', 'notation-jlg' ),
+            )
         );
     }
 
     public function widget( $args, $instance ) {
-        $title  = apply_filters( 'widget_title', $instance['title'] ?? __( 'Derniers Tests', 'notation-jlg' ) );
-        $number = ( ! empty( $instance['number'] ) ) ? absint( $instance['number'] ) : 5;
+        $settings = $this->parse_instance_settings( $instance );
+
+        $title      = apply_filters( 'widget_title', $settings['title'] );
+        $post_limit = $settings['number'];
+
+        $allowed_post_types = Helpers::get_allowed_post_types();
+
+        if ( empty( $allowed_post_types ) ) {
+            $this->render_empty_widget( $args, $title );
+            return;
+        }
 
         $rated_post_ids = Helpers::get_rated_post_ids();
 
         if ( empty( $rated_post_ids ) ) {
-            echo $args['before_widget'];
-            if ( ! empty( $title ) ) {
-                echo $args['before_title'] . $title . $args['after_title'];
-            }
-            echo '<p>' . esc_html__( 'Aucun test trouvé.', 'notation-jlg' ) . '</p>';
-            echo $args['after_widget'];
+            $this->render_empty_widget( $args, $title );
             return;
         }
 
-        $query_args = array(
-            'post_type'           => Helpers::get_allowed_post_types(),
-            'posts_per_page'      => $number,
-            'post__in'            => $rated_post_ids,
-            'orderby'             => 'date',
-            'order'               => 'DESC',
-            'ignore_sticky_posts' => 1,
+        $query_args = $this->build_query_args( $post_limit, $rated_post_ids, $allowed_post_types );
+
+        $query_args = apply_filters(
+            'jlg_latest_reviews_widget_query_args',
+            $query_args,
+            array(
+                'title'  => $settings['title'],
+                'number' => $post_limit,
+            ),
+            $args,
+            $this
         );
 
         $latest_reviews = new WP_Query( $query_args );
 
-        // Utilisation d'un fichier template pour l'affichage
         echo Frontend::get_template_html(
             'widget-latest-reviews',
             array(
-				'widget_args'    => $args,
-				'title'          => $title,
-				'latest_reviews' => $latest_reviews,
-			)
+                'widget_args'    => $args,
+                'title'          => $title,
+                'latest_reviews' => $latest_reviews,
+            )
         );
     }
 
     public function form( $instance ) {
-        $title  = ! empty( $instance['title'] ) ? $instance['title'] : __( 'Derniers Tests', 'notation-jlg' );
-        $number = isset( $instance['number'] ) ? absint( $instance['number'] ) : 5;
+        $settings = $this->parse_instance_settings( $instance );
+
+        $title  = $settings['title'];
+        $number = $settings['number'];
         ?>
         <p>
             <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php echo esc_html__( 'Titre :', 'notation-jlg' ); ?></label>
             <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
-                    name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
-                    type="text" value="<?php echo esc_attr( $title ); ?>">
+                name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+                type="text" value="<?php echo esc_attr( $title ); ?>">
         </p>
         <p>
             <label for="<?php echo esc_attr( $this->get_field_id( 'number' ) ); ?>"><?php echo esc_html__( 'Nombre d\'articles à afficher :', 'notation-jlg' ); ?></label>
             <input class="tiny-text" id="<?php echo esc_attr( $this->get_field_id( 'number' ) ); ?>"
-                    name="<?php echo esc_attr( $this->get_field_name( 'number' ) ); ?>"
-                    type="number" step="1" min="1" value="<?php echo esc_attr( $number ); ?>" size="3">
+                name="<?php echo esc_attr( $this->get_field_name( 'number' ) ); ?>"
+                type="number" step="1" min="1" value="<?php echo esc_attr( $number ); ?>" size="3">
         </p>
         <?php
     }
 
     public function update( $new_instance, $old_instance ) {
-        $instance           = array();
-        $instance['title']  = ( ! empty( $new_instance['title'] ) ) ? wp_strip_all_tags( $new_instance['title'] ) : '';
-        $instance['number'] = ( ! empty( $new_instance['number'] ) ) ? absint( $new_instance['number'] ) : 5;
-        return $instance;
+        unset( $old_instance );
+
+        $settings = $this->parse_instance_settings( $new_instance );
+
+        return array(
+            'title'  => $settings['title'],
+            'number' => $settings['number'],
+        );
+    }
+
+    /**
+     * Normalise et sécurise les paramètres saisis dans le formulaire du widget.
+     *
+     * @param array|null $instance Valeurs brutes issues de WordPress.
+     * @return array{title:string,number:int}
+     */
+    private function parse_instance_settings( $instance ) {
+        if ( ! is_array( $instance ) ) {
+            $instance = array();
+        }
+
+        $raw_title = isset( $instance['title'] ) && is_string( $instance['title'] )
+            ? $instance['title']
+            : '';
+
+        $title = $raw_title !== ''
+            ? sanitize_text_field( wp_strip_all_tags( $raw_title ) )
+            : __( 'Derniers Tests', 'notation-jlg' );
+
+        $raw_number = isset( $instance['number'] ) ? absint( $instance['number'] ) : 0;
+
+        if ( $raw_number < 1 ) {
+            $raw_number = self::DEFAULT_POST_COUNT;
+        }
+
+        return array(
+            'title'  => $title,
+            'number' => $raw_number,
+        );
+    }
+
+    /**
+     * Construit les arguments WP_Query utilisés par le widget.
+     *
+     * @param int     $post_limit         Nombre de posts à afficher.
+     * @param int[]   $rated_post_ids     Liste brute des identifiants notés.
+     * @param string[] $allowed_post_types Types de contenus autorisés.
+     * @return array
+     */
+    private function build_query_args( $post_limit, $rated_post_ids, $allowed_post_types ) {
+        $post_limit = max( 1, (int) $post_limit );
+
+        $post_ids = array_values( array_unique( array_filter( array_map( 'intval', (array) $rated_post_ids ) ) ) );
+
+        $max_ids = $post_limit * 3;
+        if ( $max_ids > 0 && count( $post_ids ) > $max_ids ) {
+            $post_ids = array_slice( $post_ids, 0, $max_ids );
+        }
+
+        if ( empty( $post_ids ) ) {
+            $post_ids = array( 0 );
+        }
+
+        $allowed_post_types = array_values( array_filter( array_map( 'sanitize_key', (array) $allowed_post_types ) ) );
+
+        if ( empty( $allowed_post_types ) ) {
+            $allowed_post_types = array( 'post' );
+        }
+
+        return array(
+            'post_type'              => $allowed_post_types,
+            'posts_per_page'         => $post_limit,
+            'post__in'               => $post_ids,
+            'orderby'                => 'date',
+            'order'                  => 'DESC',
+            'ignore_sticky_posts'    => true,
+            'no_found_rows'          => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+            'lazy_load_term_meta'    => false,
+        );
+    }
+
+    /**
+     * Affiche le widget vide lorsqu'aucun contenu n'est disponible.
+     *
+     * @param array  $args  Arguments fournis par WordPress.
+     * @param string $title Titre à afficher.
+     * @return void
+     */
+    private function render_empty_widget( $args, $title ) {
+        echo $args['before_widget'];
+
+        if ( ! empty( $title ) ) {
+            echo $args['before_title'] . $title . $args['after_title'];
+        }
+
+        echo '<p>' . esc_html__( 'Aucun test trouvé.', 'notation-jlg' ) . '</p>';
+        echo $args['after_widget'];
     }
 }

--- a/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
+++ b/plugin-notation-jeux_V4/templates/widget-latest-reviews.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 echo $widget_args['before_widget'];

--- a/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
+++ b/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
@@ -21,4 +21,38 @@ final class LatestReviewsWidgetTest extends TestCase
         $this->assertSame('Top Jeu Edition', preg_replace('/\s+/', ' ', $clean_instance['title']));
         $this->assertSame(8, $clean_instance['number']);
     }
+
+    public function test_parse_instance_settings_defaults_to_safe_values(): void
+    {
+        $widget = new LatestReviewsWidget();
+
+        $reflection = new \ReflectionMethod($widget, 'parse_instance_settings');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($widget, ['title' => '', 'number' => 0]);
+
+        $this->assertSame('Derniers Tests', $result['title']);
+        $this->assertSame(5, $result['number']);
+    }
+
+    public function test_build_query_args_limits_post_ids_and_adds_optimisations(): void
+    {
+        $widget = new LatestReviewsWidget();
+
+        $method = new \ReflectionMethod($widget, 'build_query_args');
+        $method->setAccessible(true);
+
+        $post_ids = array_map('strval', range(1, 50));
+
+        $args = $method->invoke($widget, 3, $post_ids, ['post', 'custom_review']);
+
+        $this->assertSame(3, $args['posts_per_page']);
+        $this->assertSame(['post', 'custom_review'], $args['post_type']);
+        $this->assertCount(9, $args['post__in']);
+        $this->assertTrue($args['ignore_sticky_posts']);
+        $this->assertTrue($args['no_found_rows']);
+        $this->assertFalse($args['update_post_meta_cache']);
+        $this->assertFalse($args['update_post_term_cache']);
+        $this->assertFalse($args['lazy_load_term_meta']);
+    }
 }


### PR DESCRIPTION
## Résumé
- renforce le widget « Derniers Tests » (normalisation des paramètres, optimisation de la requête, nouveau filtre d’extension)
- met à jour le template associé et étend la couverture de tests unitaires
- ajoute une note de revue de code détaillant les constats et recommandations du 8 octobre 2025

## Tests
- `composer test`
- `composer cs`


------
https://chatgpt.com/codex/tasks/task_e_68e639dc3f6c832eb0673369bc11bcd1