### PR TITLE
Fix latest reviews widget post ID slicing

### DIFF
--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -148,7 +148,7 @@ class LatestReviewsWidget extends WP_Widget {
 
         $max_ids = $post_limit * 3;
         if ( $max_ids > 0 && count( $post_ids ) > $max_ids ) {
-            $post_ids = array_slice( $post_ids, 0, $max_ids );
+            $post_ids = array_slice( $post_ids, -$max_ids, $max_ids );
         }
 
         if ( empty( $post_ids ) ) {

--- a/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
+++ b/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
@@ -55,4 +55,18 @@ final class LatestReviewsWidgetTest extends TestCase
         $this->assertFalse($args['update_post_term_cache']);
         $this->assertFalse($args['lazy_load_term_meta']);
     }
+
+    public function test_build_query_args_prioritises_most_recent_rated_posts(): void
+    {
+        $widget = new LatestReviewsWidget();
+
+        $method = new \ReflectionMethod($widget, 'build_query_args');
+        $method->setAccessible(true);
+
+        $post_ids = range(1, 30);
+
+        $args = $method->invoke($widget, 5, $post_ids, ['post']);
+
+        $this->assertSame(range(16, 30), $args['post__in']);
+    }
 }


### PR DESCRIPTION
## Résumé
- renforce le widget « Derniers Tests » (normalisation des paramètres, optimisation de la requête, nouveau filtre d’extension)
- met à jour le template associé et étend la couverture de tests unitaires
- ajoute une note de revue de code détaillant les constats et recommandations du 8 octobre 2025
- corrige la troncature des identifiants pour que le widget conserve les tests les plus récents et ajoute un test de régression

## Tests
- `composer test`
- `composer cs`


------
https://chatgpt.com/codex/tasks/task_e_68e64ee5bc38832e9349d4df0625f6c5