### PR TITLE
Fix Latest Reviews widget to keep newest rated posts

### DIFF
--- a/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
+++ b/plugin-notation-jeux_V4/includes/LatestReviewsWidget.php
@@ -148,7 +148,8 @@ class LatestReviewsWidget extends WP_Widget {
 
         $max_ids = $post_limit * 3;
         if ( $max_ids > 0 && count( $post_ids ) > $max_ids ) {
-            $post_ids = array_slice( $post_ids, -$max_ids, null, false );
+            // Conserve the most recent rated posts by trimming from the end of the list.
+            $post_ids = array_slice( $post_ids, -$max_ids, $max_ids, false );
         }
 
         if ( empty( $post_ids ) ) {


### PR DESCRIPTION
## Summary
- adjust the rated post slicing in `LatestReviewsWidget::build_query_args()` to keep the most recent IDs when trimming large lists

## Testing
- `composer test` *(fails: phpunit executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e65530d09c832e980666b8afd1bcbd