### PR TITLE
Fix latest reviews widget slicing order

### DIFF
--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -148,7 +148,8 @@ class LatestReviewsWidget extends WP_Widget {
 
         $max_ids = $post_limit * 3;
         if ( $max_ids > 0 && count( $post_ids ) > $max_ids ) {
-            $post_ids = array_slice( $post_ids, -$max_ids );
+            $start_index = count( $post_ids ) - $max_ids;
+            $post_ids    = array_slice( $post_ids, $start_index, null, false );
         }
 
         if ( empty( $post_ids ) ) {

--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -148,7 +148,7 @@ class LatestReviewsWidget extends WP_Widget {
 
         $max_ids = $post_limit * 3;
         if ( $max_ids > 0 && count( $post_ids ) > $max_ids ) {
-            $post_ids = array_slice( $post_ids, 0, $max_ids );
+            $post_ids = array_slice( $post_ids, -$max_ids );
         }
 
         if ( empty( $post_ids ) ) {

--- a/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
+++ b/plugin-notation-jeux_V4/tests/LatestReviewsWidgetTest.php
@@ -48,7 +48,7 @@ final class LatestReviewsWidgetTest extends TestCase
 
         $this->assertSame(3, $args['posts_per_page']);
         $this->assertSame(['post', 'custom_review'], $args['post_type']);
-        $this->assertCount(9, $args['post__in']);
+        $this->assertSame(range(42, 50), $args['post__in']);
         $this->assertTrue($args['ignore_sticky_posts']);
         $this->assertTrue($args['no_found_rows']);
         $this->assertFalse($args['update_post_meta_cache']);


### PR DESCRIPTION
## Summary
- ensure the latest reviews widget keeps the most recent rated posts when limiting the query
- update the widget unit test expectations to cover the new ordering

## Testing
- composer test *(fails: phpunit not available in container)*
- composer cs *(fails: phpcs not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64fdcd208832e82fbe5f75111ca54