### PR TITLE
fix: sécuriser la factory vidéo et exposer un filtre d'extension

### DIFF
--- a/plugin-notation-jeux_V4/docs/code-review-2025-10-13.md
+++ b/plugin-notation-jeux_V4/docs/code-review-2025-10-13.md
@@ -1,0 +1,14 @@
+# Code review – Refactorisation de l'embed vidéo (13 octobre 2025)
+
+## Verdict global
+Le découpage de `Helpers::get_review_video_embed_data()` en fournisseurs dédiés rend le code plus lisible et facilitera des tests ciblés. Cependant, quelques points bloquants subsistent avant de fusionner sereinement.
+
+## Points bloquants
+1. **Absence du garde `ABSPATH` dans les nouveaux fichiers** – Les nouvelles classes (`VideoEmbedFactory` et chaque fournisseur) peuvent être chargées directement via leur URL, ce qui expose inutilement des dépendances internes. Toutes les autres classes du plugin conservent le garde `if ( ! defined( 'ABSPATH' ) ) { exit; }`, il faut donc l'ajouter pour rester cohérent et sécuriser l'accès direct.【F:plugin-notation-jeux_V4/includes/Video/VideoEmbedFactory.php†L1-L12】【F:plugin-notation-jeux_V4/includes/Video/Providers/YouTubeProvider.php†L1-L6】【F:plugin-notation-jeux_V4/includes/Video/Providers/VimeoProvider.php†L1-L6】【F:plugin-notation-jeux_V4/includes/Video/Providers/TwitchProvider.php†L1-L6】【F:plugin-notation-jeux_V4/includes/Video/Providers/DailymotionProvider.php†L1-L6】【F:plugin-notation-jeux_V4/includes/Video/Providers/VideoEmbedProviderInterface.php†L1-L6】
+2. **Extensibilité limitée du registre de fournisseurs** – Le refactor introduit `VideoEmbedFactory::bootstrap_providers()` mais la liste est figée dans le code. Sans filtre, tout fournisseur additionnel (ex : PeerTube) imposerait un patch core. Ajouter un filtre ou un point d'extension (ex. `apply_filters( 'jlg_video_embed_providers', $providers )`) rendrait l'approche modulaire alignée avec la logique de la factory.【F:plugin-notation-jeux_V4/includes/Video/VideoEmbedFactory.php†L62-L76】
+
+## Améliorations suggérées
+- Couvrir chaque fournisseur par des tests unitaires spécifiques (ex. `YouTubeProviderTest`) afin d'isoler les scénarios d'extraction d'ID (URLs courtes, shorts, clips, etc.). Aujourd'hui, les tests passent par `Helpers` et ne valident pas directement les classes fraîchement introduites, ce qui compliquera les retours en arrière ciblés si un fournisseur évolue.【F:plugin-notation-jeux_V4/tests/HelpersReviewVideoEmbedTest.php†L13-L45】
+
+## Conclusion
+Une fois le garde de sécurité restauré et un point d'extension ajouté au registre des fournisseurs, le refactor pourra être intégré sans risque. Pensez également à renforcer la couverture unitaire pour profiter pleinement de ce découpage.

--- a/plugin-notation-jeux_V4/includes/Video/Providers/DailymotionProvider.php
+++ b/plugin-notation-jeux_V4/includes/Video/Providers/DailymotionProvider.php
@@ -2,6 +2,10 @@
 
 namespace JLG\Notation\Video\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class DailymotionProvider implements VideoEmbedProviderInterface {
 
     public function get_slug(): string {

--- a/plugin-notation-jeux_V4/includes/Video/Providers/TwitchProvider.php
+++ b/plugin-notation-jeux_V4/includes/Video/Providers/TwitchProvider.php
@@ -2,6 +2,10 @@
 
 namespace JLG\Notation\Video\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class TwitchProvider implements VideoEmbedProviderInterface {
 
     public function get_slug(): string {

--- a/plugin-notation-jeux_V4/includes/Video/Providers/VideoEmbedProviderInterface.php
+++ b/plugin-notation-jeux_V4/includes/Video/Providers/VideoEmbedProviderInterface.php
@@ -2,6 +2,10 @@
 
 namespace JLG\Notation\Video\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 interface VideoEmbedProviderInterface {
 
     public function get_slug(): string;

--- a/plugin-notation-jeux_V4/includes/Video/Providers/VimeoProvider.php
+++ b/plugin-notation-jeux_V4/includes/Video/Providers/VimeoProvider.php
@@ -2,6 +2,10 @@
 
 namespace JLG\Notation\Video\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class VimeoProvider implements VideoEmbedProviderInterface {
 
     public function get_slug(): string {

--- a/plugin-notation-jeux_V4/includes/Video/Providers/YouTubeProvider.php
+++ b/plugin-notation-jeux_V4/includes/Video/Providers/YouTubeProvider.php
@@ -2,6 +2,10 @@
 
 namespace JLG\Notation\Video\Providers;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class YouTubeProvider implements VideoEmbedProviderInterface {
 
     public function get_slug(): string {

--- a/plugin-notation-jeux_V4/includes/Video/VideoEmbedFactory.php
+++ b/plugin-notation-jeux_V4/includes/Video/VideoEmbedFactory.php
@@ -9,6 +9,10 @@ use JLG\Notation\Video\Providers\VideoEmbedProviderInterface;
 use JLG\Notation\Video\Providers\VimeoProvider;
 use JLG\Notation\Video\Providers\YouTubeProvider;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class VideoEmbedFactory {
 
     private static $providers = null;
@@ -90,12 +94,26 @@ class VideoEmbedFactory {
     }
 
     private static function bootstrap_providers(): array {
-        return array(
+        $providers = array(
             new YouTubeProvider(),
             new VimeoProvider(),
             new TwitchProvider(),
             new DailymotionProvider(),
         );
+
+        /**
+         * Filters the list of video embed providers registered by the factory.
+         *
+         * This allows third-party integrations to provide their own implementation
+         * of {@see VideoEmbedProviderInterface} without altering the core plugin.
+         *
+         * @since 4.x.x
+         *
+         * @param VideoEmbedProviderInterface[] $providers Array of provider instances.
+         */
+        $filtered_providers = apply_filters( 'jlg_video_embed_providers', $providers );
+
+        return is_array( $filtered_providers ) ? $filtered_providers : $providers;
     }
 
     private static function get_video_fallback_message( $provider_label = '' ) {


### PR DESCRIPTION
## Summary
- ajouter les gardes `ABSPATH` à l'ensemble des fournisseurs d'embed vidéo et à la factory associée
- introduire un filtre `jlg_video_embed_providers` pour permettre l'enregistrement extensible des fournisseurs

## Testing
- composer test
- composer cs

------
https://chatgpt.com/codex/tasks/task_e_68e6780e5db0832e9027339b064d51c7